### PR TITLE
Enhance rust-td-layout

### DIFF
--- a/rust-td-layout/Cargo.toml
+++ b/rust-td-layout/Cargo.toml
@@ -12,7 +12,10 @@ boot-kernel = []
 scroll = { version = "0.10", default-features = false, features = ["derive"]}
 log = "0.4.13"
 
+[dev-dependencies]
+memoffset = "0.6"
+
 [build-dependencies]
 json5 = "0.3.0"
-serde = { version = "1.0", features = ["derive"] }
 scroll = { version = "0.10", default-features = false, features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }

--- a/rust-td-layout/src/lib.rs
+++ b/rust-td-layout/src/lib.rs
@@ -5,6 +5,20 @@
 #![no_std]
 #![forbid(unsafe_code)]
 
+//! Define file (build-time) and runtime layout for shim binary.
+//!
+//! Note:
+//! `repr(C)` should be used to control the exact data structure layout.
+//! - `repr(rust)`: By default, composite structures have an alignment equal to the maximum of their
+//!   fields' alignments. Rust will consequently insert padding where necessary to ensure that all
+//!   fields are properly aligned and that the overall type's size is a multiple of its alignment.
+//!   And fields may be reordered, not following the literal order of fields.
+//! - `repr(C)` is the most important repr. It has fairly simple intent: do what C does. The order,
+//!   size, and alignment of fields is exactly what you would expect from C or C++. Any type you
+//!   expect to pass through an FFI boundary should have repr(C), as C is the lingua-franca of the
+//!   programming world. This is also necessary to soundly do more elaborate tricks with data layout
+//!   such as reinterpreting values as a different type.
+
 use core::fmt;
 
 pub mod build_time;

--- a/rust-td-layout/src/mailbox.rs
+++ b/rust-td-layout/src/mailbox.rs
@@ -4,7 +4,7 @@
 
 use scroll::{Pread, Pwrite};
 
-// #[repr(packed)]
+#[repr(C)]
 #[derive(Default, Pwrite, Pread)]
 pub struct TdxMpWakeupMailbox {
     pub command: u16,

--- a/rust-td-layout/src/mailbox.rs
+++ b/rust-td-layout/src/mailbox.rs
@@ -12,3 +12,18 @@ pub struct TdxMpWakeupMailbox {
     pub apic_id: u32,
     pub wakeup_vector: u64,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+    use memoffset::offset_of;
+
+    #[test]
+    fn ensure_data_struct_size() {
+        assert_eq!(size_of::<TdxMpWakeupMailbox>(), 16);
+        assert_eq!(offset_of!(TdxMpWakeupMailbox, command), 0);
+        assert_eq!(offset_of!(TdxMpWakeupMailbox, apic_id), 4);
+        assert_eq!(offset_of!(TdxMpWakeupMailbox, wakeup_vector), 8);
+    }
+}

--- a/rust-td-layout/src/metadata.rs
+++ b/rust-td-layout/src/metadata.rs
@@ -4,24 +4,31 @@
 
 use scroll::{Pread, Pwrite};
 
-pub const TDX_METADATA_GUID1: u32 = 0xe9eaf9f3;
-pub const TDX_METADATA_GUID2: u32 = 0x44d5168e;
-pub const TDX_METADATA_GUID3: u32 = 0x4d7feba8;
-pub const TDX_METADATA_GUID4: u32 = 0xaef63887;
+const TDX_METADATA_GUID1: u32 = 0xe9eaf9f3;
+const TDX_METADATA_GUID2: u32 = 0x44d5168e;
+const TDX_METADATA_GUID3: u32 = 0x4d7feba8;
+const TDX_METADATA_GUID4: u32 = 0xaef63887;
 
-pub const TDX_METADATA_SIGNATURE: u32 = 0x46564454;
+const TDX_METADATA_SIGNATURE: u32 = 0x46564454;
 
+/// Section type for EFI Boot Firmware Volume.
 pub const TDX_METADATA_SECTION_TYPE_BFV: u32 = 0;
+/// Section type for EFI Boot Configuration Volume.
 pub const TDX_METADATA_SECTION_TYPE_CFV: u32 = 1;
+/// Section type for EFI Hand-off Blob.
 pub const TDX_METADATA_SECTION_TYPE_TD_HOB: u32 = 2;
+/// Section type for stack, heap and mailbox.
 pub const TDX_METADATA_SECTION_TYPE_TEMP_MEM: u32 = 3;
+/// Section type for kernel image.
 pub const TDX_METADATA_SECTION_TYPE_PAYLOAD: u32 = 5;
+/// Section type for kernel parameters.
 pub const TDX_METADATA_SECTION_TYPE_PAYLOAD_PARAM: u32 = 6;
 
+/// Attribute flags for BFV.
 pub const TDX_METADATA_ATTRIBUTES_EXTENDMR: u32 = 0x00000001;
 
 #[repr(C)]
-#[derive(Default, Pread, Pwrite)]
+#[derive(Pread, Pwrite)]
 pub struct TdxMetadataDescriptor {
     pub signature: u32,
     pub length: u32,
@@ -29,8 +36,40 @@ pub struct TdxMetadataDescriptor {
     pub number_of_section_entry: u32,
 }
 
+impl Default for TdxMetadataDescriptor {
+    fn default() -> Self {
+        TdxMetadataDescriptor {
+            signature: TDX_METADATA_SIGNATURE,
+            length: 16,
+            version: 1,
+            number_of_section_entry: 0,
+        }
+    }
+}
+
+impl TdxMetadataDescriptor {
+    pub fn set_sections(&mut self, sections: u32) {
+        // TdxMetadataDescriptor.length does not include TdxMetadata.guid, so "16 + 32 * sections"
+        // instead of "32 + 32 * sections".
+        assert!(sections < 0x10000);
+        self.number_of_section_entry = sections;
+        self.length = 16 + sections * 32;
+    }
+
+    pub fn is_valid(&self) -> bool {
+        let len = self.length;
+
+        !(self.signature != TDX_METADATA_SIGNATURE
+            || self.version != 1
+            || self.number_of_section_entry == 0
+            || len < 16
+            || (len - 16) % 32 != 0
+            || (len - 16) / 32 != self.number_of_section_entry)
+    }
+}
+
 #[repr(C)]
-#[derive(Default, Pwrite, Pread)]
+#[derive(Clone, Copy, Default, Pwrite, Pread)]
 pub struct TdxMetadataSection {
     pub data_offset: u32,
     pub raw_data_size: u32,
@@ -41,7 +80,7 @@ pub struct TdxMetadataSection {
 }
 
 #[repr(C)]
-#[derive(Default, Pwrite, Pread)]
+#[derive(Pwrite, Pread)]
 pub struct TdxMetadataGuid {
     pub data1: u32,
     pub data2: u32,
@@ -49,14 +88,57 @@ pub struct TdxMetadataGuid {
     pub data4: u32,
 }
 
+impl TdxMetadataGuid {
+    /// Check whether it's a valid
+    pub fn is_valid(&self) -> bool {
+        self.data1 == TDX_METADATA_GUID1
+            && self.data2 == TDX_METADATA_GUID2
+            && self.data3 == TDX_METADATA_GUID3
+            && self.data4 == TDX_METADATA_GUID4
+    }
+}
+
+impl Default for TdxMetadataGuid {
+    fn default() -> Self {
+        TdxMetadataGuid {
+            data1: TDX_METADATA_GUID1,
+            data2: TDX_METADATA_GUID2,
+            data3: TDX_METADATA_GUID3,
+            data4: TDX_METADATA_GUID4,
+        }
+    }
+}
+
 #[repr(C)]
-#[derive(Default, Pwrite)]
+#[derive(Pwrite)]
 pub struct TdxMetadata {
     pub guid: TdxMetadataGuid,
     pub descriptor: TdxMetadataDescriptor,
+    /// Sections for BFV, CFV, stack, heap, TD_HOP, Mailbox.
     pub sections: [TdxMetadataSection; 6],
     #[cfg(feature = "boot-kernel")]
+    /// Sections for kernel image and parameters.
     pub payload_sections: [TdxMetadataSection; 2],
+}
+
+impl Default for TdxMetadata {
+    fn default() -> Self {
+        let mut data = TdxMetadata {
+            guid: Default::default(),
+            descriptor: Default::default(),
+            sections: [Default::default(); 6],
+            #[cfg(feature = "boot-kernel")]
+            payload_sections: [Default::default(), 2],
+        };
+
+        if cfg!(feature = "boot-kernel") {
+            data.descriptor.set_sections(8);
+        } else {
+            data.descriptor.set_sections(6);
+        }
+
+        data
+    }
 }
 
 #[repr(C)]

--- a/rust-td-layout/src/metadata.rs
+++ b/rust-td-layout/src/metadata.rs
@@ -20,6 +20,7 @@ pub const TDX_METADATA_SECTION_TYPE_PAYLOAD_PARAM: u32 = 6;
 
 pub const TDX_METADATA_ATTRIBUTES_EXTENDMR: u32 = 0x00000001;
 
+#[repr(C)]
 #[derive(Default, Pread, Pwrite)]
 pub struct TdxMetadataDescriptor {
     pub signature: u32,
@@ -28,6 +29,7 @@ pub struct TdxMetadataDescriptor {
     pub number_of_section_entry: u32,
 }
 
+#[repr(C)]
 #[derive(Default, Pwrite, Pread)]
 pub struct TdxMetadataSection {
     pub data_offset: u32,
@@ -38,6 +40,7 @@ pub struct TdxMetadataSection {
     pub attributes: u32,
 }
 
+#[repr(C)]
 #[derive(Default, Pwrite, Pread)]
 pub struct TdxMetadataGuid {
     pub data1: u32,
@@ -46,6 +49,7 @@ pub struct TdxMetadataGuid {
     pub data4: u32,
 }
 
+#[repr(C)]
 #[derive(Default, Pwrite)]
 pub struct TdxMetadata {
     pub guid: TdxMetadataGuid,
@@ -55,6 +59,7 @@ pub struct TdxMetadata {
     pub payload_sections: [TdxMetadataSection; 2],
 }
 
+#[repr(C)]
 #[derive(Default, Pwrite, Pread)]
 pub struct TdxMetadataPtr {
     pub ptr: u32,

--- a/rust-td-layout/src/metadata.rs
+++ b/rust-td-layout/src/metadata.rs
@@ -146,3 +146,53 @@ impl Default for TdxMetadata {
 pub struct TdxMetadataPtr {
     pub ptr: u32,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scroll::export::mem::size_of;
+
+    #[test]
+    fn ensure_data_struct_size() {
+        assert_eq!(size_of::<TdxMetadataDescriptor>(), 16);
+        assert_eq!(size_of::<TdxMetadataSection>(), 32);
+        assert_eq!(size_of::<TdxMetadataGuid>(), 16);
+        assert_eq!(size_of::<TdxMetadataPtr>(), 4);
+        #[cfg(not(feature = "boot-kernel"))]
+        assert_eq!(size_of::<TdxMetadata>(), 224);
+        #[cfg(feature = "boot-kernel")]
+        assert_eq!(size_of::<TdxMetadata>(), 256);
+    }
+
+    #[test]
+    fn test_tdx_metadata_descriptor() {
+        let mut desc = TdxMetadataDescriptor::default();
+
+        assert_eq!(desc.signature, TDX_METADATA_SIGNATURE);
+        assert_eq!(desc.length, 16);
+        assert_eq!(desc.version, 1);
+        assert_eq!(desc.number_of_section_entry, 0);
+        assert_eq!(desc.is_valid(), false);
+
+        desc.set_sections(1);
+        assert_eq!(desc.signature, TDX_METADATA_SIGNATURE);
+        assert_eq!(desc.length, 48);
+        assert_eq!(desc.version, 1);
+        assert_eq!(desc.number_of_section_entry, 1);
+        assert_eq!(desc.is_valid(), true);
+    }
+
+    #[test]
+    fn test_tdx_metadata_guid() {
+        let mut guid = TdxMetadataGuid::default();
+
+        assert_eq!(guid.data1, TDX_METADATA_GUID1);
+        assert_eq!(guid.data2, TDX_METADATA_GUID2);
+        assert_eq!(guid.data3, TDX_METADATA_GUID3);
+        assert_eq!(guid.data4, TDX_METADATA_GUID4);
+        assert_eq!(guid.is_valid(), true);
+
+        guid.data1 = 0;
+        assert_eq!(guid.is_valid(), false);
+    }
+}

--- a/rust-td-tool/src/main.rs
+++ b/rust-td-tool/src/main.rs
@@ -338,21 +338,6 @@ fn build_tdx_metadata_ptr(metadata_ptr: &mut [u8]) {
 fn build_tdx_metadata(metadata: &mut [u8]) {
     let mut tdx_metadata = TdxMetadata::default();
 
-    tdx_metadata.guid.data1 = TDX_METADATA_GUID1;
-    tdx_metadata.guid.data2 = TDX_METADATA_GUID2;
-    tdx_metadata.guid.data3 = TDX_METADATA_GUID3;
-    tdx_metadata.guid.data4 = TDX_METADATA_GUID4;
-
-    tdx_metadata.descriptor.signature = TDX_METADATA_SIGNATURE;
-    tdx_metadata.descriptor.length = 0xd0;
-    tdx_metadata.descriptor.version = 1;
-    tdx_metadata.descriptor.number_of_section_entry = 6;
-    #[cfg(feature = "boot-kernel")]
-    {
-        tdx_metadata.descriptor.length += 64;
-        tdx_metadata.descriptor.number_of_section_entry += 2;
-    }
-
     // BFV
     tdx_metadata.sections[0].data_offset = TD_SHIM_PAYLOAD_OFFSET;
     tdx_metadata.sections[0].raw_data_size =


### PR DESCRIPTION
Enhance rust-td-layout by
1) add methods to validate structures
2) using `repr(C)` to ensure data structure layout
3) add more tests