### PR TITLE
Fix version of crate x86_64 to "0.14.6"

### DIFF
--- a/rust-paging/Cargo.toml
+++ b/rust-paging/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 bitfield = "0.13.2"
 x86 = "0.41.0"
-x86_64 = "0.14.4"
+x86_64 = "=0.14.6"
 log = "0.4.13"
 rust-td-layout = { path = "../rust-td-layout" }
 bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator", rev = "03bd9909" }

--- a/rust-tdshim/Cargo.toml
+++ b/rust-tdshim/Cargo.toml
@@ -29,7 +29,7 @@ rust-td-layout = { path = "../rust-td-layout" }
 paging = { path = "../rust-paging" }
 ring = { git = "https://github.com/jyao1/ring.git", branch = "uefi_support", default-features = false }
 scroll = { version = "0.10", default-features = false, features = ["derive"] }
-x86_64 = "0.14.4"
+x86_64 = "=0.14.6"
 x86 = "0.43.0"
 spin = "0.9.2"
 bitflags = "1.2.1"

--- a/test_lib/Cargo.toml
+++ b/test_lib/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 
 [dependencies]
 spin = { version = "0.9.2", features = ["lazy"]}
+x86_64 = "=0.14.6"
 uart_16550 = "0.2.14"
-x86_64 = "0.14.6"
 linked_list_allocator = "0.9.0"


### PR DESCRIPTION
Latest version "0.14.7" of x86_64 fails to build due to error[E0658]:
panicking in constant functions is unstable.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>