### PR TITLE
tdx-tdcall: introduce constants, structures and wrappers for tdcall services

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -10,7 +10,8 @@ on:
 name: Library Crates
 
 env:
-  RUST_TOOLCHAIN: 1.58.1
+  STABLE_RUST_TOOLCHAIN: 1.58.1
+  NIGHTLY_RUST_TOOLCHAIN: nightly-2021-08-20
   TOOLCHAIN_PROFILE: minimal
 
 jobs:
@@ -38,7 +39,14 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: ${{ env.TOOLCHAIN_PROFILE }}
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          toolchain: ${{ env.STABLE_RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: ${{ env.TOOLCHAIN_PROFILE }}
+          toolchain: ${{ env.NIGHTLY_RUST_TOOLCHAIN }}
           override: true
 
       - name: Checkout sources
@@ -74,7 +82,14 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: ${{ env.TOOLCHAIN_PROFILE }}
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          toolchain: ${{ env.STABLE_RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: ${{ env.TOOLCHAIN_PROFILE }}
+          toolchain: ${{ env.NIGHTLY_RUST_TOOLCHAIN }}
           override: true
 
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 	"devtools/test-runner-server",
 	"td-layout",
 	"td-paging",
+	"tdx-tdcall",
 ]
 
 # the profile used for `cargo build`

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else
 endif
 
 GENERIC_LIB_CRATES = td-layout
-NIGHTLY_LIB_CRATES = td-paging
+NIGHTLY_LIB_CRATES = td-paging tdx-tdcall
 SHIM_CRATES = 
 TEST_CRATES = 
 TOOL_CRATES = 

--- a/tdx-tdcall/Cargo.toml
+++ b/tdx-tdcall/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tdx-tdcall"
+version = "0.1.0"
+description = "Constants, stuctures and wrappers to access TDCALL services"
+repository = "https://github.com/confidential-containers/td-shim"
+homepage = "https://github.com/confidential-containers"
+license = "BSD-2-Clause-Patent"
+edition = "2018"
+
+[dependencies]
+lazy_static = { version = "1.0", features = ["spin_no_std"] }
+log = "0.4.13"
+scroll = { version = "0.10", default-features = false, features = ["derive"] }
+spin = "0.9.2"
+
+[features]
+default = []
+use_tdx_emulation = []

--- a/tdx-tdcall/src/asm/mod.rs
+++ b/tdx-tdcall/src/asm/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#[cfg(feature = "use_tdx_emulation")]
+global_asm!(include_str!("tdcall_emu.asm"));
+
+#[cfg(feature = "use_tdx_emulation")]
+global_asm!(include_str!("tdvmcall_emu.asm"));
+
+#[cfg(not(feature = "use_tdx_emulation"))]
+global_asm!(include_str!("tdcall.asm"));
+
+#[cfg(not(feature = "use_tdx_emulation"))]
+global_asm!(include_str!("tdvmcall.asm"));

--- a/tdx-tdcall/src/asm/tdcall.asm
+++ b/tdx-tdcall/src/asm/tdcall.asm
@@ -1,0 +1,69 @@
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+.section .text
+.equ USE_TDX_EMULATION, 0
+.equ number_of_regs_pushed, 8
+.equ number_of_parameters,  4
+
+.equ first_variable_on_stack_offset,   (number_of_regs_pushed * 8) + (number_of_parameters * 8) + 8
+.equ second_variable_on_stack_offset,  first_variable_on_stack_offset + 8
+
+#  TdCall (
+#    UINT64  Leaf,
+#    UINT64  P1,
+#    UINT64  P2,
+#    UINT64  P3,
+#    UINT64  Results,
+#    )
+.global td_call
+td_call:
+        # tdcall_push_regs
+        push rbp
+        mov rbp, rsp
+        push r15
+        push r14
+        push r13
+        push r12
+        push rbx
+        push rsi
+        push rdi
+
+       mov rax, rcx
+       mov rcx, rdx
+       mov rdx, r8
+       mov r8, r9
+
+       # tdcall
+       .if USE_TDX_EMULATION != 0
+       vmcall
+       .else
+       .byte 0x66,0x0f,0x01,0xcc
+       .endif
+
+       # exit if tdcall reports failure.
+       test rax, rax
+       jnz exit
+
+       # test if caller wanted results
+       mov  r12, [rsp + first_variable_on_stack_offset]
+       test r12, r12
+       jz exit
+       mov [r12], rcx
+       mov [r12+8], rdx
+       mov [r12+16], r8
+       mov [r12+24], r9
+       mov [r12+32], r10
+       mov [r12+40], r11
+exit:
+        # tdcall_pop_regs
+        pop rdi
+        pop rsi
+        pop rbx
+        pop r12
+        pop r13
+        pop r14
+        pop r15
+        pop rbp
+
+       ret

--- a/tdx-tdcall/src/asm/tdcall_emu.asm
+++ b/tdx-tdcall/src/asm/tdcall_emu.asm
@@ -1,0 +1,69 @@
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+.section .text
+.equ USE_TDX_EMULATION, 1
+.equ number_of_regs_pushed, 8
+.equ number_of_parameters,  4
+
+.equ first_variable_on_stack_offset,   (number_of_regs_pushed * 8) + (number_of_parameters * 8) + 8
+.equ second_variable_on_stack_offset,  first_variable_on_stack_offset + 8
+
+#  TdCall (
+#    UINT64  Leaf,
+#    UINT64  P1,
+#    UINT64  P2,
+#    UINT64  P3,
+#    UINT64  Results,
+#    )
+.global td_call
+td_call:
+        # tdcall_push_regs
+        push rbp
+        mov rbp, rsp
+        push r15
+        push r14
+        push r13
+        push r12
+        push rbx
+        push rsi
+        push rdi
+
+       mov rax, rcx
+       mov rcx, rdx
+       mov rdx, r8
+       mov r8, r9
+
+       # tdcall
+       .if USE_TDX_EMULATION != 0
+       vmcall
+       .else
+       .byte 0x66,0x0f,0x01,0xcc
+       .endif
+
+       # exit if tdcall reports failure.
+       test rax, rax
+       jnz exit
+
+       # test if caller wanted results
+       mov  r12, [rsp + first_variable_on_stack_offset]
+       test r12, r12
+       jz exit
+       mov [r12], rcx
+       mov [r12+8], rdx
+       mov [r12+16], r8
+       mov [r12+24], r9
+       mov [r12+32], r10
+       mov [r12+40], r11
+exit:
+        # tdcall_pop_regs
+        pop rdi
+        pop rsi
+        pop rbx
+        pop r12
+        pop r13
+        pop r14
+        pop r15
+        pop rbp
+
+       ret

--- a/tdx-tdcall/src/asm/tdvmcall.asm
+++ b/tdx-tdcall/src/asm/tdvmcall.asm
@@ -1,0 +1,113 @@
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+.section .text
+
+.equ USE_TDX_EMULATION, 0
+.equ TDVMCALL_EXPOSE_REGS_MASK,       0xffec
+.equ TDVMCALL,                        0x0
+.equ EXIT_REASON_CPUID,               0xa
+
+.equ number_of_regs_pushed, 8
+.equ number_of_parameters,  4
+
+.equ first_variable_on_stack_offset,   (number_of_regs_pushed * 8) + (number_of_parameters * 8) + 8
+.equ second_variable_on_stack_offset,  first_variable_on_stack_offset + 8
+
+#  UINT64
+#  TdVmCall (
+#    UINT64  Leaf,
+#    UINT64  P1,
+#    UINT64  P2,
+#    UINT64  P3,
+#    UINT64  P4,
+#    UINT64  *Val
+#    )
+.global td_vm_call
+td_vm_call:
+        # tdcall_push_regs
+        push rbp
+        mov  rbp, rsp
+        push r15
+        push r14
+        push r13
+        push r12
+        push rbx
+        push rsi
+        push rdi
+
+        mov  r11, rcx
+        mov  r12, rdx
+        mov  r13, r8
+        mov  r14, r9
+        mov  r15, [rsp+first_variable_on_stack_offset]
+
+       #tdcall_regs_preamble TDVMCALL, TDVMCALL_EXPOSE_REGS_MASK
+        mov rax, TDVMCALL
+
+        mov ecx, TDVMCALL_EXPOSE_REGS_MASK
+
+        # R10 = 0 (standard TDVMCALL)
+
+        xor r10d, r10d
+
+        # Zero out unused (for standard TDVMCALL) registers to avoid leaking
+        # secrets to the VMM.
+
+        xor ebx, ebx
+        xor esi, esi
+        xor edi, edi
+
+        xor edx, edx
+        xor ebp, ebp
+        xor r8d, r8d
+        xor r9d, r9d
+
+       # tdcall
+       .if USE_TDX_EMULATION != 0
+       vmcall
+       .else
+       .byte 0x66,0x0f,0x01,0xcc
+       .endif
+
+       # ignore return dataif TDCALL reports failure.
+       test rax, rax
+       jnz no_return_data
+
+       # Propagate TDVMCALL success/failure to return value.
+       mov rax, r10
+
+       # Retrieve the Val pointer.
+       mov r9, [rsp+second_variable_on_stack_offset]
+       test r9, r9
+       jz no_return_data
+
+       # On success, propagate TDVMCALL output value to output param
+       test rax, rax
+       jnz no_return_data
+       mov [r9], r11
+
+no_return_data:
+        #tdcall_regs_postamble
+        xor ebx, ebx
+        xor esi, esi
+        xor edi, edi
+
+        xor ecx, ecx
+        xor edx, edx
+        xor r8d, r8d
+        xor r9d, r9d
+        xor r10d, r10d
+        xor r11d, r11d
+
+        # tdcall_pop_regs
+        pop rdi
+        pop rsi
+        pop rbx
+        pop r12
+        pop r13
+        pop r14
+        pop r15
+        pop rbp
+
+       ret

--- a/tdx-tdcall/src/asm/tdvmcall_emu.asm
+++ b/tdx-tdcall/src/asm/tdvmcall_emu.asm
@@ -1,0 +1,113 @@
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+.section .text
+
+.equ USE_TDX_EMULATION, 1
+.equ TDVMCALL_EXPOSE_REGS_MASK,       0xffec
+.equ TDVMCALL,                        0x0
+.equ EXIT_REASON_CPUID,               0xa
+
+.equ number_of_regs_pushed, 8
+.equ number_of_parameters,  4
+
+.equ first_variable_on_stack_offset,   (number_of_regs_pushed * 8) + (number_of_parameters * 8) + 8
+.equ second_variable_on_stack_offset,  first_variable_on_stack_offset + 8
+
+#  UINT64
+#  TdVmCall (
+#    UINT64  Leaf,
+#    UINT64  P1,
+#    UINT64  P2,
+#    UINT64  P3,
+#    UINT64  P4,
+#    UINT64  *Val
+#    )
+.global td_vm_call
+td_vm_call:
+        # tdcall_push_regs
+        push rbp
+        mov  rbp, rsp
+        push r15
+        push r14
+        push r13
+        push r12
+        push rbx
+        push rsi
+        push rdi
+
+        mov  r11, rcx
+        mov  r12, rdx
+        mov  r13, r8
+        mov  r14, r9
+        mov  r15, [rsp+first_variable_on_stack_offset]
+
+       #tdcall_regs_preamble TDVMCALL, TDVMCALL_EXPOSE_REGS_MASK
+        mov rax, TDVMCALL
+
+        mov ecx, TDVMCALL_EXPOSE_REGS_MASK
+
+        # R10 = 0 (standard TDVMCALL)
+
+        xor r10d, r10d
+
+        # Zero out unused (for standard TDVMCALL) registers to avoid leaking
+        # secrets to the VMM.
+
+        xor ebx, ebx
+        xor esi, esi
+        xor edi, edi
+
+        xor edx, edx
+        xor ebp, ebp
+        xor r8d, r8d
+        xor r9d, r9d
+
+       # tdcall
+       .if USE_TDX_EMULATION != 0
+       vmcall
+       .else
+       .byte 0x66,0x0f,0x01,0xcc
+       .endif
+
+       # ignore return dataif TDCALL reports failure.
+       test rax, rax
+       jnz no_return_data
+
+       # Propagate TDVMCALL success/failure to return value.
+       mov rax, r10
+
+       # Retrieve the Val pointer.
+       mov r9, [rsp+second_variable_on_stack_offset]
+       test r9, r9
+       jz no_return_data
+
+       # On success, propagate TDVMCALL output value to output param
+       test rax, rax
+       jnz no_return_data
+       mov [r9], r11
+
+no_return_data:
+        #tdcall_regs_postamble
+        xor ebx, ebx
+        xor esi, esi
+        xor edi, edi
+
+        xor ecx, ecx
+        xor edx, edx
+        xor r8d, r8d
+        xor r9d, r9d
+        xor r10d, r10d
+        xor r11d, r11d
+
+        # tdcall_pop_regs
+        pop rdi
+        pop rsi
+        pop rbx
+        pop r12
+        pop r13
+        pop r14
+        pop r15
+        pop rbp
+
+       ret

--- a/tdx-tdcall/src/lib.rs
+++ b/tdx-tdcall/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_std]
+#![feature(global_asm)]
+
+#[cfg(feature = "use_tdx_emulation")]
+pub const USE_TDX_EMULATION: bool = true;
+#[cfg(not(feature = "use_tdx_emulation"))]
+pub const USE_TDX_EMULATION: bool = false;
+
+pub mod asm;
+pub mod tdreport;
+pub mod tdx;

--- a/tdx-tdcall/src/tdreport.rs
+++ b/tdx-tdcall/src/tdreport.rs
@@ -1,0 +1,268 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use core::fmt;
+use core::mem::{size_of, zeroed};
+use core::ptr::{slice_from_raw_parts, slice_from_raw_parts_mut};
+use lazy_static::lazy_static;
+use scroll::{Pread, Pwrite};
+use spin::Mutex;
+
+use crate::tdx;
+
+pub const TD_REPORT_SIZE: usize = 0x400;
+pub const TD_REPORT_ADDITIONAL_DATA_SIZE: usize = 64;
+
+// The buffer to td_report() must be aligned to TD_REPORT_SIZE.
+const TD_REPORT_BUFF_SIZE: usize = (TD_REPORT_SIZE * 2) + TD_REPORT_ADDITIONAL_DATA_SIZE;
+
+#[repr(C)]
+#[derive(Debug, Pread, Pwrite)]
+pub struct ReportType {
+    pub r#type: u8,
+    pub subtype: u8,
+    pub version: u8,
+    pub reserved: u8,
+}
+
+#[repr(C)]
+#[derive(Debug, Pread, Pwrite)]
+pub struct ReportMac {
+    pub report_type: ReportType,
+    reserved0: [u8; 12],
+    pub cpu_svn: [u8; 16],
+    pub tee_tcb_info_hash: [u8; 48],
+    pub tee_info_hash: [u8; 48],
+    pub report_data: [u8; 64],
+    reserved1: [u8; 32],
+    pub mac: [u8; 32],
+}
+
+impl fmt::Display for ReportMac {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Report MAC:\n\tReport Type:\n\ttype: {:x?}\tsubtype: {:x?}\
+                        \tversion: {:x?}\n\tCPU SVN:\n\t{:x?}\n\
+                        \tTEE TCB Info Hash:\n\t{:x?}\n\tTEE Info Hash:\n\t{:x?}\n\
+                        \tReport Data:\n\t{:x?}\n\tMAC:\n\t{:x?}\n",
+            self.report_type.r#type,
+            self.report_type.subtype,
+            self.report_type.version,
+            self.cpu_svn,
+            self.tee_tcb_info_hash,
+            self.tee_info_hash,
+            self.report_data,
+            self.mac
+        )
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Pread, Pwrite)]
+pub struct TeeTcbInfo {
+    pub valid: [u8; 8],
+    pub tee_tcb_svn: [u8; 16],
+    pub mrseam: [u8; 48],
+    pub mrsigner_seam: [u8; 48],
+    pub attributes: [u8; 8],
+    reserved: [u8; 111],
+}
+
+impl fmt::Display for TeeTcbInfo {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TEE TCB Info:\n\tValid:\n\t{:x?}\n\tTEE TCB SVN:\n\t{:x?}\n\
+                        \tMR SEAM:\n\t{:x?}\n\tMR Signer SEAM:\n\t{:x?}\n\
+                        \tAttributes:\n\t{:x?}\n",
+            self.valid, self.tee_tcb_svn, self.mrseam, self.mrsigner_seam, self.attributes
+        )
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Pread, Pwrite)]
+pub struct TdInfo {
+    pub attributes: [u8; 8],
+    pub xfam: [u8; 8],
+    pub mrtd: [u8; 48],
+    pub mrconfig_id: [u8; 48],
+    pub mrowner: [u8; 48],
+    pub mrownerconfig: [u8; 48],
+    pub rtmr0: [u8; 48],
+    pub rtmr1: [u8; 48],
+    pub rtmr2: [u8; 48],
+    pub rtmr3: [u8; 48],
+    reserved: [u8; 112],
+}
+
+impl fmt::Display for TdInfo {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TdInfo:\n\tAttributes:\n\t{:x?}\n\txfam:\n\t{:x?}\n\
+                        \tMR TD:\n\t{:x?}\n\tMR Config ID:\n\t{:x?}\n\
+                        \tMR Owner:\n\t{:x?}\n\tMR Owner Config:\n\t{:x?}\n\
+                        \tRTMR[0]:\n\t{:x?}\n\tRTMR[1]:\n\t{:x?}\n\
+                        \tRTMR[2]:\n\t{:x?}\n\tRTMR[3]:\n\t{:x?}\n",
+            self.attributes,
+            self.xfam,
+            self.mrtd,
+            self.mrconfig_id,
+            self.mrowner,
+            self.mrownerconfig,
+            self.rtmr0,
+            self.rtmr1,
+            self.rtmr2,
+            self.rtmr3
+        )
+    }
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Pread, Pwrite)]
+pub struct TdxReport {
+    pub report_mac: ReportMac,
+    pub tee_tcb_info: TeeTcbInfo,
+    reserved: [u8; 17],
+    pub td_info: TdInfo,
+}
+
+impl fmt::Display for TdxReport {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TDX Report:\n{}\n{}\n{}\n",
+            self.report_mac, self.tee_tcb_info, self.td_info
+        )
+    }
+}
+
+impl TdxReport {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        unsafe { &mut *slice_from_raw_parts_mut(self as *mut Self as *mut u8, size_of::<Self>()) }
+    }
+}
+
+impl Default for TdxReport {
+    fn default() -> Self {
+        unsafe { zeroed() }
+    }
+}
+
+/// Struct to fulfill the alignment requirement of buffer for td-report tdcall.
+struct TdxReportBuf {
+    buf: [u8; TD_REPORT_BUFF_SIZE],
+    start: usize,
+    offset: usize,
+    end: usize,
+    additional: usize,
+}
+
+impl TdxReportBuf {
+    fn new() -> Self {
+        let mut buf = TdxReportBuf {
+            buf: [0u8; TD_REPORT_BUFF_SIZE],
+            start: 0,
+            offset: 0,
+            end: 0,
+            additional: 0,
+        };
+        buf.adjust();
+        buf
+    }
+
+    fn adjust(&mut self) {
+        let pos = self.buf.as_ptr() as *const u8 as usize;
+        if pos != self.start {
+            self.start = pos;
+            self.offset = TD_REPORT_SIZE - (pos & (TD_REPORT_SIZE - 1));
+            self.end = self.offset + TD_REPORT_SIZE;
+            self.additional = self.end + TD_REPORT_ADDITIONAL_DATA_SIZE;
+        }
+    }
+
+    fn report_buf_start(&mut self) -> u64 {
+        &mut self.buf[self.offset] as *mut u8 as u64
+    }
+
+    fn additional_buf_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[self.end..self.additional]
+    }
+
+    fn to_owned(&self) -> TdxReport {
+        let mut report: TdxReport = TdxReport::default();
+        report
+            .as_bytes_mut()
+            .copy_from_slice(&self.buf[self.offset..self.end]);
+        report
+    }
+}
+
+lazy_static! {
+    static ref TD_REPORT: Mutex<TdxReportBuf> = Mutex::new(TdxReportBuf::new());
+}
+
+/// Query TDX report information.
+pub fn tdcall_report(additional_data: &[u8; TD_REPORT_ADDITIONAL_DATA_SIZE]) -> TdxReport {
+    let mut buff = TD_REPORT.lock();
+    // lazy_static!() moves the underlying object, so we need to repair the object here.
+    buff.adjust();
+
+    let addr = buff.report_buf_start();
+    buff.additional_buf_mut().copy_from_slice(additional_data);
+
+    let ret = unsafe {
+        tdx::td_call(
+            tdx::TDCALL_TDREPORT,
+            addr,
+            addr + TD_REPORT_SIZE as u64,
+            0,
+            0,
+        )
+    };
+    if ret != tdx::TDX_EXIT_REASON_SUCCESS {
+        tdx::tdvmcall_halt();
+    }
+
+    buff.to_owned()
+}
+
+/// Dump TDX report information.
+pub fn tdreport_dump() {
+    let addtional_data: [u8; 64] = [0; 64];
+    let tdx_report = tdcall_report(&addtional_data);
+    log::info!("{}", tdx_report);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tdx_report_size() {
+        assert_eq!(size_of::<TdxReport>(), 0x400);
+    }
+
+    #[test]
+    fn test_tdx_report_buf() {
+        let mut buf = TdxReportBuf::new();
+        assert_eq!(buf.report_buf_start() & 0x3ff, 0);
+
+        let additional = buf.additional_buf_mut().as_ptr() as u64;
+        assert_eq!(buf.report_buf_start() + 0x400, additional);
+
+        TD_REPORT.lock().adjust();
+        assert_eq!(TD_REPORT.lock().report_buf_start() & 0x3ff, 0);
+    }
+}

--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -1,0 +1,301 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use core::result::Result;
+use core::sync::atomic::{fence, Ordering};
+use lazy_static::lazy_static;
+
+extern "win64" {
+    pub fn td_call(Leaf: u64, P1: u64, P2: u64, P3: u64, Results: u64) -> u64;
+    pub fn td_vm_call(
+        Leaf: u64,
+        P1: u64,
+        P2: u64,
+        P3: u64,
+        P4: u64,
+        Val: *mut core::ffi::c_void,
+    ) -> u64;
+}
+
+// const TDCALL_TDVMCALL: u64 = 0;
+const TDCALL_TDINFO: u64 = 1;
+const TDCALL_TDEXTENDRTMR: u64 = 2;
+const TDCALL_TDGETVEINFO: u64 = 3;
+pub(crate) const TDCALL_TDREPORT: u64 = 4;
+// const TDCALL_TDSETCPUIDVE: u64 = 5;
+const TDCALL_TDACCEPTPAGE: u64 = 6;
+
+// const TDVMCALL_CPUID: u64 = 0x0000a;
+const TDVMCALL_HALT: u64 = 0x0000c;
+const TDVMCALL_IO: u64 = 0x0001e;
+// const TDVMCALL_RDMSR: u64 = 0x0001f;
+// const TDVMCALL_WRMSR: u64 = 0x00020;
+const TDVMCALL_MMIO: u64 = 0x00030;
+const TDVMCALL_MAPGPA: u64 = 0x10001;
+
+const IO_READ: u64 = 0;
+const IO_WRITE: u64 = 1;
+
+const TDVMCALL_STATUS_SUCCESS: u64 = 0;
+
+pub(crate) const TDX_EXIT_REASON_SUCCESS: u64 = 0;
+const TDX_EXIT_REASON_PAGE_ALREADY_ACCEPTED: u64 = 0x00000B0A00000000;
+const TDX_EXIT_REASON_PAGE_SIZE_MISMATCH: u64 = 0xC0000B0B00000000;
+
+pub const EXIT_REASON_CPUID: u32 = 10;
+pub const EXIT_REASON_HLT: u32 = 12;
+pub const EXIT_REASON_IO_INSTRUCTION: u32 = 30;
+pub const EXIT_REASON_MSR_READ: u32 = 31;
+pub const EXIT_REASON_MSR_WRITE: u32 = 32;
+pub const EXIT_REASON_EPT_VIOLATION: u32 = 48;
+pub const EXIT_REASON_VMCALL: u32 = 18;
+pub const EXIT_REASON_MWAIT_INSTRUCTION: u32 = 36;
+pub const EXIT_REASON_MONITOR_INSTRUCTION: u32 = 39;
+pub const EXIT_REASON_WBINVD: u32 = 54;
+pub const EXIT_REASON_RDPMC: u32 = 15;
+
+lazy_static! {
+    static ref SHARED_MASK: u64 = td_shared_page_mask();
+}
+
+// Both alignment and size are 64 bytes.
+#[repr(C, align(64))]
+pub struct TdxDigest {
+    pub data: [u8; 48],
+}
+
+#[repr(C)]
+pub struct TdCallGenericReturnData {
+    pub data: [u64; 6],
+}
+
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct TdInfoReturnData {
+    pub gpaw: u64,
+    pub attributes: u64,
+    pub max_vcpus: u32,
+    pub num_vcpus: u32,
+    pub rsvd: [u64; 3],
+}
+
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct TdVeInfoReturnData {
+    pub exit_reason: u32,
+    pub rsvd: u32,
+    pub exit_qualification: u64,
+    pub guest_la: u64,
+    pub guest_pa: u64,
+    pub exit_instruction_length: u32,
+    pub exit_instruction_info: u32,
+    pub rsvd1: u64,
+}
+
+#[derive(PartialEq)]
+pub enum TdCallError {
+    TdxExitReasonPageAlreadyAccepted,
+    TdxExitReasonPageSizeMismatch,
+    TdxExitReasonOperandInvalid,
+    TdxExitReasonOperandBusy,
+}
+
+pub fn tdvmcall_halt() {
+    unsafe { td_vm_call(TDVMCALL_HALT, 0, 0, 0, 0, core::ptr::null_mut()) };
+}
+
+pub fn tdvmcall_io_read_8(port: u16) -> u8 {
+    let mut val: u64 = 0;
+    let ret = unsafe {
+        td_vm_call(
+            TDVMCALL_IO,
+            core::mem::size_of::<u8>() as u64,
+            IO_READ,
+            port as u64,
+            0,
+            &mut val as *mut u64 as *mut core::ffi::c_void,
+        )
+    };
+    if ret != TDVMCALL_STATUS_SUCCESS {
+        tdvmcall_halt();
+    }
+    val as u8
+}
+
+pub fn tdvmcall_io_read_32(port: u16) -> u32 {
+    let mut val: u64 = 0;
+    let ret = unsafe {
+        td_vm_call(
+            TDVMCALL_IO,
+            core::mem::size_of::<u32>() as u64,
+            IO_READ,
+            port as u64,
+            0,
+            &mut val as *mut u64 as *mut core::ffi::c_void,
+        )
+    };
+    if ret != TDVMCALL_STATUS_SUCCESS {
+        tdvmcall_halt();
+    }
+    val as u32
+}
+
+pub fn tdvmcall_io_write_8(port: u16, byte: u8) {
+    let ret = unsafe {
+        td_vm_call(
+            TDVMCALL_IO,
+            core::mem::size_of::<u8>() as u64,
+            IO_WRITE,
+            port as u64,
+            byte as u64,
+            core::ptr::null_mut(),
+        )
+    };
+    if ret != TDVMCALL_STATUS_SUCCESS {
+        tdvmcall_halt();
+    }
+}
+
+pub fn tdvmcall_io_write_32(port: u16, byte: u32) {
+    let ret = unsafe {
+        td_vm_call(
+            TDVMCALL_IO,
+            core::mem::size_of::<u32>() as u64,
+            IO_WRITE,
+            port as u64,
+            byte as u64,
+            core::ptr::null_mut(),
+        )
+    };
+    if ret != TDVMCALL_STATUS_SUCCESS {
+        tdvmcall_halt();
+    }
+}
+
+pub fn tdvmcall_mmio_write<T: Sized>(address: *const T, value: T) {
+    let address = address as u64 | *SHARED_MASK;
+    fence(Ordering::SeqCst);
+    let ret = unsafe {
+        let val = *(&value as *const T as *const u64);
+        td_vm_call(
+            TDVMCALL_MMIO,
+            core::mem::size_of::<T>() as u64,
+            IO_WRITE,
+            address,
+            val,
+            core::ptr::null_mut(),
+        )
+    };
+    if ret != TDVMCALL_STATUS_SUCCESS {
+        tdvmcall_halt();
+    }
+}
+
+pub fn tdvmcall_mmio_read<T: Clone + Copy + Sized>(address: usize) -> T {
+    let mut val = 0u64;
+    let address = address as u64 | *SHARED_MASK;
+    fence(Ordering::SeqCst);
+    let ret = unsafe {
+        td_vm_call(
+            TDVMCALL_MMIO,
+            core::mem::size_of::<T>() as u64,
+            IO_READ,
+            address,
+            0,
+            &mut val as *mut u64 as *mut core::ffi::c_void,
+        )
+    };
+    if ret != TDVMCALL_STATUS_SUCCESS {
+        tdvmcall_halt();
+    }
+    unsafe { *(&val as *const u64 as *const T) }
+}
+
+pub fn tdvmcall_mapgpa(paddress: u64, length: usize) {
+    let paddr = paddress | *SHARED_MASK;
+    let ret = unsafe {
+        td_vm_call(
+            TDVMCALL_MAPGPA,
+            paddr,
+            length as u64,
+            0,
+            0,
+            core::ptr::null_mut(),
+        )
+    };
+    if ret != TDVMCALL_STATUS_SUCCESS {
+        tdvmcall_halt();
+    }
+    log::info!(
+        "tdvmcall mapgpa - paddr: {:x}, length: {:x}\n",
+        paddr,
+        length
+    );
+}
+
+pub fn tdcall_get_td_info(td_info: &mut TdInfoReturnData) {
+    let buffer: u64 = td_info as *mut TdInfoReturnData as *mut core::ffi::c_void as usize as u64;
+    log::info!("td_info data addr: 0x{:x}\n", buffer);
+
+    let ret = unsafe { td_call(TDCALL_TDINFO, 0, 0, 0, buffer) };
+    if ret != TDX_EXIT_REASON_SUCCESS {
+        tdvmcall_halt();
+    }
+}
+
+pub fn tdcall_extend_rtmr(digest: &TdxDigest, mr_index: u32) {
+    let buffer: u64 = &digest.data as *const u8 as *const core::ffi::c_void as usize as u64;
+    log::info!("rtmr data addr: 0x{:x}\n", buffer);
+
+    let ret = unsafe { td_call(TDCALL_TDEXTENDRTMR, buffer, mr_index as u64, 0, 0) };
+    if ret != TDX_EXIT_REASON_SUCCESS {
+        tdvmcall_halt();
+    }
+}
+
+pub fn tdcall_get_ve_info(ve_info: &mut TdVeInfoReturnData) {
+    let buffer: u64 = ve_info as *mut TdVeInfoReturnData as *mut core::ffi::c_void as usize as u64;
+
+    let ret = unsafe { td_call(TDCALL_TDGETVEINFO, 0, 0, 0, buffer) };
+    if ret != TDX_EXIT_REASON_SUCCESS {
+        tdvmcall_halt();
+    }
+}
+
+pub fn tdcall_accept_page(address: u64) -> Result<(), TdCallError> {
+    let ret = unsafe { td_call(TDCALL_TDACCEPTPAGE, address, 0, 0, 0) };
+    if ret != TDX_EXIT_REASON_SUCCESS {
+        if (ret & !0xffu64) == TDX_EXIT_REASON_PAGE_ALREADY_ACCEPTED {
+            return Err(TdCallError::TdxExitReasonPageAlreadyAccepted);
+        } else if (ret & !0xffu64) == TDX_EXIT_REASON_PAGE_SIZE_MISMATCH {
+            return Err(TdCallError::TdxExitReasonPageSizeMismatch);
+        } else {
+            tdvmcall_halt();
+        }
+    }
+    Ok(())
+}
+
+pub fn td_shared_page_mask() -> u64 {
+    let mut td_info = TdInfoReturnData::default();
+    tdcall_get_td_info(&mut td_info);
+    let gpaw = (td_info.gpaw & 0x3f) as u8;
+    assert!((gpaw == 48 || gpaw == 52));
+    1u64 << (gpaw - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn test_struct_size_alignment() {
+        assert_eq!(align_of::<TdxDigest>(), 64);
+        assert_eq!(size_of::<TdxDigest>(), 64);
+        assert_eq!(size_of::<TdCallGenericReturnData>(), 48);
+        assert_eq!(size_of::<TdInfoReturnData>(), 48);
+        assert_eq!(size_of::<TdVeInfoReturnData>(), 48);
+    }
+}


### PR DESCRIPTION
The Intel TDX defines a group of TDCALLs, so the trusted domain may ask
for services from the underlying hardware/firmware. This crates defines
constants, structures and functions to access those services.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>
Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>