### PR TITLE
Lock version of crate bootloader

### DIFF
--- a/rust-paging/Cargo.toml
+++ b/rust-paging/Cargo.toml
@@ -14,7 +14,7 @@ rust-td-layout = { path = "../rust-td-layout" }
 bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator", rev = "03bd9909" }
 test_lib = { path = "../test_lib" }
 spin = "0.9.2"
-bootloader = "0.10.9"
+bootloader = "=0.10.9"
 
 [package.metadata.bootloader]
 map-physical-memory = true

--- a/rust-td-payload/Cargo.toml
+++ b/rust-td-payload/Cargo.toml
@@ -32,7 +32,7 @@ x86 = "0.41.0"
 benchmark = { path = "../benchmark", optional = true }
 test_lib = { path = "../test_lib" }
 
-bootloader = "0.10.9"
+bootloader = "=0.10.9"
 
 
 [dependencies.lazy_static]


### PR DESCRIPTION
Latest version of bootloader depends on the version 0.14.7 of x86_64,
so lock the version for now.