### PR TITLE
tdx-tdcall: minor syntax improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 LIB_CRATES = pe-loader td-layout td-paging
-SHIM_CRATES = rust-tdshim td-exception td-payload
+SHIM_CRATES = rust-tdshim td-exception td-payload tdx-tdcall
 TEST_CRATES = test-td-exception test-td-paging test-td-payload
 TOOL_CRATES = td-shim-ld td-shim-enroll-key td-shim-sign-payload
 

--- a/tdx-tdcall/Cargo.toml
+++ b/tdx-tdcall/Cargo.toml
@@ -1,20 +1,18 @@
 [package]
 name = "tdx-tdcall"
 version = "0.1.0"
+description = "Data stuctures and wrappers for TD_CALL/TDVM_CALL"
+repository = "https://github.com/confidential-containers/td-shim"
+homepage = "https://github.com/confidential-containers"
+license = "BSD-2-Clause-Patent"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+lazy_static = { version = "1.0", features = ["spin_no_std"] }
 log = "0.4.13"
-spin = "0.9.2"
 scroll = { version = "0.10", default-features=false, features = ["derive"] }
-[dependencies.lazy_static]
-version = "1.0"
-features = ["spin_no_std"]
+spin = "0.9.2"
 
 [features]
-
 default = []
-
 use_tdx_emulation = []

--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -59,7 +59,8 @@ lazy_static! {
     static ref SHARED_MASK: u64 = td_shared_page_mask();
 }
 
-#[repr(align(64))]
+// Both alignment and size are 64 bytes.
+#[repr(C, align(64))]
 pub struct TdxDigest {
     pub data: [u8; 48],
 }
@@ -282,4 +283,19 @@ pub fn td_shared_page_mask() -> u64 {
     let gpaw = (td_info.gpaw & 0x3f) as u8;
     assert!((gpaw == 48 || gpaw == 52));
     1u64 << (gpaw - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn test_struct_size_alignment() {
+        assert_eq!(align_of::<TdxDigest>(), 64);
+        assert_eq!(size_of::<TdxDigest>(), 64);
+        assert_eq!(size_of::<TdCallGenericReturnData>(), 48);
+        assert_eq!(size_of::<TdInfoReturnData>(), 48);
+        assert_eq!(size_of::<TdVeInfoReturnData>(), 48);
+    }
 }


### PR DESCRIPTION
Refine the tdx-tdcall crate by:
1) use repr(C) to ensure correct data layout
2) impl as_bytes() for data structs
3) introduce TdxReportBuf to improve readability
4) move constant definition to a central place

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>