### PR TITLE
doc: Fix typo and bump version + date

### DIFF
--- a/doc/tdshim_spec.md
+++ b/doc/tdshim_spec.md
@@ -1,8 +1,8 @@
 # TD-SHIM specification
 
-version 0.5
+version 0.5.1
 
-Data: October 2021
+Date: February 2022
 
 ## Background
 


### PR DESCRIPTION
Fix typo Data -> Date

Bump version to 0.5.1 and date to February 2022.

Signed-off-by: Christophe de Dinechin <christophe@dinechin.org>