### PR TITLE
rust-test-payload: Refine the test-payload

### DIFF
--- a/rust-test-payload/src/lib.rs
+++ b/rust-test-payload/src/lib.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_std]
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+#[derive(Copy, Clone)]
+pub enum TestResult {
+    Done,
+    Error,
+}
+
+pub trait TestCase {
+    fn setup(&mut self);
+    fn run(&mut self);
+    fn teardown(&mut self);
+    fn get_name(&mut self) -> String;
+    fn get_result(&mut self) -> TestResult;
+}
+
+pub struct TestSuite {
+    pub testsuite: Vec<Box<dyn TestCase>>,
+    pub done_cases: u32,
+    pub failed_cases: u32,
+}
+
+impl TestSuite {
+    pub fn run(&mut self) {
+        for tc in self.testsuite.iter_mut() {
+            log::info!("[Test: {}]\n", String::from(tc.get_name()));
+            tc.setup();
+            tc.run();
+            tc.teardown();
+
+            let res = tc.get_result();
+            match res {
+                TestResult::Done => {
+                    self.done_cases += 1;
+                    log::info!("[Test: {0}] - Done\n", tc.get_name());
+                }
+                TestResult::Error => {
+                    self.failed_cases += 1;
+                    log::info!("[Test: {0}] - Error\n", tc.get_name());
+                }
+            }
+
+            log::info!("---------------------------------------------\n")
+        }
+    }
+}

--- a/rust-test-payload/src/tdinfo.rs
+++ b/rust-test-payload/src/tdinfo.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_std]
+extern crate alloc;
+
+use crate::lib::{TestCase, TestResult};
+use alloc::string::String;
+use core::ffi::c_void;
+use tdx_tdcall::tdx;
+
+/**
+ * Test Tdinfo
+ */
+pub struct Tdinfo {
+    pub name: String,
+    pub hob: *const c_void,
+    pub result: TestResult,
+}
+
+/**
+ * Implement the TestCase trait for Tdinfo
+ */
+impl TestCase for Tdinfo {
+    /**
+     * set up the Test case of Tdinfo
+     */
+    fn setup(&mut self) {
+        self.result = TestResult::Error;
+    }
+
+    /**
+     * run the test case
+     */
+    fn run(&mut self) {
+        let mut td_info = tdx::TdInfoReturnData {
+            gpaw: 0,
+            attributes: 0,
+            max_vcpus: 0,
+            num_vcpus: 0,
+            rsvd: [0; 3],
+        };
+        tdx::tdcall_get_td_info(&mut td_info);
+
+        log::info!("gpaw - {:?}\n", td_info.gpaw);
+        log::info!("attributes - {:?}\n", td_info.attributes);
+        log::info!("max_vcpus - {:?}\n", td_info.max_vcpus);
+        log::info!("num_vcpus - {:?}\n", td_info.num_vcpus);
+        log::info!("rsvd - {:?}\n", td_info.rsvd);
+
+        self.result = TestResult::Done;
+    }
+
+    /**
+     * Tear down the test case.
+     */
+    fn teardown(&mut self) {}
+
+    /**
+     * get the name of the test case.
+     */
+    fn get_name(&mut self) -> String {
+        String::from(&self.name)
+    }
+
+    /**
+     * get the result of the test case.
+     */
+    fn get_result(&mut self) -> TestResult {
+        self.result
+    }
+}


### PR DESCRIPTION
In rust-test-payload there are multi test cases, such as Tdinfo, Acpi,
Event log, Multi-processor, etc. This commit refines the rust-test-payload
so that developer can focuse on the test case itself.

There are below major changes.
1. trait TestCase
  TestCase defines 5 interfaces which should be implemented by the actual
  test case.
  - setup(&mut self)
  - run(&mut self)
  - teardown(&mut self)
  - get_name(&mut self) -> String
  - get_result(&mut self) -> TestResult

2. struct TestSuite
  testsuite is the member of TestSuite which holds the test cases which
  implementes the trait of TestCase.

3. enum TestResult
  Done means the test case is finished. Error means there is something
  wrong when the case run.
  Note: External parse script takes the responsibility to determines if
  the test case pass or fail. Because test case itself doesn't have the
  enough knowlodge. For example, the guest is configured with 8 CPU but
  Tdinfo call returns 4 CPU. payload itself doesn't know it is correct or
  not.

4. struct Tdinfo
  Tdinfo is the actual test case which implements trait of TestCase.

If some more test case is to be added, Tdinfo can be the example. After
a new case is defined, it can be created and added into TestSuite.
    let mut tdinfo = Tdinfo {
        name: String::from("Tdinfo"),
        hob: hob,
        result: TestResult::Error
    };
    ts.testsuite.push(Box::new(tdinfo));

Below is the sample of test-payload log.

INFO - Start to run tests.
INFO - ---------------------------------------------
INFO - [Test: Tdinfo]                    <-- test case name
INFO - td_info data addr: 0x7f7ffe38     <-- below is the log by tdinfo
INFO - gpaw - 52
INFO - attributes - 9223372036854775809
INFO - max_vcpus - 8
INFO - num_vcpus - 8
INFO - rsvd - [0, 0, 0]
INFO - [Test: Tdinfo] - Done             <-- test is done
INFO - ---------------------------------------------
INFO - Total: 1, Done: 1, Failed: 0      <-- summary

Signed-off-by: Min Xu <min.m.xu@intel.com>