### PR TITLE
test-runner: add crates to run tests for td-shim no_std components

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -1,0 +1,64 @@
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  workflow_dispatch:
+
+name: Devtools
+
+env:
+  STABLE_RUST_TOOLCHAIN: 1.58.1
+  NIGHTLY_RUST_TOOLCHAIN: nightly-2021-08-20
+  TOOLCHAIN_PROFILE: minimal
+
+jobs:
+  devtools_install:
+    name: Install
+    runs-on: ${{ matrix.host_os }}
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        host_os:
+          - ubuntu-20.04
+          - windows-2019
+    steps:
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "10.0"
+          directory: ${{ runner.temp }}/llvm
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: ${{ env.TOOLCHAIN_PROFILE }}
+          toolchain: ${{ env.NIGHTLY_RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: ${{ env.TOOLCHAIN_PROFILE }}
+          toolchain: ${{ env.STABLE_RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Install devtools
+        run: make install-devtools
+
+      - name: Set PATH
+        shell: bash
+        run: |
+          echo "$GITHUB_WORKSPACE/devtools/bin" >> $GITHUB_PATH
+
+      - name: Exec Runner Server
+        run: test-runner-server -h

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,11 +13,11 @@ jobs:
       - name: install NASM
         uses: ilammy/setup-nasm@v1
 
-      - name: Install nightly toolchain with clippy available
+      - name: Install toolchain with clippy available
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-08-20
+          toolchain: 1.58.1
           override: true
           components: clippy
 
@@ -35,11 +35,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install nightly toolchain with rustfmt available
+      - name: Install toolchain with rustfmt available
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-08-20
+          toolchain: 1.58.1
           override: true
           components: rustfmt
 

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -10,11 +10,11 @@ on:
 name: Library Crates
 
 env:
-  RUST_TOOLCHAIN: nightly-2021-08-20
+  RUST_TOOLCHAIN: 1.58.1
   TOOLCHAIN_PROFILE: minimal
 
 jobs:
-  library_compile:
+  compile:
     name: Build Library Crates
     runs-on: ${{ matrix.host_os }}
     timeout-minutes: 30
@@ -34,15 +34,15 @@ jobs:
           version: "10.0"
           directory: ${{ runner.temp }}/llvm
 
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
 
       - name: Cache
         uses: Swatinem/rust-cache@v1
@@ -61,11 +61,27 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: install NASM
+        uses: ilammy/setup-nasm@v1
+
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
         with:
-          profile: minimal
+          version: "10.0"
+          directory: ${{ runner.temp }}/llvm
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: ${{ env.TOOLCHAIN_PROFILE }}
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
 
       - name: Test library crates
         run: make lib-test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ default-members = ["fake"]
 members = [
 	"fake",
 	"devtools/td-layout-config",
+	"devtools/test-runner-client",
+	"devtools/test-runner-server",
 	"td-layout",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 export CARGO=cargo
+export STABLE_TOOLCHAIN:=1.58.1
+export NIGHTLY_TOOLCHAIN:=nightly-2021-08-20
 export BUILD_TYPE:=debug
 export PREFIX:=/usr/local
 
@@ -68,49 +70,49 @@ lib-test: $(LIB_CRATES:%=test-%)
 lib-clean: $(LIB_CRATES:%=clean-%)
 
 # Targets for integration test crates
-integration-build: $(LIB_CRATES:%=integration-build-%)
+integration-build: $(TEST_CRATES:%=integration-build-%)
 
-integration-check: $(LIB_CRATES:%=integration-check-%)
+integration-check: $(TEST_CRATES:%=integration-check-%)
 
-integration-test: $(LIB_CRATES:%=integration-test-%)
+integration-test: $(TEST_CRATES:%=integration-test-%)
 
-integration-clean: $(LIB_CRATES:%=integration-clean-%)
+integration-clean: $(TEST_CRATES:%=integration-clean-%)
 
 # Target for crates which should be compiled with `x86_64-unknown-uefi` target
 uefi-build-%:
-	cargo xbuild --target x86_64-unknown-uefi -p $(patsubst uefi-build-%,%,$@) ${BUILD_TYPE_FLAG}
+	${CARGO} +${NIGHTLY_TOOLCHAIN} xbuild --target x86_64-unknown-uefi -p $(patsubst uefi-build-%,%,$@) ${BUILD_TYPE_FLAG}
 
 uefi-check-%:
-	cargo xcheck --target x86_64-unknown-uefi -p $(patsubst uefi-check-%,%,$@) ${BUILD_TYPE_FLAG}
+	 ${CARGO} +${NIGHTLY_TOOLCHAIN}xcheck --target x86_64-unknown-uefi -p $(patsubst uefi-check-%,%,$@) ${BUILD_TYPE_FLAG}
 
 uefi-clean-%:
-	cargo clean --target x86_64-unknown-uefi -p $(patsubst uefi-clean-%,%,$@) ${BUILD_TYPE_FLAG}
+	${CARGO} +${NIGHTLY_TOOLCHAIN} clean --target x86_64-unknown-uefi -p $(patsubst uefi-clean-%,%,$@) ${BUILD_TYPE_FLAG}
 
 # Target for integration test crates which should be compiled with `x86_64-custom.json` target
 integration-build-%:
-	cargo xbuild --target ${TOPDIR}/devtools/rustc-targets/x86_64-custom.json -p $(patsubst integration-build-%,%,$@) ${BUILD_TYPE_FLAG}
+	${CARGO} +${NIGHTLY_TOOLCHAIN} xbuild --target ${TOPDIR}/devtools/rustc-targets/x86_64-custom.json -p $(patsubst integration-build-%,%,$@) ${BUILD_TYPE_FLAG}
 
 integration-check-%:
-	cargo xcheck --target ${TOPDIR}/devtools/rustc-targets/x86_64-custom.json -p $(patsubst integration-check-%,%,$@) ${BUILD_TYPE_FLAG}
+	${CARGO} +${NIGHTLY_TOOLCHAIN} xcheck --target ${TOPDIR}/devtools/rustc-targets/x86_64-custom.json -p $(patsubst integration-check-%,%,$@) ${BUILD_TYPE_FLAG}
 
 integration-test-%:
-	cargo xtest --target ${TOPDIR}/devtools/rustc-targets/x86_64-custom.json -p $(patsubst integration-test-%,%,$@) ${BUILD_TYPE_FLAG}
+	${CARGO} +${NIGHTLY_TOOLCHAIN} xtest --target ${TOPDIR}/devtools/rustc-targets/x86_64-custom.json -p $(patsubst integration-test-%,%,$@) ${BUILD_TYPE_FLAG}
 
 integration-clean-%:
-	cargo clean --target ${TOPDIR}/devtools/rustc-targets/x86_64-custom.json -p $(patsubst integration-clean-%,%,$@) ${BUILD_TYPE_FLAG}
+	${CARGO} +${NIGHTLY_TOOLCHAIN} clean --target ${TOPDIR}/devtools/rustc-targets/x86_64-custom.json -p $(patsubst integration-clean-%,%,$@) ${BUILD_TYPE_FLAG}
 
 # Targets for normal library/binary crates
 build-%:
-	cargo build -p $(patsubst build-%,%,$@) ${BUILD_TYPE_FLAG}
+	${CARGO} +${STABLE_TOOLCHAIN} build -p $(patsubst build-%,%,$@) ${BUILD_TYPE_FLAG}
 
 check-%:
-	cargo check -p $(patsubst check-%,%,$@) ${BUILD_TYPE_FLAG}
+	${CARGO} +${STABLE_TOOLCHAIN} check -p $(patsubst check-%,%,$@) ${BUILD_TYPE_FLAG}
 
 clean-%:
-	cargo clean -p $(patsubst clean-%,%,$@) ${BUILD_TYPE_FLAG}
+	${CARGO} +${STABLE_TOOLCHAIN} clean -p $(patsubst clean-%,%,$@) ${BUILD_TYPE_FLAG}
 
 test-%:
-	cargo test -p $(patsubst test-%,%,$@) ${BUILD_TYPE_FLAG}
+	${CARGO} +${STABLE_TOOLCHAIN} test -p $(patsubst test-%,%,$@) ${BUILD_TYPE_FLAG}
 
 # Targets for subdirectories
 build-subdir-%:

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -1,16 +1,24 @@
 build:
-	cargo build ${BUILD_TYPE_FLAG} -p td-layout-config
+	${CARGO} +${STABLE_TOOLCHAIN} build ${BUILD_TYPE_FLAG} -p td-layout-config
+	${CARGO} +${NIGHTLY_TOOLCHAIN} build ${BUILD_TYPE_FLAG} -p test-runner-client
+	${CARGO} +${STABLE_TOOLCHAIN} build ${BUILD_TYPE_FLAG} -p test-runner-server
 
 check:
-	cargo check ${BUILD_TYPE_FLAG} -p td-layout-config
+	${CARGO} +${STABLE_TOOLCHAIN} check ${BUILD_TYPE_FLAG} -p td-layout-config
+	${CARGO} +${NIGHTLY_TOOLCHAIN} check ${BUILD_TYPE_FLAG} -p test-runner-client
+	${CARGO} +${STABLE_TOOLCHAIN} check ${BUILD_TYPE_FLAG} -p test-runner-server
 
 clean:
-	cargo clean ${BUILD_TYPE_FLAG} -p td-layout-config
+	${CARGO} +${STABLE_TOOLCHAIN} clean ${BUILD_TYPE_FLAG} -p td-layout-config
+	${CARGO} +${NIGHTLY_TOOLCHAIN} clean ${BUILD_TYPE_FLAG} -p test-runner-client
+	${CARGO} +${STABLE_TOOLCHAIN} clean ${BUILD_TYPE_FLAG} -p test-runner-server
 
 install:
 	mkdir -p ${TOPDIR}/devtools/bin
 	install -m u+rx ${TOPDIR}/target/${BUILD_TYPE}/td-layout-config ${TOPDIR}/devtools/bin/td-layout-config
+	install -m u+rx ${TOPDIR}/target/${BUILD_TYPE}/test-runner-server ${TOPDIR}/devtools/bin/test-runner-server
 
 uninstall:
 	rm ${TOPDIR}/devtools/bin/td-layout-config
+	rm ${TOPDIR}/devtools/bin/test-runner-server
 

--- a/devtools/test-runner-client/Cargo.toml
+++ b/devtools/test-runner-client/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test-runner-client"
+version = "0.1.0"
+description = "Client cooperating with test-runner-server to execute unit test cases in virtual machines"
+repository = "https://github.com/confidential-containers/td-shim"
+homepage = "https://github.com/confidential-containers"
+license = "Apache 2.0"
+edition = "2018"
+
+[dependencies]
+linked_list_allocator = "0.9.0"
+spin = { version = "0.9.2", features = ["lazy"]}
+uart_16550 = "0.2.14"
+x86_64 = "=0.14.6"

--- a/devtools/test-runner-client/README.md
+++ b/devtools/test-runner-client/README.md
@@ -1,0 +1,34 @@
+# test-runner-server & test-runner-client
+
+Rust has a [built-in test framework](https://doc.rust-lang.org/book/ch11-00-testing.html) that is capable of running
+unit tests without the need to set anything up.
+Just create a function that checks some results through assertions and add the `#[test]` attribute to the function
+header. Then `cargo test` will automatically find and execute all test functions of your crate.
+
+Unfortunately it’s a bit more complicated for `#[no_std]` applications such as our case. The problem is that Rust’s
+test framework implicitly uses the built-in test library, which depends on the standard library. This means that we
+can’t use the default test framework for our `#[no_std]` shim and payload.
+
+To simplify the development, test cases are divided into two classes:
+- normal test cases: which may be run on the host (build machine) directly
+- vm-based test cases: which must be run inside a virtual machine, the virtual machine may or may not be a trusted
+  domain.
+
+It's ease to deal with the normal unit test cases, just include the test cases in the crate source code and use the
+normal rust test framework for them.
+
+For vm-based test cases, two fundamental issues must be solved:
+- run `#[no_std]` unit test cases. This is solved by making use of the `custom_test_frameworks` feature which allows
+  the use of `#[test_case]` and `#![test_runner]`. Any function, const, or static can be annotated with `#[test_case]`
+  causing it to be aggregated (like #[test]) and be passed to the test runner determined by the `#![test_runner]`
+  crate attribute. The `test-runner-client` provides a `test_runner()` for this purpose.
+- run unit test cases inside a vm. The `test-runner-server` prepares a boot disk image and boot a qemu virtual machine
+  with the prepared boot image by using the `bootloader` and associated crates. The `test-runner-server` also
+  communicates `test-runner-client` through serial port and io port to collect logs and result.
+  
+And all vm-based test cases are implemented as dedicated crates under directory `tests`.
+
+## Reference
+For more detailed design information, please refer to:
+- [Writing an OS in Rust: Testing](https://os.phil-opp.com/testing/)
+- [How to Build a Custom Test Harness in Rust](https://www.infinyon.com/blog/2021/04/rust-custom-test-harness/)

--- a/devtools/test-runner-client/src/lib.rs
+++ b/devtools/test-runner-client/src/lib.rs
@@ -1,0 +1,87 @@
+// Copyright © 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_std]
+
+use core::any;
+use core::panic::PanicInfo;
+use linked_list_allocator::LockedHeap;
+
+pub mod serial;
+
+#[panic_handler]
+pub fn panic(info: &PanicInfo) -> ! {
+    serial_println!("[failed]\n");
+    serial_println!("Error: {}\n", info);
+    exit_qemu(QemuExitCode::Failed);
+}
+
+#[global_allocator]
+pub static ALLOCATOR: LockedHeap = LockedHeap::empty();
+
+pub fn init_heap(heap_start: usize, heap_size: usize) {
+    unsafe {
+        ALLOCATOR.lock().init(heap_start, heap_size);
+    }
+}
+
+/// Unit test runner to hook the rust test harness.
+///
+/// The `custom_test_frameworks` feature allows the use of `#[test_case]` and `#![test_runner]`.
+/// Any function, const, or static can be annotated with `#[test_case]` causing it to be aggregated
+/// (like #[test]) and be passed to the test runner determined by the `#![test_runner]` crate
+/// attribute.
+pub fn test_runner(tests: &[&dyn Testable]) {
+    serial_println!("Running {} tests", tests.len());
+    for test in tests {
+        test.run();
+    }
+    exit_qemu(QemuExitCode::Success);
+}
+
+/// Trait for unit test functions.
+pub trait Testable {
+    fn run(&self);
+}
+
+impl<T> Testable for T
+where
+    T: Fn(),
+{
+    fn run(&self) {
+        serial_print!("{}...\t", any::type_name::<T>());
+        self();
+        serial_println!("[ok]");
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum QemuExitCode {
+    Success = 0x10,
+    Failed = 0x11,
+}
+
+/// Notify qemu hypervisor to exit, with exit code.
+#[allow(clippy::empty_loop)]
+pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
+    use x86_64::instructions::port::Port;
+
+    unsafe {
+        let mut port = Port::new(0xf4);
+        port.write(exit_code as u32);
+    }
+
+    loop {}
+}

--- a/devtools/test-runner-client/src/serial.rs
+++ b/devtools/test-runner-client/src/serial.rs
@@ -1,0 +1,51 @@
+// Copyright © 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::fmt::Write;
+use spin::{Lazy, Mutex};
+use uart_16550::SerialPort;
+use x86_64::instructions::interrupts;
+
+pub static SERIAL1: Lazy<Mutex<SerialPort>> = Lazy::new(|| {
+    let mut serial_port = unsafe { SerialPort::new(0x3F8) };
+    serial_port.init();
+    Mutex::new(serial_port)
+});
+
+#[doc(hidden)]
+pub fn _print(args: ::core::fmt::Arguments) {
+    interrupts::without_interrupts(|| {
+        SERIAL1
+            .lock()
+            .write_fmt(args)
+            .expect("Printing to serial failed");
+    });
+}
+
+/// Prints to the host through the serial interface.
+#[macro_export]
+macro_rules! serial_print {
+    ($($arg:tt)*) => {
+        $crate::serial::_print(format_args!($($arg)*));
+    };
+}
+
+/// Prints to the host through the serial interface, appending a newline.
+#[macro_export]
+macro_rules! serial_println {
+    () => ($crate::serial_print!("\n"));
+    ($fmt:expr) => ($crate::serial_print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => ($crate::serial_print!(
+        concat!($fmt, "\n"), $($arg)*));
+}

--- a/devtools/test-runner-server/Cargo.toml
+++ b/devtools/test-runner-server/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test-runner-server"
+version = "0.1.0"
+description = "Server to run test cases inside a qemu virtual machine"
+repository = "https://github.com/confidential-containers/td-shim"
+homepage = "https://github.com/confidential-containers"
+license = "Apache 2.0"
+edition = "2018"
+
+[dependencies]
+bootloader-locator = "0.0.4" # for locating the `bootloader` dependency on disk
+clap = { version = "3.0", features = ["cargo"] }
+locate-cargo-manifest = "0.2.0" # for locating the kernel's `Cargo.toml`
+runner-utils = "0.0.2" # small helper functions for custom runners (e.g. timeouts)

--- a/devtools/test-runner-server/README.md
+++ b/devtools/test-runner-server/README.md
@@ -32,3 +32,4 @@ And all vm-based test cases are implemented as dedicated crates under directory 
 For more detailed design information, please refer to:
 - [Writing an OS in Rust: Testing](https://os.phil-opp.com/testing/)
 - [How to Build a Custom Test Harness in Rust](https://www.infinyon.com/blog/2021/04/rust-custom-test-harness/)
+- [Test Framework Example](https://github.com/rust-osdev/bootloader/tree/main/examples/test_framework)

--- a/devtools/test-runner-server/README.md
+++ b/devtools/test-runner-server/README.md
@@ -1,0 +1,34 @@
+# test-runner-server & test-runner-client
+
+Rust has a [built-in test framework](https://doc.rust-lang.org/book/ch11-00-testing.html) that is capable of running
+unit tests without the need to set anything up.
+Just create a function that checks some results through assertions and add the `#[test]` attribute to the function
+header. Then `cargo test` will automatically find and execute all test functions of your crate.
+
+Unfortunately it’s a bit more complicated for `#[no_std]` applications such as our case. The problem is that Rust’s
+test framework implicitly uses the built-in test library, which depends on the standard library. This means that we
+can’t use the default test framework for our `#[no_std]` shim and payload.
+
+To simplify the development, test cases are divided into two classes:
+- normal test cases: which may be run on the host (build machine) directly
+- vm-based test cases: which must be run inside a virtual machine, the virtual machine may or may not be a trusted
+  domain.
+
+It's ease to deal with the normal unit test cases, just include the test cases in the crate source code and use the
+normal rust test framework for them.
+
+For vm-based test cases, two fundamental issues must be solved:
+- run `#[no_std]` unit test cases. This is solved by making use of the `custom_test_frameworks` feature which allows
+  the use of `#[test_case]` and `#![test_runner]`. Any function, const, or static can be annotated with `#[test_case]`
+  causing it to be aggregated (like #[test]) and be passed to the test runner determined by the `#![test_runner]`
+  crate attribute. The `test-runner-client` provides a `test_runner()` for this purpose.
+- run unit test cases inside a vm. The `test-runner-server` prepares a boot disk image and boot a qemu virtual machine
+  with the prepared boot image by using the `bootloader` and associated crates. The `test-runner-server` also
+  communicates `test-runner-client` through serial port and io port to collect logs and result.
+  
+And all vm-based test cases are implemented as dedicated crates under directory `tests`.
+
+## Reference
+For more detailed design information, please refer to:
+- [Writing an OS in Rust: Testing](https://os.phil-opp.com/testing/)
+- [How to Build a Custom Test Harness in Rust](https://www.infinyon.com/blog/2021/04/rust-custom-test-harness/)

--- a/devtools/test-runner-server/src/main.rs
+++ b/devtools/test-runner-server/src/main.rs
@@ -1,0 +1,133 @@
+// Copyright © 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::{app_from_crate, arg};
+use std::{
+    io,
+    path::{Path, PathBuf},
+    process::{Command, ExitStatus},
+    time::Duration,
+};
+
+const RUN_ARGS: &[&str] = &["--no-reboot", "-s"];
+const TEST_ARGS: &[&str] = &[
+    "-device",
+    "isa-debug-exit,iobase=0xf4,iosize=0x04",
+    "-serial",
+    "stdio",
+    "-display",
+    "none",
+    "--no-reboot",
+];
+const TEST_TIMEOUT_SECS: u64 = 10;
+
+fn main() {
+    let matches = app_from_crate!()
+        .arg(
+            arg!([kernel] "Path of kernel file be executed by the virtual machine")
+                .required(true)
+                .allow_invalid_utf8(false),
+        )
+        .arg(
+            arg!(
+              --"no-run" "Dry-run mode, do not actually spawn the virtual machine"
+            )
+            .required(false)
+            .allow_invalid_utf8(false),
+        )
+        .get_matches();
+
+    // Safe to unwrap because they are mandatory arguments.
+    let kernel = matches.value_of("kernel").unwrap();
+    let kernel_binary_path = {
+        let path = PathBuf::from(kernel);
+        path.canonicalize().expect(&format!(
+            "Invalid kernel file path {}: {}",
+            kernel,
+            io::Error::last_os_error()
+        ))
+    };
+    let bios = create_disk_images(&kernel_binary_path);
+
+    //let output = matches.value_of("no-run")
+    if matches.is_present("no-run") {
+        println!("Created disk image at `{}`", bios.display());
+        return;
+    }
+
+    let mut run_cmd = Command::new("qemu-system-x86_64");
+    run_cmd
+        .arg("-drive")
+        .arg(format!("format=raw,file={}", bios.display()));
+
+    let binary_kind = runner_utils::binary_kind(&kernel_binary_path);
+    if binary_kind.is_test() {
+        run_cmd.args(TEST_ARGS);
+
+        let exit_status = run_test_command(run_cmd);
+        match exit_status.code() {
+            // TODO: should this be QemuExitCode::Success?
+            Some(33) => {} // success
+            other => panic!("Test failed (exit code: {:?})", other),
+        }
+    } else {
+        run_cmd.args(RUN_ARGS);
+
+        let exit_status = run_cmd.status().unwrap();
+        if !exit_status.success() {
+            std::process::exit(exit_status.code().unwrap_or(1));
+        }
+    }
+}
+
+fn run_test_command(mut cmd: Command) -> ExitStatus {
+    runner_utils::run_with_timeout(&mut cmd, Duration::from_secs(TEST_TIMEOUT_SECS)).unwrap()
+}
+
+fn create_disk_images(kernel_binary_path: &Path) -> PathBuf {
+    let bootloader_manifest_path = bootloader_locator::locate_bootloader("bootloader").unwrap();
+    let kernel_manifest_path = locate_cargo_manifest::locate_manifest().unwrap();
+
+    let mut build_cmd = Command::new(env!("CARGO"));
+    build_cmd.current_dir(bootloader_manifest_path.parent().unwrap());
+    build_cmd.arg("builder");
+    build_cmd
+        .arg("--kernel-manifest")
+        .arg(&kernel_manifest_path);
+    build_cmd.arg("--kernel-binary").arg(&kernel_binary_path);
+    build_cmd
+        .arg("--target-dir")
+        .arg(kernel_manifest_path.parent().unwrap().join("target"));
+    build_cmd
+        .arg("--out-dir")
+        .arg(kernel_binary_path.parent().unwrap());
+    build_cmd.arg("--quiet");
+
+    if !build_cmd.status().unwrap().success() {
+        panic!("build failed");
+    }
+
+    let kernel_binary_name = kernel_binary_path.file_name().unwrap().to_str().unwrap();
+    let disk_image = kernel_binary_path
+        .parent()
+        .unwrap()
+        .join(format!("boot-bios-{}.img", kernel_binary_name));
+    if !disk_image.exists() {
+        panic!(
+            "Disk image does not exist at {} after bootloader build",
+            disk_image.display()
+        );
+    }
+    disk_image
+}

--- a/doc/test_in_no_std.md
+++ b/doc/test_in_no_std.md
@@ -1,0 +1,94 @@
+### test_in_no_std
+
+#### Run test in no_std environment
+
+##### Requirements
+
+You need a nightly [Rust](https://www.rust-lang.org/) compiler with the `llvm-tools-preview` component, which can be installed through `rustup component add llvm-tools-preview` and `cargo install cargo-xbuild`.
+
+```
+rustup install nightly
+rustup component add llvm-tools-preview
+cargo install cargo-xbuild
+```
+
+#### Main.rs file header added
+
+```rust
+#![no_std]
+#![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+#[cfg(test)]
+use bootloader::{entry_point, BootInfo};
+#[cfg(test)]
+entry_point!(kernel_main);
+
+#[cfg(test)]
+fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
+
+    // turn the screen gray
+    if let Some(framebuffer) = boot_info.framebuffer.as_mut() {
+        for byte in framebuffer.buffer_mut() {
+            *byte = 0x90;
+        }
+    }
+
+    #[cfg(test)]
+    test_main();
+
+    loop {}
+}
+```
+
+#### Cargo.toml file add dependency
+
+```toml
+[dependencies]
+# add bootloader
+bootloader = "0.10.9"
+
+[package.metadata.bootloader]
+# To map the complete physical memory starting at virtual address.
+map-physical-memory = true
+```
+
+#### Write test case, the test case mark is changed from #[test] to #[test_case]
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test_case]
+    fn trivial_assertion() {
+        assert_eq!(1, 1);
+    }
+}
+```
+
+#### Create a .cargo/config.toml file in the current library, add content
+
+```toml
+[target.'cfg(target_os = "none")']
+runner = "cargo run --package boot --"
+
+[alias]
+ktest = "xtest --target x86_64-custom.json"
+
+```
+
+#### case runs in qemu, refer to current member boot
+
+##### run rust-td-payload test
+
+```
+cd rust-td-payload
+cargo ktest
+```
+
+#### reference
+
+[bootloader](https://github.com/rust-osdev/bootloader)
+
+[examples_test_framework](https://github.com/rust-osdev/bootloader/tree/main/examples/test_framework)


### PR DESCRIPTION
Some td-shim components are compiled with `#[no_std]` and should be run
on physical/virtual machines. The normal rust test harness does not
support such cases, but it provides mechanisms to extend the stand test
harness. A pair of crates, test-runner-server and test-runner-client,
are implemented to run unit test cases for td-shim no_std components.
These components are used for development only, so hosted uner the
devtools directory.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>