### PR TITLE
td-paging: add crates to manage page table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 	"fake",
 	"devtools/td-layout-config",
 	"td-layout",
+	"td-paging",
 ]
 
 # the profile used for `cargo build`

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
 	export BUILD_TYPE_FLAG=
 endif
 
-LIB_CRATES = td-layout
+LIB_CRATES = td-layout td-paging
 SHIM_CRATES = 
 TEST_CRATES = 
 TOOL_CRATES = 

--- a/td-paging/Cargo.toml
+++ b/td-paging/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "td-paging"
+version = "0.1.0"
+description = "Setup and manage page table for td-shim"
+repository = "https://github.com/confidential-containers/td-shim"
+homepage = "https://github.com/confidential-containers"
+license = "BSD-2-Clause-Patent"
+edition = "2018"
+
+[dependencies]
+bitfield = "0.13.2"
+log = "0.4.13"
+spin = "0.9.2"
+td-layout = { path = "../td-layout" }
+x86 = "0.41.0"
+x86_64 = "=0.14.6"

--- a/td-paging/src/consts.rs
+++ b/td-paging/src/consts.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+/// Guest physical to virtual address mapping offset. 0 means identity mapping.
+pub const PHYS_VIRT_OFFSET: usize = 0;
+/// Page size.
+pub const PAGE_SIZE: usize = 0x1000;
+/// The memory size reserved for page table pages.
+pub const PAGE_TABLE_SIZE: usize = 0x100000;
+
+/// Default PTE(page table entry) size.
+pub const PAGE_SIZE_DEFAULT: usize = 0x4000_0000;
+/// Minimal PTE(page table entry) size.
+pub const PAGE_SIZE_4K: usize = 0x1000;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use td_layout::runtime;
+
+    #[test]
+    fn test_constants() {
+        // Ensure the runtime layout has reserved enough space for page table pages.
+        assert!(
+            PAGE_TABLE_SIZE as u64
+                <= runtime::TD_PAYLOAD_PARAM_BASE - runtime::TD_PAYLOAD_PAGE_TABLE_BASE
+        );
+    }
+}

--- a/td-paging/src/frame.rs
+++ b/td-paging/src/frame.rs
@@ -1,0 +1,239 @@
+// Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2022 Alibaba Cloud
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use core::ops::Range;
+use log::{info, trace};
+use spin::Mutex;
+use x86_64::{
+    structures::paging::{FrameAllocator, PhysFrame, Size4KiB},
+    PhysAddr,
+};
+
+use super::consts::{PAGE_SIZE, PAGE_TABLE_SIZE};
+use td_layout::runtime::TD_PAYLOAD_PAGE_TABLE_BASE;
+
+const NUM_PAGE_TABLE_PAGES: usize = PAGE_TABLE_SIZE / PAGE_SIZE;
+const BITMAP_ALLOCATOR_ARRAY_SIZE: usize = (NUM_PAGE_TABLE_PAGES + 127) / 128;
+
+/// Global page table page allocator.
+pub static FRAME_ALLOCATOR: Mutex<BMFrameAllocator> = Mutex::new(BMFrameAllocator::empty());
+
+#[derive(Default)]
+struct FrameAlloc {
+    //  A bit of `1` means available.
+    bitmap: [u128; BITMAP_ALLOCATOR_ARRAY_SIZE],
+}
+
+impl FrameAlloc {
+    fn alloc(&mut self) -> Option<usize> {
+        for (idx, map) in self.bitmap.iter_mut().enumerate() {
+            let pos = map.trailing_zeros();
+            if pos < 128 {
+                *map &= !(1 << pos);
+                return Some(idx * 128 + pos as usize);
+            }
+        }
+
+        None
+    }
+
+    fn free(&mut self, range: Range<usize>) {
+        for idx in range {
+            if idx >= NUM_PAGE_TABLE_PAGES {
+                panic!("invalid page frame index {} for FrameAlloc::free()!", idx);
+            }
+            if self.bitmap[idx / 128] & (1 << (idx % 128)) != 0 {
+                panic!(
+                    "try to free unallocated page frame index {} for FrameAlloc::free()!",
+                    idx
+                );
+            }
+            self.bitmap[idx / 128] |= 1 << (idx % 128);
+        }
+    }
+
+    fn reserve(&mut self, idx: usize) {
+        if idx >= NUM_PAGE_TABLE_PAGES {
+            panic!("invalid page frame index {} for FrameAlloc::free()!", idx);
+        }
+        if self.bitmap[idx / 128] & (1 << (idx % 128)) == 0 {
+            panic!(
+                "try to reserve unavailable page frame index {} for FrameAlloc::free()!",
+                idx
+            );
+        }
+        self.bitmap[idx / 128] &= !(1 << (idx % 128));
+    }
+}
+
+#[derive(Default)]
+pub struct BMFrameAllocator {
+    base: usize,
+    size: usize,
+    inner: FrameAlloc,
+}
+
+#[allow(dead_code)]
+impl BMFrameAllocator {
+    const fn empty() -> Self {
+        Self {
+            base: 0,
+            size: 0,
+            inner: FrameAlloc {
+                bitmap: [0; BITMAP_ALLOCATOR_ARRAY_SIZE],
+            },
+        }
+    }
+
+    // Caller needs to ensure:
+    // - base is page aligned
+    // - size is page aligned
+    // - base + size doesn't wrap around
+    fn new(base: usize, size: usize) -> Self {
+        let mut inner = FrameAlloc::default();
+        let base = base / PAGE_SIZE;
+        let page_count = size / PAGE_SIZE;
+
+        inner.free(0..page_count);
+
+        Self { base, size, inner }
+    }
+
+    fn alloc(&mut self) -> Option<usize> {
+        let ret = self.inner.alloc().map(|idx| idx * PAGE_SIZE + self.base);
+        trace!("Allocate frame: {:x?}\n", ret);
+        ret
+    }
+
+    pub(crate) fn reserve(&mut self, addr: u64) {
+        let idx = addr as usize / PAGE_SIZE;
+        if addr > usize::MAX as u64 || idx < self.base || idx >= self.base + self.size {
+            panic!(
+                "Invalid address 0x{:x} to BMFrameAllocator::reserve()",
+                addr
+            );
+        }
+        self.inner.reserve(idx - self.base);
+    }
+}
+
+unsafe impl FrameAllocator<Size4KiB> for BMFrameAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysFrame<Size4KiB>> {
+        self.alloc()
+            .map(|addr| PhysFrame::containing_address(PhysAddr::new(addr as u64)))
+    }
+}
+
+/// Initialize the physical frame allocator.
+pub(super) fn init() {
+    let mut allocator = FRAME_ALLOCATOR.lock();
+    if allocator.base == 0 && allocator.size == 0 {
+        *allocator = BMFrameAllocator::new(TD_PAYLOAD_PAGE_TABLE_BASE as usize, PAGE_TABLE_SIZE);
+        info!(
+            "Frame allocator init done: {:#x?}\n",
+            TD_PAYLOAD_PAGE_TABLE_BASE..TD_PAYLOAD_PAGE_TABLE_BASE + PAGE_TABLE_SIZE as u64
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_configuration() {
+        // At least 4-levels of page table pages.
+        assert!(NUM_PAGE_TABLE_PAGES > 4);
+    }
+
+    #[test]
+    fn test_frame_alloc() {
+        let mut allocator = FrameAlloc::default();
+
+        assert_eq!(allocator.bitmap[0] & 0x1, 0);
+        assert_eq!(allocator.bitmap[0] & 0x2, 0);
+        assert_eq!(allocator.bitmap[0] & 0x4, 0);
+
+        allocator.free(0..3);
+        assert_eq!(allocator.bitmap[0] & 0x1, 0x1);
+        assert_eq!(allocator.bitmap[0] & 0x2, 0x2);
+        assert_eq!(allocator.bitmap[0] & 0x4, 0x4);
+
+        allocator.reserve(0);
+        assert_eq!(allocator.bitmap[0] & 0x1, 0x0);
+        assert_eq!(allocator.bitmap[0] & 0x2, 0x2);
+        assert_eq!(allocator.bitmap[0] & 0x4, 0x4);
+
+        assert_eq!(allocator.alloc().unwrap(), 1);
+        assert_eq!(allocator.bitmap[0] & 0x1, 0x0);
+        assert_eq!(allocator.bitmap[0] & 0x2, 0x0);
+        assert_eq!(allocator.bitmap[0] & 0x4, 0x4);
+
+        allocator.free(1..2);
+        assert_eq!(allocator.bitmap[0] & 0x1, 0x0);
+        assert_eq!(allocator.bitmap[0] & 0x2, 0x2);
+        assert_eq!(allocator.bitmap[0] & 0x4, 0x4);
+
+        assert_eq!(allocator.alloc().unwrap(), 1);
+        assert_eq!(allocator.alloc().unwrap(), 2);
+        assert!(allocator.alloc().is_none());
+        assert!(allocator.alloc().is_none());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_frame_free_invalid_index() {
+        let mut allocator = FrameAlloc::default();
+
+        allocator.free(0..NUM_PAGE_TABLE_PAGES + 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_frame_free_invalid_state() {
+        let mut allocator = FrameAlloc::default();
+
+        allocator.free(0..3);
+        allocator.free(0..3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_frame_reserve_invalid_index() {
+        let mut allocator = FrameAlloc::default();
+
+        allocator.reserve(NUM_PAGE_TABLE_PAGES);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_frame_reserve_invalid_state() {
+        let mut allocator = FrameAlloc::default();
+
+        allocator.free(0..3);
+        allocator.reserve(1);
+        allocator.reserve(1);
+    }
+
+    #[test]
+    fn test_empty_bm_allocator() {
+        let mut allocator = BMFrameAllocator::empty();
+        assert!(allocator.alloc().is_none());
+        assert!(allocator.alloc().is_none());
+    }
+
+    #[test]
+    fn test_bm_allocator() {
+        init();
+        let mut allocator = FRAME_ALLOCATOR.lock();
+
+        allocator.reserve(TD_PAYLOAD_PAGE_TABLE_BASE);
+        allocator.reserve(TD_PAYLOAD_PAGE_TABLE_BASE + PAGE_TABLE_SIZE as u64 - 1);
+        assert_eq!(
+            allocator.allocate_frame().unwrap().start_address().as_u64(),
+            0x1000
+        );
+    }
+}

--- a/td-paging/src/lib.rs
+++ b/td-paging/src/lib.rs
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_std]
+
+mod consts;
+mod frame;
+mod page_table;
+
+pub use consts::*;
+pub use page_table::{cr3_write, create_mapping, create_mapping_with_flags, set_page_flags};
+
+/// Initialize the page table management subsystem.
+pub fn init() {
+    frame::init();
+}
+
+/// Reserve page table page at physical address `addr`.
+pub fn reserve_page(addr: u64) {
+    frame::FRAME_ALLOCATOR.lock().reserve(addr);
+}

--- a/td-paging/src/page_table.rs
+++ b/td-paging/src/page_table.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use core::cmp::min;
+use log::{info, trace};
+use x86_64::{
+    structures::paging::PageTableFlags as Flags,
+    structures::paging::{
+        mapper::MappedFrame, mapper::TranslateResult, Mapper, OffsetPageTable, Page, PageSize,
+        PhysFrame, Size1GiB, Size2MiB, Size4KiB, Translate,
+    },
+    PhysAddr, VirtAddr,
+};
+
+use super::frame::{BMFrameAllocator, FRAME_ALLOCATOR};
+use td_layout::runtime::TD_PAYLOAD_PAGE_TABLE_BASE;
+
+const ALIGN_4K_BITS: u64 = 12;
+const ALIGN_4K: u64 = 1 << ALIGN_4K_BITS;
+const ALIGN_2M_BITS: u64 = 21;
+const ALIGN_2M: u64 = 1 << ALIGN_2M_BITS;
+const ALIGN_1G_BITS: u64 = 30;
+const ALIGN_1G: u64 = 1 << ALIGN_1G_BITS;
+
+/// Write physical address of level 4 page table page to `CR3`.
+pub fn cr3_write() {
+    unsafe {
+        x86::controlregs::cr3_write(TD_PAYLOAD_PAGE_TABLE_BASE);
+    }
+    info!("Cr3 - {:x}\n", unsafe { x86::controlregs::cr3() });
+}
+
+/// Create page table entries to map `[va, va + sz)` to `[pa, ps + sz)` with page size `ps` and
+/// page attribute `flags`.
+///
+/// # Panic
+/// - `pa + sz` wraps around.
+/// - `va + sz` wraps around.
+/// - `pa`, `va` or `sz` is not page aligned.
+pub fn create_mapping_with_flags(
+    pt: &mut OffsetPageTable,
+    mut pa: PhysAddr,
+    mut va: VirtAddr,
+    ps: u64,
+    mut sz: u64,
+    flags: Flags,
+) {
+    let allocator: &mut BMFrameAllocator = &mut FRAME_ALLOCATOR.lock();
+
+    if pa.as_u64().checked_add(sz).is_none()
+        || va.as_u64().checked_add(sz).is_none()
+        || pa.as_u64() & (ALIGN_4K - 1) != 0
+        || va.as_u64() & (ALIGN_4K - 1) != 0
+        || sz & (ALIGN_4K - 1) != 0
+        || ps.count_ones() != 1
+        || ps < ALIGN_4K as u64
+    {
+        panic!("invalid argument to create_mapping_with_flags()");
+    }
+
+    while sz > 0 {
+        let addr_align = min(
+            ps.trailing_zeros(),
+            min(pa.as_u64().trailing_zeros(), va.as_u64().trailing_zeros()),
+        ) as u64;
+        let mapped_size = if addr_align >= ALIGN_1G_BITS && sz >= ALIGN_1G {
+            trace!(
+                "1GB {} {:016x} /{:016x} {:016x}\n",
+                addr_align,
+                sz,
+                pa.as_u64(),
+                va.as_u64()
+            );
+            type S = Size1GiB;
+            let page: Page<S> = Page::containing_address(va);
+            let frame: PhysFrame<S> = PhysFrame::containing_address(pa);
+            unsafe {
+                pt.map_to(page, frame, flags, allocator)
+                    .expect("map_to failed")
+                    .flush();
+            }
+            S::SIZE
+        } else if addr_align >= ALIGN_2M_BITS && sz >= ALIGN_2M {
+            trace!(
+                "2MB {} {:016x} /{:016x} {:016x}\n",
+                addr_align,
+                sz,
+                pa.as_u64(),
+                va.as_u64()
+            );
+            type S = Size2MiB;
+            let page: Page<S> = Page::containing_address(va);
+            let frame: PhysFrame<S> = PhysFrame::containing_address(pa);
+            unsafe {
+                pt.map_to(page, frame, flags, allocator)
+                    .expect("map_to failed")
+                    .flush();
+            }
+            S::SIZE
+        } else {
+            trace!(
+                "4KB {} {:016x} /{:016x} {:016x}\n",
+                addr_align,
+                sz,
+                pa.as_u64(),
+                va.as_u64()
+            );
+            type S = Size4KiB;
+            let page: Page<S> = Page::containing_address(va);
+            let frame: PhysFrame<S> = PhysFrame::containing_address(pa);
+            unsafe {
+                pt.map_to(page, frame, flags, allocator)
+                    .expect("map_to failed")
+                    .flush();
+            }
+            S::SIZE
+        };
+
+        sz -= mapped_size;
+        pa += mapped_size;
+        va += mapped_size;
+    }
+}
+
+/// Create page table entries to map `[va, va + sz)` to `[pa, ps + sz)` with page size `ps` and
+/// mark pages as `PRESENT | WRITABLE`.
+///
+/// Note: the caller must ensure `pa + sz` and `va + sz` doesn't wrap around.
+pub fn create_mapping(pt: &mut OffsetPageTable, pa: PhysAddr, va: VirtAddr, ps: u64, sz: u64) {
+    let flags = Flags::PRESENT | Flags::WRITABLE;
+
+    create_mapping_with_flags(pt, pa, va, ps, sz, flags)
+}
+
+/// Modify page flags for all 4K PTEs for virtual address range [va, va + sz), stops at the first
+/// whole.
+pub fn set_page_flags(pt: &mut OffsetPageTable, mut va: VirtAddr, mut size: i64, flag: Flags) {
+    let mut page_size: u64;
+
+    while size > 0 {
+        if let TranslateResult::Mapped { frame, .. } = pt.translate(va) {
+            match frame {
+                MappedFrame::Size4KiB(..) => {
+                    type S = Size4KiB;
+                    page_size = S::SIZE;
+                    let page: Page<S> = Page::containing_address(va);
+                    unsafe {
+                        pt.update_flags(page, flag).unwrap().flush();
+                    }
+                }
+                MappedFrame::Size2MiB(..) => {
+                    type S = Size2MiB;
+                    page_size = S::SIZE;
+                }
+                MappedFrame::Size1GiB(..) => {
+                    type S = Size1GiB;
+                    page_size = S::SIZE;
+                }
+            }
+        } else {
+            break;
+        }
+        size -= page_size as i64;
+        va += page_size;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{frame, init, PAGE_SIZE_4K, PHYS_VIRT_OFFSET};
+    use x86_64::structures::paging::PageTable;
+
+    fn create_pt(base: u64, offset: u64) -> OffsetPageTable<'static> {
+        let pt = unsafe {
+            OffsetPageTable::new(&mut *(base as *mut PageTable), VirtAddr::new(offset as u64))
+        };
+        frame::FRAME_ALLOCATOR.lock().reserve(base);
+
+        pt
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_pa_sz() {
+        init();
+        let mut pt = create_pt(TD_PAYLOAD_PAGE_TABLE_BASE, PHYS_VIRT_OFFSET as u64);
+        create_mapping(
+            &mut pt,
+            PhysAddr::new(0x1000000),
+            VirtAddr::new(0),
+            PAGE_SIZE_4K as u64,
+            u64::MAX,
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_va_sz() {
+        init();
+        let mut pt = create_pt(TD_PAYLOAD_PAGE_TABLE_BASE, PHYS_VIRT_OFFSET as u64);
+        create_mapping(
+            &mut pt,
+            PhysAddr::new(0x0),
+            VirtAddr::new(0x1000000),
+            PAGE_SIZE_4K as u64,
+            u64::MAX,
+        );
+    }
+}


### PR DESCRIPTION
Add the td-paging to setup and manage page tables for td-shim.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>