### PR TITLE
rust-tdshim: add feature "boot-kernel" pass down to rust-td-layout

### DIFF
--- a/rust-tdshim/Cargo.toml
+++ b/rust-tdshim/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 [features]
 cet-ss = []
 secure-boot = []
+boot-kernel = ["rust-td-layout/boot-kernel"]
 
 [build-dependencies]
 cc = { git = "https://github.com/jyao1/cc-rs.git", branch = "uefi_support" }


### PR DESCRIPTION
rust-tdshim and rust-td-tool both use rust-td-layout as dependency.
If feature "boot-kernel" is not enabled, the auto-generated code
build-time.rs changed by rust-tdshim will be reused when rebuilding the
rust-td-tool.

Add this feature in rust-tdshim to fix this bug. It will be necessary to
enable this feature to boot kernel.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>