### PR TITLE
The second part of td-shim refactor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,19 +61,19 @@ jobs:
           AR: llvm-ar
         with:
           command: xbuild
-          args: -p rust-tdshim --target x86_64-unknown-uefi --release
+          args: -p rust-tdshim --target x86_64-unknown-uefi --release --features=tdx
 
       - name: Build PE format payload
         run: |
           pushd td-payload
-          cargo xbuild --target x86_64-unknown-uefi --release
+          cargo xbuild --target x86_64-unknown-uefi --release --features=tdx
           popd
           cargo run -p td-shim-ld -- target/x86_64-unknown-uefi/release/ResetVector.bin target/x86_64-unknown-uefi/release/rust-tdshim.efi target/x86_64-unknown-uefi/release/td-payload.efi -o target/x86_64-unknown-uefi/release/final.bin
 
       - name: Build Elf format payload
         run: |
           pushd td-payload
-          cargo xbuild --target ../devtools/rustc-targets/x86_64-unknown-none.json --release
+          cargo xbuild --target ../devtools/rustc-targets/x86_64-unknown-none.json --release --features=tdx
           popd
           cargo run -p td-shim-ld -- target/x86_64-unknown-uefi/release/ResetVector.bin target/x86_64-unknown-uefi/release/rust-tdshim.efi target/x86_64-unknown-none/release/td-payload -o target/x86_64-unknown-uefi/release/final.bin
 

--- a/rust-tdshim/Cargo.toml
+++ b/rust-tdshim/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 build = "build.rs"
 
 [features]
-default = ["cet-ss", "secure-boot", "boot-kernel"]
-cet-ss = []
-secure-boot = ["der"]
+default = ["boot-kernel", "cet-ss", "secure-boot"]
 boot-kernel = ["td-layout/boot-kernel"]
+cet-ss = []
+secure-boot = ["der", "td-shim-enroll-key", "td-shim-sign-payload"]
 
 [build-dependencies]
 cc = { git = "https://github.com/jyao1/cc-rs.git", branch = "uefi_support" }
@@ -18,7 +18,6 @@ td-layout = { path = "../td-layout" }
 tdx-tdcall = { path = "../tdx-tdcall" }
 
 [dependencies]
-der = {version = "0.4.5", features = ["derive", "alloc"], optional = true}
 elf-loader = { path = "../elf-loader" }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 linked_list_allocator = "0.9.0"
@@ -38,5 +37,11 @@ x86 = "0.44.0"
 x86_64 = "=0.14.6"
 zerocopy = "0.6.0"
 
+# secure boot
+der = {version = "0.4.5", features = ["derive", "alloc"], optional = true}
+td-shim-enroll-key = { path = "../td-shim-enroll-key", default-features = false, optional = true }
+td-shim-sign-payload = { path = "../td-shim-sign-payload", default-features = false, optional = true }
+
+# TDX
 tdx-tdcall = { path = "../tdx-tdcall" }
 

--- a/rust-tdshim/Cargo.toml
+++ b/rust-tdshim/Cargo.toml
@@ -11,6 +11,7 @@ default = ["boot-kernel", "cet-ss", "secure-boot"]
 boot-kernel = ["td-layout/boot-kernel"]
 cet-ss = []
 secure-boot = ["der", "td-shim-enroll-key", "td-shim-sign-payload"]
+tdx = ["tdx-tdcall", "td-exception/tdx", "td-logger/tdx"]
 
 [build-dependencies]
 cc = { git = "https://github.com/jyao1/cc-rs.git", branch = "uefi_support" }
@@ -43,5 +44,5 @@ td-shim-enroll-key = { path = "../td-shim-enroll-key", default-features = false,
 td-shim-sign-payload = { path = "../td-shim-sign-payload", default-features = false, optional = true }
 
 # TDX
-tdx-tdcall = { path = "../tdx-tdcall" }
+tdx-tdcall = { path = "../tdx-tdcall", optional = true }
 

--- a/rust-tdshim/Cargo.toml
+++ b/rust-tdshim/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2018"
 build = "build.rs"
 
 [features]
+default = ["cet-ss", "secure-boot", "boot-kernel"]
 cet-ss = []
-secure-boot = []
+secure-boot = ["der"]
 boot-kernel = ["td-layout/boot-kernel"]
 
 [build-dependencies]
@@ -17,27 +18,25 @@ td-layout = { path = "../td-layout" }
 tdx-tdcall = { path = "../tdx-tdcall" }
 
 [dependencies]
-r-efi = "3.2.0"
+der = {version = "0.4.5", features = ["derive", "alloc"], optional = true}
+elf-loader = { path = "../elf-loader" }
+lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 linked_list_allocator = "0.9.0"
 log = "0.4.13"
-elf-loader = { path = "../elf-loader" }
 pe-loader = { path = "../pe-loader" }
-uefi-pi =  { path = "../uefi-pi" }
-tdx-tdcall = { path = "../tdx-tdcall" }
-td-logger =  { path = "../td-logger" }
+r-efi = "3.2.0"
+ring = { git = "https://github.com/jyao1/ring.git", branch = "uefi_support", default-features = false, features = ["alloc"] }
+scroll = { version = "0.10", default-features = false, features = ["derive"] }
+spin = "0.9.2"
 td-exception =  { path = "../td-exception", features = ["tdx"] }
 td-layout = { path = "../td-layout" }
+td-logger =  { path = "../td-logger" }
 td-paging = { path = "../td-paging" }
-ring = { git = "https://github.com/jyao1/ring.git", branch = "uefi_support", default-features = false, features = ["alloc"]}
-scroll = { version = "0.10", default-features = false, features = ["derive"] }
-x86_64 = "=0.14.6"
+uefi-pi =  { path = "../uefi-pi" }
 # Lock down to 0.44, otherwise it depends on inline asm
 x86 = "0.44.0"
-spin = "0.9.2"
-bitflags = "1.2.1"
+x86_64 = "=0.14.6"
 zerocopy = "0.6.0"
-der = {version = "0.4.5", features = ["derive", "alloc"]}
 
-[dependencies.lazy_static]
-version = "1.0"
-features = ["spin_no_std"]
+tdx-tdcall = { path = "../tdx-tdcall" }
+

--- a/rust-tdshim/src/ipl.rs
+++ b/rust-tdshim/src/ipl.rs
@@ -5,9 +5,10 @@
 use elf_loader::elf;
 use elf_loader::elf64::ProgramHeader;
 use pe_loader::pe::{self, Section};
+use td_layout::memslice;
 use td_layout::runtime::{TD_PAYLOAD_BASE, TD_PAYLOAD_SIZE};
 
-use crate::{memslice, Memory};
+use crate::memory::Memory;
 
 const SIZE_4KB: u64 = 0x00001000u64;
 

--- a/rust-tdshim/src/main.rs
+++ b/rust-tdshim/src/main.rs
@@ -128,7 +128,7 @@ fn log_hob_list(hob_list: &[u8], td_event_log: &mut tcg::TdEventLog) {
         .pwrite(hand_off_table_pointers, 0)
         .unwrap();
 
-    td_event_log.create_td_event(
+    td_event_log.create_event_log(
         1,
         EV_EFI_HANDOFF_TABLES2,
         &tdx_handofftable_pointers_buffer,
@@ -235,7 +235,7 @@ pub extern "win64" fn _start(
             td_event_log_base as usize,
         )
     };
-    let mut td_event_log = tcg::TdEventLog::init(event_log_buf);
+    let mut td_event_log = tcg::TdEventLog::new(event_log_buf);
     log_hob_list(hob_list, &mut td_event_log);
 
     let fv_buffer = memslice::get_mem_slice(memslice::SliceType::ShimPayload);
@@ -460,15 +460,15 @@ pub extern "win64" fn _start(
         let cfv = memslice::get_mem_slice(memslice::SliceType::Config);
         let verifier = verifier::PayloadVerifier::new(payload, cfv);
         if let Ok(verifier) = &verifier {
-            td_event_log.create_td_event(
+            td_event_log.create_event_log(
                 4,
                 EV_PLATFORM_CONFIG_FLAGS,
                 b"td payload",
                 verifier::PayloadVerifier::get_trust_anchor(cfv).unwrap(),
             );
             verifier.verify().expect("Verification fails");
-            td_event_log.create_td_event(4, EV_PLATFORM_CONFIG_FLAGS, b"td payload", payload);
-            td_event_log.create_td_event(
+            td_event_log.create_event_log(4, EV_PLATFORM_CONFIG_FLAGS, b"td payload", payload);
+            td_event_log.create_event_log(
                 4,
                 EV_PLATFORM_CONFIG_FLAGS,
                 b"td payload svn",

--- a/rust-tdshim/src/td/dummy.rs
+++ b/rust-tdshim/src/td/dummy.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 Alibaba Cloud
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+/// Enable the execute disable.
+
+pub fn enable_execution_disable_bit() {}
+
+pub fn get_shared_page_mask() -> u64 {
+    0
+}
+
+pub fn accept_memory_resource_range(_cpu_num: u32, _address: u64, _size: u64) {}
+
+pub fn get_num_vcpus() -> u32 {
+    1
+}
+
+pub fn extend_rtmr(_data: &[u8], _pcr_index: u32) {}

--- a/rust-tdshim/src/td/mod.rs
+++ b/rust-tdshim/src/td/mod.rs
@@ -2,7 +2,14 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
+#[cfg(feature = "tdx")]
 mod tdx;
+#[cfg(feature = "tdx")]
 mod tdx_mailbox;
-
+#[cfg(feature = "tdx")]
 pub use tdx::*;
+
+#[cfg(not(feature = "tdx"))]
+mod dummy;
+#[cfg(not(feature = "tdx"))]
+pub use dummy::*;

--- a/rust-tdshim/src/td/tdx.rs
+++ b/rust-tdshim/src/td/tdx.rs
@@ -53,6 +53,22 @@ pub fn accept_memory_resource_range(mut cpu_num: u32, address: u64, size: u64) {
     super::tdx_mailbox::accept_memory_resource_range(cpu_num, address, size)
 }
 
+pub fn get_num_vcpus() -> u32 {
+    let mut td_info = tdx::TdInfoReturnData {
+        gpaw: 0,
+        attributes: 0,
+        max_vcpus: 0,
+        num_vcpus: 0,
+        rsvd: [0; 3],
+    };
+
+    tdx::tdcall_get_td_info(&mut td_info);
+    log::info!("gpaw - {:?}\n", td_info.gpaw);
+    log::info!("num_vcpus - {:?}\n", td_info.num_vcpus);
+
+    td_info.num_vcpus
+}
+
 pub fn extend_rtmr(data: &[u8; SHA384_DIGEST_SIZE], pcr_index: u32) {
     let digest = tdx::TdxDigest { data: *data };
 

--- a/rust-tdshim/src/verifier.rs
+++ b/rust-tdshim/src/verifier.rs
@@ -23,7 +23,7 @@ use uefi_pi::{fv, pi};
 
 #[derive(Debug)]
 pub enum VerifyErr {
-    InvalidAlgorithm,
+    UnknownAlgorithm,
     InvalidContent,
     InvalidPublicKey,
     InvalidSignature,
@@ -118,7 +118,7 @@ impl<'a> PayloadVerifier<'a> {
 
                 verify_alg = &signature::RSA_PSS_2048_8192_SHA384;
             }
-            _ => return Err(VerifyErr::InvalidAlgorithm),
+            _ => return Err(VerifyErr::UnknownAlgorithm),
         }
 
         Ok(PayloadVerifier {
@@ -183,9 +183,9 @@ impl<'a> PayloadVerifier<'a> {
 
         let mut readlen = 0;
         let header = file.gread::<CfvPubKeyFileHeader>(&mut readlen).unwrap();
-        if &header.type_guid != CFV_FILE_HEADER_PUBKEY_GUID.as_bytes() {
-            return Err(VerifyErr::InvalidPublicKey);
-        } else if header.length as usize > file.len() {
+        if &header.type_guid != CFV_FILE_HEADER_PUBKEY_GUID.as_bytes()
+            || header.length as usize > file.len()
+        {
             return Err(VerifyErr::InvalidPublicKey);
         }
 

--- a/td-layout/src/metadata.rs
+++ b/td-layout/src/metadata.rs
@@ -129,7 +129,7 @@ impl Default for TdxMetadata {
             descriptor: Default::default(),
             sections: [Default::default(); 6],
             #[cfg(feature = "boot-kernel")]
-            payload_sections: [Default::default(), 2],
+            payload_sections: [Default::default(); 2],
         };
 
         if cfg!(feature = "boot-kernel") {

--- a/td-payload/Cargo.toml
+++ b/td-payload/Cargo.toml
@@ -16,9 +16,10 @@ r-efi = "3.2.0"
 serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 td-layout = { path = "../td-layout" }
-td-logger =  { path = "../td-logger", optional = true }
-tdx-tdcall = { path = "../tdx-tdcall", optional = true }
+td-logger =  { path = "../td-logger" }
 uefi-pi =  { path = "../uefi-pi" }
+
+tdx-tdcall = { path = "../tdx-tdcall", optional = true }
 
 [features]
 default = []

--- a/td-payload/src/main.rs
+++ b/td-payload/src/main.rs
@@ -77,7 +77,7 @@ mod payload_impl {
     pub extern "win64" fn _start(hob: *const c_void) -> ! {
         #[cfg(feature = "tdx")]
         {
-            tdx_logger::init().expect("td-payload: failed to initialize tdx logger");
+            td_logger::init().expect("td-payload: failed to initialize tdx logger");
         }
         log::info!("Starting td-payload hob - {:p}\n", hob);
         log::info!("setup_exception_handlers done\n");

--- a/td-shim-enroll-key/Cargo.toml
+++ b/td-shim-enroll-key/Cargo.toml
@@ -7,14 +7,19 @@ homepage = "https://github.com/confidential-containers"
 license = "BSD-2-Clause-Patent"
 edition = "2018"
 
+[features]
+default = ["enroller"]
+enroller = ["clap", "der", "env_logger", "log", "ring", "td-shim-ld/linker"]
+
 [dependencies]
-clap = { version = "3.0", features = ["cargo"] }
-der = { version = "0.4.5", features = ["oid"]}
-env_logger = "0.9.0"
-log = "0.4.5"
-ring = { git = "https://github.com/jyao1/ring.git", branch = "uefi_support", default-features = false, features = ["alloc"]}
 r-efi = "3.2.0"
 scroll = { version = "0.10", default-features = false, features = ["derive"]}
 td-layout = { path = "../td-layout" }
-td-shim-ld = { path = "../td-shim-ld" }
+td-shim-ld = { path = "../td-shim-ld", default-features = false }
 uefi-pi =  { path = "../uefi-pi" }
+
+clap = { version = "3.0", features = ["cargo"], optional = true }
+der = { version = "0.4.5", features = ["oid"], optional = true }
+env_logger = { version = "0.9.0", optional = true }
+log = { version = "0.4.5", optional = true }
+ring = { git = "https://github.com/jyao1/ring.git", branch = "uefi_support", default-features = false, features = ["alloc"], optional = true }

--- a/td-shim-enroll-key/src/lib.rs
+++ b/td-shim-enroll-key/src/lib.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2022 Alibaba Cloud
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![cfg_attr(not(feature = "enroller"), no_std)]
+
+use core::mem::size_of;
+use core::ptr::slice_from_raw_parts;
+
+use r_efi::efi::Guid;
+use scroll::{Pread, Pwrite};
+use td_layout::build_time::TD_SHIM_CONFIG_SIZE;
+use td_shim_ld::{write_u24, FvFfsHeader, FvHeader};
+use uefi_pi::pi::fv::{FIRMWARE_FILE_SYSTEM3_GUID, FV_FILETYPE_RAW};
+
+#[cfg(feature = "enroller")]
+pub mod public_key;
+
+/// GUID for trust anchor in the Configuration Firmware Volume (CFV).
+///
+/// Please refer to doc/secure_boot.md for definition.
+pub const CFV_FFS_HEADER_TRUST_ANCHOR_GUID: Guid = Guid::from_fields(
+    0x77a2742e,
+    0x9340,
+    0x4ac9,
+    0x8f,
+    0x85,
+    &[0xb7, 0xb9, 0x78, 0x58, 0x0, 0x21],
+); // {77A2742E-9340-4AC9-8F85-B7B978580021}
+
+/// GUID for pubkey hash file in the Configuration Firmware Volume (CFV).
+///
+/// Please refer to doc/secure_boot.md for definition.
+pub const CFV_FILE_HEADER_PUBKEY_GUID: Guid = Guid::from_fields(
+    0xbe8f65a3,
+    0xa83b,
+    0x415c,
+    0xa1,
+    0xfb,
+    &[0xf7, 0x8e, 0x10, 0x5e, 0x82, 0x4e],
+); // {BE8F65A3-A83B-415C-A1FB-F78E105E824E}
+
+pub const PUBKEY_FILE_STRUCT_VERSION_V1: u32 = 0x01;
+pub const PUBKEY_HASH_ALGORITHM_SHA384: u64 = 1;
+
+#[repr(C, align(4))]
+#[derive(Debug, Pread, Pwrite)]
+pub struct CfvPubKeyFileHeader {
+    pub type_guid: [u8; 16],
+    pub struct_version: u32,
+    pub length: u32,
+    pub hash_algorithm: u64,
+    pub reserved: u32,
+}
+
+impl CfvPubKeyFileHeader {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+pub fn build_cfv_header() -> FvHeader {
+    let mut cfv_header = FvHeader::default();
+
+    cfv_header
+        .fv_header
+        .file_system_guid
+        .copy_from_slice(FIRMWARE_FILE_SYSTEM3_GUID.as_bytes());
+    cfv_header.fv_header.fv_length = TD_SHIM_CONFIG_SIZE as u64;
+    cfv_header.fv_header.checksum = 0xdc0a;
+    cfv_header.fv_block_map[0].num_blocks = (TD_SHIM_CONFIG_SIZE as u32) / 0x1000;
+    cfv_header.fv_block_map[0].length = 0x1000;
+    cfv_header.fv_ext_header.ext_header_size = 0x14;
+
+    cfv_header
+}
+
+pub fn build_cfv_ffs_header() -> FvFfsHeader {
+    let mut cfv_ffs_header = FvFfsHeader::default();
+    cfv_ffs_header
+        .ffs_header
+        .name
+        .copy_from_slice(CFV_FFS_HEADER_TRUST_ANCHOR_GUID.as_bytes());
+
+    cfv_ffs_header.ffs_header.integrity_check = 0xaa4c;
+    cfv_ffs_header.ffs_header.r#type = FV_FILETYPE_RAW;
+    cfv_ffs_header.ffs_header.attributes = 0x00;
+    write_u24(
+        TD_SHIM_CONFIG_SIZE - size_of::<FvHeader>() as u32,
+        &mut cfv_ffs_header.ffs_header.size,
+    );
+    cfv_ffs_header.ffs_header.state = 0x07u8;
+
+    cfv_ffs_header
+}

--- a/td-shim-enroll-key/src/main.rs
+++ b/td-shim-enroll-key/src/main.rs
@@ -1,103 +1,132 @@
 // Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2022 Alibaba Cloud
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #[macro_use]
 extern crate clap;
 
-use std::ptr::slice_from_raw_parts;
+use std::convert::TryFrom;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::vec::Vec;
-use std::{convert::TryFrom, mem::size_of};
 use std::{env, io, path::Path};
 
 use log::{error, trace, LevelFilter};
-
-use r_efi::efi::Guid;
 use ring::digest;
-use scroll::{Pread, Pwrite};
-use td_layout::build_time::{TD_SHIM_CONFIG_OFFSET, TD_SHIM_CONFIG_SIZE, TD_SHIM_FIRMWARE_SIZE};
-use td_shim_ld::{write_u24, FvFfsHeader, FvHeader, InputData, OutputFile};
-use uefi_pi::fv::*;
-
-mod public_key;
-use self::public_key::{
+use td_layout::build_time::{TD_SHIM_CONFIG_OFFSET, TD_SHIM_FIRMWARE_SIZE};
+use td_shim_enroll_key::public_key::{
     RsaPublicKeyInfo, SubjectPublicKeyInfo, ID_EC_PUBKEY_OID, RSA_PUBKEY_OID, SECP384R1_OID,
 };
+use td_shim_enroll_key::{
+    build_cfv_ffs_header, build_cfv_header, CfvPubKeyFileHeader, CFV_FILE_HEADER_PUBKEY_GUID,
+    PUBKEY_FILE_STRUCT_VERSION_V1, PUBKEY_HASH_ALGORITHM_SHA384,
+};
+use td_shim_ld::linker::{InputData, OutputFile};
 
-const CFV_FFS_HEADER_GUID: Guid = Guid::from_fields(
-    0x77a2742e,
-    0x9340,
-    0x4ac9,
-    0x8f,
-    0x85,
-    &[0xb7, 0xb9, 0x78, 0x58, 0x0, 0x21],
-); // {77A2742E-9340-4AC9-8F85-B7B978580021}
-
-const FS_DATA_HEADER_GUID: Guid = Guid::from_fields(
-    0xbe8f65a3,
-    0xa83b,
-    0x415c,
-    0xa1,
-    0xfb,
-    &[0xf7, 0x8e, 0x10, 0x5e, 0x82, 0x4e],
-); // {BE8F65A3-A83B-415C-A1FB-F78E105E824E}
-
-const PUBKEY_FILE_STRUCT_VERSION: u32 = 0x01;
 const TDSHIM_SB_NAME: &str = "final.sb.bin";
 
-#[repr(C, align(4))]
-#[derive(Pread, Pwrite)]
-struct CfvDataFileHeader {
-    pub type_guid: [u8; 16],
-    pub struct_version: u32,
-    pub length: u32,
-    pub hash_algorithm: u64,
-    pub reserved: u32,
-}
+fn enroll_key(
+    tdshim_file: &str,
+    key_file: &str,
+    output_file: PathBuf,
+    hash_alg: &'static digest::Algorithm,
+) -> io::Result<()> {
+    let tdshim_bin = InputData::new(
+        tdshim_file,
+        TD_SHIM_FIRMWARE_SIZE as usize..=TD_SHIM_FIRMWARE_SIZE as usize,
+        "shim binary",
+    )?;
+    let key_data = InputData::new(key_file, 1..=1024 * 1024, "public key")?;
+    let key = SubjectPublicKeyInfo::try_from(key_data.as_bytes()).map_err(|e| {
+        error!("Can not load key from file {}: {}", key_file, e);
+        io::Error::new(io::ErrorKind::Other, "invalid key data")
+    })?;
 
-impl CfvDataFileHeader {
-    pub fn as_bytes(&self) -> &[u8] {
-        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    let mut public_bytes: Vec<u8> = Vec::new();
+    match key.algorithm.algorithm {
+        ID_EC_PUBKEY_OID => {
+            if let Some(curve) = key.algorithm.parameters {
+                if curve.as_bytes() != SECP384R1_OID.as_bytes() {
+                    error!("Unsupported Named Curve from file {}", key_file);
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "unsupported Named Curve",
+                    ));
+                }
+                if key.subject_public_key.as_bytes()[0] != 0x04 {
+                    error!("Invalid SECP384R1 public key from file {}", key_file);
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "Invalid SECP384R1 public key",
+                    ));
+                }
+                public_bytes.extend_from_slice(&key.subject_public_key.as_bytes()[1..]);
+            } else {
+                error!("Invalid algorithm parameter from file {}", key_file);
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Invalid key algorithm parameter",
+                ));
+            }
+        }
+        RSA_PUBKEY_OID => {
+            let pubkey =
+                RsaPublicKeyInfo::try_from(key.subject_public_key.as_bytes()).map_err(|e| {
+                    error!("Invalid key from file {}: {}", key_file, e);
+                    io::Error::new(io::ErrorKind::Other, "invalid key from file")
+                })?;
+            public_bytes.extend_from_slice(pubkey.modulus.as_bytes());
+            let mut exp_bytes = [0u8; 8];
+            if pubkey.exponents.as_bytes().len() > 8 {
+                error!("Invalid exponent size from key file {}", key_file);
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Invalid exponent size",
+                ));
+            }
+            exp_bytes[8 - pubkey.exponents.as_bytes().len()..]
+                .copy_from_slice(pubkey.exponents.as_bytes());
+            public_bytes.extend_from_slice(&exp_bytes);
+        }
+        t => {
+            error!("Unsupported key type {} from file {}", t, key_file);
+            return Err(io::Error::new(io::ErrorKind::Other, "unsupported key type"));
+        }
     }
+
+    let hash = digest::digest(hash_alg, public_bytes.as_slice());
+    let hash = hash.as_ref();
+
+    //Build public key header in CFV
+    let pub_key_header = CfvPubKeyFileHeader {
+        type_guid: *CFV_FILE_HEADER_PUBKEY_GUID.as_bytes(),
+        struct_version: PUBKEY_FILE_STRUCT_VERSION_V1,
+        length: (36 + hash.len()) as u32,
+        hash_algorithm: PUBKEY_HASH_ALGORITHM_SHA384,
+        reserved: 0,
+    };
+
+    // Create and write the td-shim binary with key enrolled.
+    let mut output = OutputFile::new(output_file)?;
+    let cfv_header = build_cfv_header();
+    let cfv_ffs_header = build_cfv_ffs_header();
+
+    output.seek_and_write(0, tdshim_bin.as_bytes(), "enrolled shim binary")?;
+    output.seek_and_write(
+        TD_SHIM_CONFIG_OFFSET as u64,
+        cfv_header.as_bytes(),
+        "firmware volume header",
+    )?;
+    output.write(cfv_ffs_header.as_bytes(), "firmware volume fs header")?;
+    output.write(pub_key_header.as_bytes(), "firmware key")?;
+    output.write(hash, "firmware hash value")?;
+    output.flush()?;
+
+    Ok(())
 }
 
-fn build_cfv_header() -> FvHeader {
-    let mut cfv_header = FvHeader::default();
-
-    cfv_header
-        .fv_header
-        .file_system_guid
-        .copy_from_slice(FIRMWARE_FILE_SYSTEM3_GUID.as_bytes());
-    cfv_header.fv_header.fv_length = TD_SHIM_CONFIG_SIZE as u64;
-    cfv_header.fv_header.checksum = 0xdc0a;
-    cfv_header.fv_block_map[0].num_blocks = (TD_SHIM_CONFIG_SIZE as u32) / 0x1000;
-    cfv_header.fv_block_map[0].length = 0x1000;
-    cfv_header.fv_ext_header.ext_header_size = 0x14;
-
-    cfv_header
-}
-
-fn build_cfv_ffs_header() -> FvFfsHeader {
-    let mut cfv_ffs_header = FvFfsHeader::default();
-    cfv_ffs_header
-        .ffs_header
-        .name
-        .copy_from_slice(CFV_FFS_HEADER_GUID.as_bytes());
-
-    cfv_ffs_header.ffs_header.integrity_check = 0xaa4c;
-    cfv_ffs_header.ffs_header.r#type = FV_FILETYPE_RAW;
-    cfv_ffs_header.ffs_header.attributes = 0x00;
-    write_u24(
-        TD_SHIM_CONFIG_SIZE - size_of::<FvHeader>() as u32,
-        &mut cfv_ffs_header.ffs_header.size,
-    );
-    cfv_ffs_header.ffs_header.state = 0x07u8;
-
-    cfv_ffs_header
-}
-
-fn main() -> std::io::Result<()> {
+fn main() -> io::Result<()> {
     use env_logger::Env;
     let env = Env::default()
         .filter_or("MY_LOG_LEVEL", "info")
@@ -173,96 +202,5 @@ fn main() -> std::io::Result<()> {
         }
     };
 
-    let tdshim_bin = InputData::new(
-        tdshim_file,
-        TD_SHIM_FIRMWARE_SIZE as usize..=TD_SHIM_FIRMWARE_SIZE as usize,
-        "shim binary",
-    )?;
-    let key_data = InputData::new(key_file, 1..=1024 * 1024, "private key")?;
-    let key = SubjectPublicKeyInfo::try_from(key_data.as_bytes()).map_err(|e| {
-        error!("Can not load key from file {}: {}", key_file, e);
-        io::Error::new(io::ErrorKind::Other, "invalid key data")
-    })?;
-
-    let mut public_bytes: Vec<u8> = Vec::new();
-    match key.algorithm.algorithm {
-        ID_EC_PUBKEY_OID => {
-            if let Some(curve) = key.algorithm.parameters {
-                if curve.as_bytes() != SECP384R1_OID.as_bytes() {
-                    error!("Unsupported Named Curve from file {}", key_file);
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "unsupported Named Curve",
-                    ));
-                }
-                if key.subject_public_key.as_bytes()[0] != 0x04 {
-                    error!("Invalid SECP384R1 public key from file {}", key_file);
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "Invalid SECP384R1 public key",
-                    ));
-                }
-                public_bytes.extend_from_slice(&key.subject_public_key.as_bytes()[1..]);
-            } else {
-                error!("Invalid algorithm parameter from file {}", key_file);
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Invalid key algorithm parameter",
-                ));
-            }
-        }
-        RSA_PUBKEY_OID => {
-            let pubkey =
-                RsaPublicKeyInfo::try_from(key.subject_public_key.as_bytes()).map_err(|e| {
-                    error!("Invalid key from file {}: {}", key_file, e);
-                    io::Error::new(io::ErrorKind::Other, "invalid key from file")
-                })?;
-            public_bytes.extend_from_slice(pubkey.modulus.as_bytes());
-            let mut exp_bytes = [0u8; 8];
-            if pubkey.exponents.as_bytes().len() > 8 {
-                error!("Invalid exponent size from key file {}", key_file);
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Invalid exponent size",
-                ));
-            }
-            exp_bytes[8 - pubkey.exponents.as_bytes().len()..]
-                .copy_from_slice(pubkey.exponents.as_bytes());
-            public_bytes.extend_from_slice(&exp_bytes);
-        }
-        t => {
-            error!("Unsupported key type {} from file {}", t, key_file);
-            return Err(io::Error::new(io::ErrorKind::Other, "unsupported key type"));
-        }
-    }
-
-    let hash = digest::digest(hash_alg, public_bytes.as_slice());
-    let hash = hash.as_ref();
-
-    //Build public key header in CFV
-    let pub_key_header = CfvDataFileHeader {
-        type_guid: *FS_DATA_HEADER_GUID.as_bytes(),
-        struct_version: PUBKEY_FILE_STRUCT_VERSION,
-        length: (36 + hash.len()) as u32,
-        hash_algorithm: 1,
-        reserved: 0,
-    };
-
-    // Create and write the td-shim binary with key enrolled.
-    let mut output = OutputFile::new(output_file)?;
-    let cfv_header = build_cfv_header();
-    let cfv_ffs_header = build_cfv_ffs_header();
-
-    output.seek_and_write(0, tdshim_bin.as_bytes(), "enrolled shim binary")?;
-    output.seek_and_write(
-        TD_SHIM_CONFIG_OFFSET as u64,
-        cfv_header.as_bytes(),
-        "firmware volume header",
-    )?;
-    output.write(cfv_ffs_header.as_bytes(), "firmware volume fs header")?;
-    output.write(pub_key_header.as_bytes(), "firmware key")?;
-    output.write(hash, "firmware hash value")?;
-    output.flush()?;
-
-    Ok(())
+    enroll_key(tdshim_file, key_file, output_file, hash_alg)
 }

--- a/td-shim-ld/Cargo.toml
+++ b/td-shim-ld/Cargo.toml
@@ -8,15 +8,17 @@ license = "BSD-2-Clause-Patent"
 edition = "2018"
 
 [features]
-default = []
+default = ["linker"]
 boot-kernel = ["td-layout/boot-kernel"]
+linker = ["clap", "env_logger", "log", "pe-loader"]
 
 [dependencies]
-clap = { version = "3.0", features = ["cargo"] }
-env_logger = "0.9.0"
-log = "0.4.5"
-pe-loader = { path = "../pe-loader" }
 r-efi = "3.2.0"
-scroll = { version = "0.10", default-features=false }
+scroll = { version = "0.10", default-features = false }
 td-layout = { path = "../td-layout" }
 uefi-pi =  { path = "../uefi-pi" }
+
+clap = { version = "3.0", features = ["cargo"], optional = true }
+env_logger = { version = "0.9.0", optional = true }
+log = { version = "0.4.5", optional = true }
+pe-loader = { path = "../pe-loader", optional = true }

--- a/td-shim-ld/src/lib.rs
+++ b/td-shim-ld/src/lib.rs
@@ -371,9 +371,9 @@ pub fn build_tdx_metadata() -> TdxMetadata {
 }
 
 pub fn build_tdx_metadata_ptr() -> TdxMetadataPtr {
-    let mut tdx_metadata_ptr = TdxMetadataPtr::default();
-    tdx_metadata_ptr.ptr = TD_SHIM_METADATA_OFFSET;
-    tdx_metadata_ptr
+    TdxMetadataPtr {
+        ptr: TD_SHIM_METADATA_OFFSET,
+    }
 }
 
 #[repr(C, align(4))]

--- a/td-shim-ld/src/lib.rs
+++ b/td-shim-ld/src/lib.rs
@@ -3,30 +3,38 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-use std::fs::{self, File};
-use std::io::{self, Seek, SeekFrom, Write};
-use std::mem::size_of;
-use std::ops::RangeInclusive;
-use std::path::{Path, PathBuf};
-use std::ptr::slice_from_raw_parts;
+#![cfg_attr(not(feature = "linker"), no_std)]
+use core::mem::size_of;
+use core::ptr::slice_from_raw_parts;
 
-use log::{error, trace};
-use scroll::{Pread, Pwrite};
-
-use pe_loader::pe;
 use r_efi::efi::Guid;
-use td_layout::build_time::*;
-use td_layout::mailbox::*;
-use td_layout::metadata::*;
-#[cfg(feature = "boot-kernel")]
-use td_layout::runtime::{
-    TD_PAYLOAD_BASE, TD_PAYLOAD_PARAM_BASE, TD_PAYLOAD_PARAM_SIZE, TD_PAYLOAD_SIZE,
+use scroll::{Pread, Pwrite};
+use td_layout::build_time::{
+    TD_SHIM_CONFIG_BASE, TD_SHIM_CONFIG_OFFSET, TD_SHIM_CONFIG_SIZE, TD_SHIM_HOB_BASE,
+    TD_SHIM_HOB_SIZE, TD_SHIM_IPL_SIZE, TD_SHIM_MAILBOX_BASE, TD_SHIM_MAILBOX_SIZE,
+    TD_SHIM_METADATA_OFFSET, TD_SHIM_PAYLOAD_BASE, TD_SHIM_PAYLOAD_OFFSET, TD_SHIM_PAYLOAD_SIZE,
+    TD_SHIM_RESET_VECTOR_SIZE, TD_SHIM_TEMP_HEAP_BASE, TD_SHIM_TEMP_HEAP_SIZE,
+    TD_SHIM_TEMP_STACK_BASE, TD_SHIM_TEMP_STACK_SIZE,
 };
-use uefi_pi::pi::fv::*;
+use td_layout::metadata::{
+    TdxMetadata, TdxMetadataPtr, TDX_METADATA_ATTRIBUTES_EXTENDMR, TDX_METADATA_SECTION_TYPE_BFV,
+    TDX_METADATA_SECTION_TYPE_CFV, TDX_METADATA_SECTION_TYPE_TD_HOB,
+    TDX_METADATA_SECTION_TYPE_TEMP_MEM,
+};
+#[cfg(feature = "boot-kernel")]
+use td_layout::{
+    metadata::{TDX_METADATA_SECTION_TYPE_PAYLOAD, TDX_METADATA_SECTION_TYPE_PAYLOAD_PARAM},
+    runtime::{TD_PAYLOAD_BASE, TD_PAYLOAD_PARAM_BASE, TD_PAYLOAD_PARAM_SIZE, TD_PAYLOAD_SIZE},
+};
+use uefi_pi::pi::fv::{
+    CommonSectionHeader, FfsFileHeader, FirmwareVolumeExtHeader, FirmwareVolumeHeader, FvBlockMap,
+    FIRMWARE_FILE_SYSTEM2_GUID, FVH_SIGNATURE, FV_FILETYPE_DXE_CORE, FV_FILETYPE_FFS_PAD,
+    FV_FILETYPE_RAW, FV_FILETYPE_SECURITY_CORE, SECTION_PE32, SECTION_RAW,
+};
 
-const MAX_IPL_CONTENT_SIZE: usize =
+pub const MAX_IPL_CONTENT_SIZE: usize =
     TD_SHIM_IPL_SIZE as usize - size_of::<IplFvHeaderByte>() - size_of::<ResetVectorHeader>();
-const MAX_PAYLOAD_CONTENT_SIZE: usize =
+pub const MAX_PAYLOAD_CONTENT_SIZE: usize =
     TD_SHIM_PAYLOAD_SIZE as usize - size_of::<FvHeaderByte>() - size_of::<TdxMetadata>();
 
 /// Write three bytes from an integer value into the buffer.
@@ -61,7 +69,7 @@ impl Default for FvHeader {
         FvHeader {
             fv_header: FirmwareVolumeHeader {
                 zero_vector: [0u8; 16],
-                file_system_guid: FIRMWARE_FILE_SYSTEM2_GUID.as_bytes().to_owned(),
+                file_system_guid: *FIRMWARE_FILE_SYSTEM2_GUID.as_bytes(),
                 fv_length: 0,
                 signature: FVH_SIGNATURE,
                 attributes: 0x0004f6ff,
@@ -73,7 +81,7 @@ impl Default for FvHeader {
             },
             fv_block_map: [FvBlockMap::default(); 2],
             pad_ffs_header: FfsFileHeader {
-                name: Guid::from_fields(
+                name: *Guid::from_fields(
                     0x00000000,
                     0x0000,
                     0x0000,
@@ -81,8 +89,7 @@ impl Default for FvHeader {
                     0x00,
                     &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
                 )
-                .as_bytes()
-                .to_owned(),
+                .as_bytes(),
                 integrity_check: 0xaae4,
                 r#type: FV_FILETYPE_FFS_PAD,
                 attributes: 0x00,
@@ -112,13 +119,14 @@ impl FvFfsHeader {
 
 #[repr(C, align(4))]
 #[derive(Copy, Clone, Debug, Pread, Pwrite, Default)]
-struct FvFfsSectionHeader {
-    section_header: CommonSectionHeader,
+pub struct FvFfsSectionHeader {
+    pub section_header: CommonSectionHeader,
 }
 
 #[repr(C, align(4))]
-struct FvHeaderByte {
-    data: [u8; size_of::<FvHeader>() + size_of::<FvFfsHeader>() + size_of::<FvFfsSectionHeader>()],
+pub struct FvHeaderByte {
+    pub data:
+        [u8; size_of::<FvHeader>() + size_of::<FvFfsHeader>() + size_of::<FvFfsSectionHeader>()],
 }
 
 impl Default for FvHeaderByte {
@@ -132,7 +140,7 @@ impl Default for FvHeaderByte {
 }
 
 impl FvHeaderByte {
-    fn build_tdx_payload_fv_header() -> Self {
+    pub fn build_tdx_payload_fv_header() -> Self {
         let mut hdr = Self::default();
         let fv_header_size = (size_of::<FvHeader>()) as usize;
 
@@ -204,7 +212,7 @@ impl FvHeaderByte {
     }
 
     // Build internal payload header
-    fn build_tdx_ipl_fv_header() -> Self {
+    pub fn build_tdx_ipl_fv_header() -> Self {
         let mut hdr = Self::default();
         let fv_header_size = (size_of::<FvHeader>()) as usize;
 
@@ -278,16 +286,16 @@ impl FvHeaderByte {
     }
 }
 
-type PayloadFvHeader = FvHeader;
-type PayloadFvFfsHeader = FvFfsHeader;
-//type PayloadFvFfsSectionHeader = FvFfsSectionHeader;
-type PayloadFvHeaderByte = FvHeaderByte;
-type IplFvHeader = PayloadFvHeader;
-type IplFvFfsHeader = PayloadFvFfsHeader;
-type IplFvFfsSectionHeader = FvFfsSectionHeader;
-type IplFvHeaderByte = FvHeaderByte;
+pub type PayloadFvHeader = FvHeader;
+pub type PayloadFvFfsHeader = FvFfsHeader;
+pub type PayloadFvFfsSectionHeader = FvFfsSectionHeader;
+pub type PayloadFvHeaderByte = FvHeaderByte;
+pub type IplFvHeader = PayloadFvHeader;
+pub type IplFvFfsHeader = PayloadFvFfsHeader;
+pub type IplFvFfsSectionHeader = FvFfsSectionHeader;
+pub type IplFvHeaderByte = FvHeaderByte;
 
-fn build_tdx_metadata() -> TdxMetadata {
+pub fn build_tdx_metadata() -> TdxMetadata {
     let mut tdx_metadata = TdxMetadata::default();
 
     // BFV
@@ -362,7 +370,7 @@ fn build_tdx_metadata() -> TdxMetadata {
     tdx_metadata
 }
 
-fn build_tdx_metadata_ptr() -> TdxMetadataPtr {
+pub fn build_tdx_metadata_ptr() -> TdxMetadataPtr {
     let mut tdx_metadata_ptr = TdxMetadataPtr::default();
     tdx_metadata_ptr.ptr = TD_SHIM_METADATA_OFFSET;
     tdx_metadata_ptr
@@ -370,15 +378,15 @@ fn build_tdx_metadata_ptr() -> TdxMetadataPtr {
 
 #[repr(C, align(4))]
 #[derive(Debug, Default, Pwrite)]
-struct ResetVectorHeader {
-    ffs_header: FfsFileHeader,
-    section_header_pad: CommonSectionHeader,
+pub struct ResetVectorHeader {
+    pub ffs_header: FfsFileHeader,
+    pub section_header_pad: CommonSectionHeader,
     pad: [u8; 8],
-    section_header_reset_vector: CommonSectionHeader,
+    pub section_header_reset_vector: CommonSectionHeader,
 }
 
 impl ResetVectorHeader {
-    fn build_tdx_reset_vector_header() -> Self {
+    pub fn build_tdx_reset_vector_header() -> Self {
         let mut tdx_reset_vector_header = ResetVectorHeader::default();
 
         tdx_reset_vector_header.ffs_header.name.copy_from_slice(
@@ -415,107 +423,139 @@ impl ResetVectorHeader {
         tdx_reset_vector_header
     }
 
-    fn as_bytes(&self) -> &[u8] {
+    pub fn as_bytes(&self) -> &[u8] {
         unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
     }
 }
 
 #[repr(C, align(4))]
 #[derive(Debug, Pread, Pwrite)]
-struct ResetVectorParams {
-    entry_point: u32, // rust entry point
-    img_base: u32,    // rust ipl bin base
-    img_size: u32,    // rust ipl bin size
+pub struct ResetVectorParams {
+    pub entry_point: u32, // rust entry point
+    pub img_base: u32,    // rust ipl bin base
+    pub img_size: u32,    // rust ipl bin size
 }
 
 impl ResetVectorParams {
-    fn as_bytes(&self) -> &[u8] {
+    pub fn as_bytes(&self) -> &[u8] {
         unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
     }
 }
 
-/// Struct to read input data from a file.
-pub struct InputData {
-    data: Vec<u8>,
-}
+#[cfg(feature = "linker")]
+pub mod linker {
+    use std::fs::{self, File};
+    use std::io::{self, Seek, SeekFrom, Write};
+    use std::mem::size_of;
+    use std::ops::RangeInclusive;
+    use std::path::{Path, PathBuf};
 
-impl InputData {
-    /// Read data from file into the internal buffer.
-    pub fn new(name: &str, range: RangeInclusive<usize>, desc: &str) -> io::Result<Self> {
-        // Check file size first to avoid allocating too much memory.
-        let md = fs::metadata(name).map_err(|e| {
-            error!("Can not get metadata of file {}: {}", name, e);
-            e
-        })?;
-        if md.len() > TD_SHIM_FIRMWARE_SIZE as u64 {
-            error!(
-                "Size of {} file ({}) is invalid, should be in range [{}-{}]",
-                desc,
-                md.len(),
-                range.start(),
-                range.end()
-            );
-            return Err(io::Error::new(io::ErrorKind::Other, "invalid file size"));
-        }
+    use log::{error, trace};
+    use pe_loader::pe;
+    use td_layout::build_time::{
+        TD_SHIM_FIRMWARE_BASE, TD_SHIM_FIRMWARE_SIZE, TD_SHIM_IPL_OFFSET, TD_SHIM_MAILBOX_OFFSET,
+        TD_SHIM_PAYLOAD_BASE, TD_SHIM_PAYLOAD_OFFSET, TD_SHIM_PAYLOAD_SIZE,
+        TD_SHIM_RESET_VECTOR_SIZE,
+    };
+    use td_layout::mailbox::TdxMpWakeupMailbox;
+    use td_layout::metadata::TdxMetadata;
 
-        let data = fs::read(name).map_err(|e| {
-            error!("Can not read data from file {}: {}", name, e);
-            e
-        })?;
-        let len = data.len();
-        if !range.contains(&len) {
-            error!(
-                "Size of {} file ({}) is invalid, should be in range [{}-{}]",
-                desc,
-                len,
-                range.start(),
-                range.end()
-            );
-            return Err(io::Error::new(io::ErrorKind::Other, "invalid file size"));
-        }
+    use super::*;
 
-        Ok(InputData { data })
+    /// Struct to read input data from a file.
+    pub struct InputData {
+        data: Vec<u8>,
     }
 
-    /// Clear the internal data buffer.
-    pub fn clear(&mut self) {
-        self.data.clear()
-    }
-
-    /// Get the input data.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.data
-    }
-}
-
-/// Struct to write out built data.
-pub struct OutputFile {
-    file: File,
-    name: PathBuf,
-}
-
-impl OutputFile {
-    pub fn new<P: AsRef<Path>>(name: P) -> io::Result<Self> {
-        let file = File::create(name.as_ref()).map_err(|e| {
-            error!(
-                "Can not open output file {}: {}",
-                name.as_ref().display(),
+    impl InputData {
+        /// Read data from file into the internal buffer.
+        pub fn new(name: &str, range: RangeInclusive<usize>, desc: &str) -> io::Result<Self> {
+            // Check file size first to avoid allocating too much memory.
+            let md = fs::metadata(name).map_err(|e| {
+                error!("Can not get metadata of file {}: {}", name, e);
                 e
-            );
-            e
-        })?;
+            })?;
+            if md.len() > TD_SHIM_FIRMWARE_SIZE as u64 {
+                error!(
+                    "Size of {} file ({}) is invalid, should be in range [{}-{}]",
+                    desc,
+                    md.len(),
+                    range.start(),
+                    range.end()
+                );
+                return Err(io::Error::new(io::ErrorKind::Other, "invalid file size"));
+            }
 
-        Ok(Self {
-            file,
-            name: name.as_ref().to_path_buf(),
-        })
+            let data = fs::read(name).map_err(|e| {
+                error!("Can not read data from file {}: {}", name, e);
+                e
+            })?;
+            let len = data.len();
+            if !range.contains(&len) {
+                error!(
+                    "Size of {} file ({}) is invalid, should be in range [{}-{}]",
+                    desc,
+                    len,
+                    range.start(),
+                    range.end()
+                );
+                return Err(io::Error::new(io::ErrorKind::Other, "invalid file size"));
+            }
+
+            Ok(InputData { data })
+        }
+
+        /// Clear the internal data buffer.
+        pub fn clear(&mut self) {
+            self.data.clear()
+        }
+
+        /// Get the input data.
+        pub fn as_bytes(&self) -> &[u8] {
+            &self.data
+        }
     }
 
-    pub fn seek_and_write(&mut self, off: u64, data: &[u8], desc: &str) -> io::Result<()> {
-        self.file
-            .seek(SeekFrom::Start(off))
-            .and(self.file.write_all(data))
-            .map_err(|e| {
+    /// Struct to write out built data.
+    pub struct OutputFile {
+        file: File,
+        name: PathBuf,
+    }
+
+    impl OutputFile {
+        pub fn new<P: AsRef<Path>>(name: P) -> io::Result<Self> {
+            let file = File::create(name.as_ref()).map_err(|e| {
+                error!(
+                    "Can not open output file {}: {}",
+                    name.as_ref().display(),
+                    e
+                );
+                e
+            })?;
+
+            Ok(Self {
+                file,
+                name: name.as_ref().to_path_buf(),
+            })
+        }
+
+        pub fn seek_and_write(&mut self, off: u64, data: &[u8], desc: &str) -> io::Result<()> {
+            self.file
+                .seek(SeekFrom::Start(off))
+                .and(self.file.write_all(data))
+                .map_err(|e| {
+                    error!(
+                        "Can not write {} to file {}: {}",
+                        desc,
+                        self.name.display(),
+                        e
+                    );
+                    e
+                })
+        }
+
+        pub fn write(&mut self, data: &[u8], desc: &str) -> io::Result<()> {
+            self.file.write_all(data).map_err(|e| {
                 error!(
                     "Can not write {} to file {}: {}",
                     desc,
@@ -524,137 +564,138 @@ impl OutputFile {
                 );
                 e
             })
-    }
-
-    pub fn write(&mut self, data: &[u8], desc: &str) -> io::Result<()> {
-        self.file.write_all(data).map_err(|e| {
-            error!(
-                "Can not write {} to file {}: {}",
-                desc,
-                self.name.display(),
-                e
-            );
-            e
-        })
-    }
-
-    pub fn flush(&mut self) -> io::Result<()> {
-        self.file.flush()
-    }
-}
-
-/// TD shim linker to compose multiple components into the final shim binary.
-#[derive(Default)]
-pub struct TdShimLinker {
-    payload_relocation: bool,
-    output_file_name: Option<String>,
-}
-
-impl TdShimLinker {
-    /// Enable/disable relocation of shim payload.
-    pub fn set_payload_relocation(&mut self, relocation: bool) -> &mut Self {
-        self.payload_relocation = relocation;
-        self
-    }
-
-    /// Set file name for the generated shim binary.
-    pub fn set_output_file(&mut self, name: String) -> &mut Self {
-        self.output_file_name = Some(name);
-        self
-    }
-
-    /// Build the shim binary.
-    pub fn build(&self, reset_name: &str, ipl_name: &str, payload_name: &str) -> io::Result<()> {
-        let reset_vector_bin = InputData::new(
-            reset_name,
-            TD_SHIM_RESET_VECTOR_SIZE as usize..=TD_SHIM_RESET_VECTOR_SIZE as usize,
-            "reset_vector",
-        )?;
-        let ipl_bin = InputData::new(ipl_name, 0..=MAX_IPL_CONTENT_SIZE, "IPL")?;
-        let payload_bin = InputData::new(payload_name, 0..=MAX_PAYLOAD_CONTENT_SIZE, "payload")?;
-        let output_file_name = self
-            .output_file_name
-            .as_ref()
-            .map(|v| v.as_str())
-            .unwrap_or("td_shim.bin");
-        let mut output_file = OutputFile::new(output_file_name)?;
-
-        let mailbox = TdxMpWakeupMailbox::default();
-        output_file.seek_and_write(
-            TD_SHIM_MAILBOX_OFFSET as u64,
-            mailbox.as_bytes(),
-            "mailbox content",
-        )?;
-
-        let payload_header = PayloadFvHeaderByte::build_tdx_payload_fv_header();
-        output_file.seek_and_write(
-            TD_SHIM_PAYLOAD_OFFSET as u64,
-            &payload_header.data,
-            "payload header",
-        )?;
-
-        if self.payload_relocation {
-            let mut payload_reloc_buf = vec![0x0u8; MAX_PAYLOAD_CONTENT_SIZE];
-            let reloc = pe::relocate(
-                &payload_bin.data,
-                &mut payload_reloc_buf,
-                TD_SHIM_PAYLOAD_BASE as usize + payload_header.data.len(),
-            )
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::Other, "Can not relocate payload content")
-            })?;
-            trace!("shim payload relocated to 0x{:x}", reloc);
-            output_file.write(&payload_reloc_buf, "payload content")?;
-        } else {
-            output_file.write(&payload_bin.data, "payload content")?;
         }
 
-        let metadata = build_tdx_metadata();
-        let pos = TD_SHIM_PAYLOAD_OFFSET as u64 + TD_SHIM_PAYLOAD_SIZE as u64
-            - size_of::<TdxMetadata>() as u64;
-        output_file.seek_and_write(pos, metadata.as_bytes(), "metadata")?;
+        pub fn flush(&mut self) -> io::Result<()> {
+            self.file.flush()
+        }
+    }
 
-        let ipl_header = IplFvHeaderByte::build_tdx_ipl_fv_header();
-        output_file.seek_and_write(TD_SHIM_IPL_OFFSET as u64, &ipl_header.data, "IPL header")?;
+    /// TD shim linker to compose multiple components into the final shim binary.
+    #[derive(Default)]
+    pub struct TdShimLinker {
+        payload_relocation: bool,
+        output_file_name: Option<String>,
+    }
 
-        let mut ipl_reloc_buf = vec![0x00u8; MAX_IPL_CONTENT_SIZE];
-        // relocate ipl to 1M
-        let reloc = pe::relocate(&ipl_bin.data, &mut ipl_reloc_buf, 0x100000 as usize)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Can not relocate IPL content"))?;
-        trace!(
-            "reloc IPL entrypoint - 0x{:x} - base: 0x{:x}",
-            reloc,
-            0x100000
-        );
-        let entry_point = (reloc - 0x100000) as u32;
-        let current_pos = output_file
-            .file
-            .metadata()
-            .map_err(|e| {
-                error!("Can not get size of file {}", output_file_name);
-                e
-            })?
-            .len();
-        let reset_vector_info = ResetVectorParams {
-            entry_point,
-            img_base: TD_SHIM_FIRMWARE_BASE + current_pos as u32,
-            img_size: ipl_bin.data.len() as u32,
-        };
+    impl TdShimLinker {
+        /// Enable/disable relocation of shim payload.
+        pub fn set_payload_relocation(&mut self, relocation: bool) -> &mut Self {
+            self.payload_relocation = relocation;
+            self
+        }
 
-        output_file.write(&ipl_reloc_buf, "internal payload content")?;
+        /// Set file name for the generated shim binary.
+        pub fn set_output_file(&mut self, name: String) -> &mut Self {
+            self.output_file_name = Some(name);
+            self
+        }
 
-        let reset_vector_header = ResetVectorHeader::build_tdx_reset_vector_header();
-        output_file.write(reset_vector_header.as_bytes(), "reset vector header")?;
-        output_file.write(&reset_vector_bin.data, "reset vector content")?;
+        /// Build the shim binary.
+        pub fn build(
+            &self,
+            reset_name: &str,
+            ipl_name: &str,
+            payload_name: &str,
+        ) -> io::Result<()> {
+            let reset_vector_bin = InputData::new(
+                reset_name,
+                TD_SHIM_RESET_VECTOR_SIZE as usize..=TD_SHIM_RESET_VECTOR_SIZE as usize,
+                "reset_vector",
+            )?;
+            let ipl_bin = InputData::new(ipl_name, 0..=MAX_IPL_CONTENT_SIZE, "IPL")?;
+            let payload_bin =
+                InputData::new(payload_name, 0..=MAX_PAYLOAD_CONTENT_SIZE, "payload")?;
+            let output_file_name = self
+                .output_file_name
+                .as_ref()
+                .map(|v| v.as_str())
+                .unwrap_or("td_shim.bin");
+            let mut output_file = OutputFile::new(output_file_name)?;
 
-        // Overwrite the ResetVectorParams and TdxMetadataPtr.
-        let pos = TD_SHIM_FIRMWARE_SIZE as u64 - 0x20 - size_of::<ResetVectorParams>() as u64;
-        output_file.seek_and_write(pos, reset_vector_info.as_bytes(), "reset vector info")?;
-        let metadata_ptr = build_tdx_metadata_ptr();
-        output_file.write(metadata_ptr.as_bytes(), "metadata_ptr")?;
+            let mailbox = TdxMpWakeupMailbox::default();
+            output_file.seek_and_write(
+                TD_SHIM_MAILBOX_OFFSET as u64,
+                mailbox.as_bytes(),
+                "mailbox content",
+            )?;
 
-        output_file.flush()?;
+            let payload_header = PayloadFvHeaderByte::build_tdx_payload_fv_header();
+            output_file.seek_and_write(
+                TD_SHIM_PAYLOAD_OFFSET as u64,
+                &payload_header.data,
+                "payload header",
+            )?;
 
-        Ok(())
+            if self.payload_relocation {
+                let mut payload_reloc_buf = vec![0x0u8; MAX_PAYLOAD_CONTENT_SIZE];
+                let reloc = pe::relocate(
+                    &payload_bin.data,
+                    &mut payload_reloc_buf,
+                    TD_SHIM_PAYLOAD_BASE as usize + payload_header.data.len(),
+                )
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::Other, "Can not relocate payload content")
+                })?;
+                trace!("shim payload relocated to 0x{:x}", reloc);
+                output_file.write(&payload_reloc_buf, "payload content")?;
+            } else {
+                output_file.write(&payload_bin.data, "payload content")?;
+            }
+
+            let metadata = build_tdx_metadata();
+            let pos = TD_SHIM_PAYLOAD_OFFSET as u64 + TD_SHIM_PAYLOAD_SIZE as u64
+                - size_of::<TdxMetadata>() as u64;
+            output_file.seek_and_write(pos, metadata.as_bytes(), "metadata")?;
+
+            let ipl_header = IplFvHeaderByte::build_tdx_ipl_fv_header();
+            output_file.seek_and_write(
+                TD_SHIM_IPL_OFFSET as u64,
+                &ipl_header.data,
+                "IPL header",
+            )?;
+
+            let mut ipl_reloc_buf = vec![0x00u8; MAX_IPL_CONTENT_SIZE];
+            // relocate ipl to 1M
+            let reloc = pe::relocate(&ipl_bin.data, &mut ipl_reloc_buf, 0x100000 as usize)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::Other, "Can not relocate IPL content")
+                })?;
+            trace!(
+                "reloc IPL entrypoint - 0x{:x} - base: 0x{:x}",
+                reloc,
+                0x100000
+            );
+            let entry_point = (reloc - 0x100000) as u32;
+            let current_pos = output_file
+                .file
+                .metadata()
+                .map_err(|e| {
+                    error!("Can not get size of file {}", output_file_name);
+                    e
+                })?
+                .len();
+            let reset_vector_info = ResetVectorParams {
+                entry_point,
+                img_base: TD_SHIM_FIRMWARE_BASE + current_pos as u32,
+                img_size: ipl_bin.data.len() as u32,
+            };
+
+            output_file.write(&ipl_reloc_buf, "internal payload content")?;
+
+            let reset_vector_header = ResetVectorHeader::build_tdx_reset_vector_header();
+            output_file.write(reset_vector_header.as_bytes(), "reset vector header")?;
+            output_file.write(&reset_vector_bin.data, "reset vector content")?;
+
+            // Overwrite the ResetVectorParams and TdxMetadataPtr.
+            let pos = TD_SHIM_FIRMWARE_SIZE as u64 - 0x20 - size_of::<ResetVectorParams>() as u64;
+            output_file.seek_and_write(pos, reset_vector_info.as_bytes(), "reset vector info")?;
+            let metadata_ptr = build_tdx_metadata_ptr();
+            output_file.write(metadata_ptr.as_bytes(), "metadata_ptr")?;
+
+            output_file.flush()?;
+
+            Ok(())
+        }
     }
 }

--- a/td-shim-ld/src/main.rs
+++ b/td-shim-ld/src/main.rs
@@ -9,7 +9,7 @@ extern crate clap;
 use log::LevelFilter;
 use std::io;
 use std::str::FromStr;
-use td_shim_ld::TdShimLinker;
+use td_shim_ld::linker::TdShimLinker;
 
 fn main() -> io::Result<()> {
     use env_logger::Env;

--- a/td-shim-sign-payload/Cargo.toml
+++ b/td-shim-sign-payload/Cargo.toml
@@ -8,12 +8,17 @@ license = "BSD-2-Clause-Patent"
 edition = "2018"
 
 [dependencies]
-clap = { version = "3.0", features = ["cargo"] }
-der = { version = "0.4.5", features = ["oid"]}
-env_logger = "0.9.0"
-log = "0.4.5"
-ring = { git = "https://github.com/jyao1/ring.git", branch = "uefi_support", default-features = false, features = ["alloc"]}
 r-efi = "3.2.0"
 scroll = { version = "0.10", default-features = false, features = ["derive"]}
-td-layout = { path = "../td-layout" }
-td-shim-ld = { path = "../td-shim-ld" }
+
+clap = { version = "3.0", features = ["cargo"], optional = true }
+der = { version = "0.4.5", features = ["oid"], optional = true}
+env_logger = { version = "0.9.0", optional = true }
+log = { version = "0.4.5", optional = true }
+ring = { git = "https://github.com/jyao1/ring.git", branch = "uefi_support", default-features = false, features = ["alloc"], optional = true}
+td-layout = { path = "../td-layout", optional = true }
+td-shim-ld = { path = "../td-shim-ld", default-features = false, optional = true}
+
+[features]
+default = ["signer"]
+signer = ["clap", "der", "env_logger", "log", "ring", "td-layout", "td-shim-ld/linker"]

--- a/td-shim-sign-payload/src/lib.rs
+++ b/td-shim-sign-payload/src/lib.rs
@@ -93,8 +93,7 @@ pub mod signer {
                         .public_key()
                         .modulus()
                         .big_endian_without_leading_zero();
-                    // TODO: figure out the exact upper bound.
-                    if rsa_keypair.public_modulus_len() > 4096 {
+                    if rsa_keypair.public_modulus_len() != 384 {
                         error!(
                             "Invalid RSA public modulus length: {}",
                             rsa_keypair.public_modulus_len()
@@ -166,8 +165,8 @@ pub mod signer {
 
         pub fn build_header(&self, payload_version: u64, payload_svn: u64) -> PayloadSignHeader {
             let signing_algorithm = match self.algorithm {
-                SigningAlgorithm::EcdsaNistP384Sha384(_) => 1,
-                SigningAlgorithm::Rsapss3072Sha384(_) => 2,
+                SigningAlgorithm::EcdsaNistP384Sha384(_) => TD_PAYLOAD_SIGN_ECDSA_NIST_P384_SHA384,
+                SigningAlgorithm::Rsapss3072Sha384(_) => TD_PAYLOAD_SIGN_RSA_PSS_3072_SHA384,
             };
             let length = (self.raw_image.len() + size_of::<PayloadSignHeader>()) as u32;
 

--- a/td-shim-sign-payload/src/lib.rs
+++ b/td-shim-sign-payload/src/lib.rs
@@ -2,18 +2,14 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-use std::io;
-use std::mem::size_of;
-use std::ptr::slice_from_raw_parts;
-use std::vec::Vec;
-
-use log::error;
+#![cfg_attr(not(feature = "signer"), no_std)]
 use r_efi::efi::Guid;
-use ring::rand;
-use ring::signature::{EcdsaKeyPair, KeyPair, RsaKeyPair, RSA_PSS_SHA384};
 use scroll::{Pread, Pwrite};
 
-const VERIFY_HEADER_GUID: Guid = Guid::from_fields(
+/// GUID for signed payload.
+///
+/// Please refer to doc/secure_boot.md for definition.
+pub const TD_PAYLOAD_SIGN_HEADER_GUID: Guid = Guid::from_fields(
     0xFCF2D558,
     0x9DF5,
     0x4F4D,
@@ -22,11 +18,17 @@ const VERIFY_HEADER_GUID: Guid = Guid::from_fields(
     &[0x3e, 0x4b, 0x79, 0x8a, 0xb0, 0x66],
 ); // {FCF2D558-9DF5-4F4D-B0D7-3E4B798AB066}
 
-const RSA_EXPONENT_SIZE: usize = 8;
+pub const TD_PAYLOAD_SIGN_ECDSA_NIST_P384_SHA384: u32 = 1;
+pub const TD_PAYLOAD_SIGN_RSA_PSS_3072_SHA384: u32 = 2;
+pub const TD_PAYLOAD_SIGN_RSA_EXPONENT_SIZE: usize = 8;
+pub const TD_PAYLOAD_SIGN_RSA_PUBLIC_KEY_MOD_SIZE: usize = 384;
 
+/// File header for signed payload.
+///
+/// Please refer to doc/secure_boot.md for definition.
 #[repr(C, align(4))]
-#[derive(Pread, Pwrite)]
-pub struct VerifyHeader {
+#[derive(Debug, Pread, Pwrite)]
+pub struct PayloadSignHeader {
     pub type_guid: [u8; 16],
     pub struct_version: u32,
     pub length: u32,
@@ -36,129 +38,148 @@ pub struct VerifyHeader {
     pub reserved: u32,
 }
 
-impl VerifyHeader {
+impl PayloadSignHeader {
     pub fn as_bytes(&self) -> &[u8] {
-        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
-    }
-}
-
-pub enum SigningAlgorithm {
-    Rsapss3072Sha384(RsaKeyPair),
-    EcdsaNistP384Sha384(EcdsaKeyPair),
-}
-
-pub struct PayloadSigner<'a> {
-    algorithm: SigningAlgorithm,
-    raw_image: &'a [u8],
-    signed_image: Vec<u8>,
-}
-
-impl<'a> PayloadSigner<'a> {
-    pub fn new(raw_image: &'a [u8], algorithm: SigningAlgorithm) -> Self {
-        PayloadSigner {
-            raw_image,
-            algorithm,
-            signed_image: Vec::new(),
+        unsafe {
+            &*core::ptr::slice_from_raw_parts(
+                self as *const Self as *const u8,
+                core::mem::size_of::<Self>(),
+            )
         }
     }
+}
 
-    pub fn sign(&mut self, header: VerifyHeader) -> io::Result<&[u8]> {
-        let rng = rand::SystemRandom::new();
+#[cfg(feature = "signer")]
+pub mod signer {
+    use std::io;
+    use std::mem::size_of;
+    use std::vec::Vec;
 
-        self.signed_image = header.as_bytes().to_vec();
-        self.signed_image.extend_from_slice(self.raw_image);
+    use log::error;
+    use ring::rand;
+    use ring::signature::{EcdsaKeyPair, KeyPair, RsaKeyPair, RSA_PSS_SHA384};
 
-        match &self.algorithm {
-            SigningAlgorithm::Rsapss3072Sha384(rsa_keypair) => {
-                let modulus = rsa_keypair
-                    .public_key()
-                    .modulus()
-                    .big_endian_without_leading_zero();
-                // TODO: figure out the exact upper bound.
-                if rsa_keypair.public_modulus_len() > 4096 {
-                    error!(
-                        "Invalid RSA public modulus length: {}",
-                        rsa_keypair.public_modulus_len()
-                    );
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "invalid RSA public modulus length",
-                    ));
-                }
+    use super::*;
 
-                let exponent = rsa_keypair
-                    .public_key()
-                    .exponent()
-                    .big_endian_without_leading_zero();
-                if exponent.len() > RSA_EXPONENT_SIZE {
-                    error!(
-                        "Invalid RSA exponent length: {}, max {}",
-                        exponent.len(),
-                        RSA_EXPONENT_SIZE
-                    );
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "invalid RSA exponent size",
-                    ));
-                }
+    pub enum SigningAlgorithm {
+        Rsapss3072Sha384(RsaKeyPair),
+        EcdsaNistP384Sha384(EcdsaKeyPair),
+    }
 
-                let mut exp_bytes = [0u8; RSA_EXPONENT_SIZE];
-                exp_bytes[RSA_EXPONENT_SIZE - exponent.len()..].copy_from_slice(exponent);
+    pub struct PayloadSigner<'a> {
+        algorithm: SigningAlgorithm,
+        raw_image: &'a [u8],
+        signed_image: Vec<u8>,
+    }
 
-                let mut signature: Vec<u8> = vec![0; rsa_keypair.public_modulus_len()];
-                rsa_keypair
-                    .sign(&RSA_PSS_SHA384, &rng, &self.signed_image, &mut signature)
-                    .map_err(|e| {
-                        error!("Failed to sign message with RSA: {}", e);
-                        io::Error::new(io::ErrorKind::Other, "failed to sign message")
-                    })?;
-
-                self.signed_image.extend_from_slice(&modulus);
-                self.signed_image.extend_from_slice(&exp_bytes);
-                self.signed_image.extend_from_slice(signature.as_slice());
-            }
-            SigningAlgorithm::EcdsaNistP384Sha384(ecdsa_keypair) => {
-                let public_key = ecdsa_keypair.public_key().as_ref();
-                // 0x4 -- Uncompressed
-                // 0x0 -- Compressed
-                if public_key[0] != 0x4 {
-                    error!("Invalid ECDSA data format: {}", public_key[0],);
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "Invalid ECDSA data format",
-                    ));
-                }
-
-                let signature = ecdsa_keypair
-                    .sign(&rng, self.signed_image.as_slice())
-                    .map_err(|e| {
-                        error!("Failed to sign message with ECDSA: {}", e);
-                        io::Error::new(io::ErrorKind::Other, "failed to sign message")
-                    })?;
-
-                self.signed_image.extend_from_slice(&public_key[1..]);
-                self.signed_image.extend_from_slice(signature.as_ref());
+    impl<'a> PayloadSigner<'a> {
+        pub fn new(raw_image: &'a [u8], algorithm: SigningAlgorithm) -> Self {
+            PayloadSigner {
+                raw_image,
+                algorithm,
+                signed_image: Vec::new(),
             }
         }
 
-        Ok(self.signed_image.as_slice())
-    }
+        pub fn sign(&mut self, header: PayloadSignHeader) -> io::Result<&[u8]> {
+            let rng = rand::SystemRandom::new();
 
-    pub fn build_header(&self, payload_version: u64, payload_svn: u64) -> VerifyHeader {
-        let signing_algorithm = match self.algorithm {
-            SigningAlgorithm::EcdsaNistP384Sha384(_) => 1,
-            SigningAlgorithm::Rsapss3072Sha384(_) => 2,
-        };
-        let length = (self.raw_image.len() + size_of::<VerifyHeader>()) as u32;
+            self.signed_image = header.as_bytes().to_vec();
+            self.signed_image.extend_from_slice(self.raw_image);
 
-        VerifyHeader {
-            type_guid: *VERIFY_HEADER_GUID.as_bytes(),
-            struct_version: 0x1,
-            length,
-            payload_version,
-            payload_svn,
-            signing_algorithm,
-            reserved: 0,
+            match &self.algorithm {
+                SigningAlgorithm::Rsapss3072Sha384(rsa_keypair) => {
+                    let modulus = rsa_keypair
+                        .public_key()
+                        .modulus()
+                        .big_endian_without_leading_zero();
+                    // TODO: figure out the exact upper bound.
+                    if rsa_keypair.public_modulus_len() > 4096 {
+                        error!(
+                            "Invalid RSA public modulus length: {}",
+                            rsa_keypair.public_modulus_len()
+                        );
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "invalid RSA public modulus length",
+                        ));
+                    }
+
+                    let exponent = rsa_keypair
+                        .public_key()
+                        .exponent()
+                        .big_endian_without_leading_zero();
+                    if exponent.len() > TD_PAYLOAD_SIGN_RSA_EXPONENT_SIZE {
+                        error!(
+                            "Invalid RSA exponent length: {}, max {}",
+                            exponent.len(),
+                            TD_PAYLOAD_SIGN_RSA_EXPONENT_SIZE
+                        );
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "invalid RSA exponent size",
+                        ));
+                    }
+
+                    let mut exp_bytes = [0u8; TD_PAYLOAD_SIGN_RSA_EXPONENT_SIZE];
+                    exp_bytes[TD_PAYLOAD_SIGN_RSA_EXPONENT_SIZE - exponent.len()..]
+                        .copy_from_slice(exponent);
+
+                    let mut signature: Vec<u8> = vec![0; rsa_keypair.public_modulus_len()];
+                    rsa_keypair
+                        .sign(&RSA_PSS_SHA384, &rng, &self.signed_image, &mut signature)
+                        .map_err(|e| {
+                            error!("Failed to sign message with RSA: {}", e);
+                            io::Error::new(io::ErrorKind::Other, "failed to sign message")
+                        })?;
+
+                    self.signed_image.extend_from_slice(&modulus);
+                    self.signed_image.extend_from_slice(&exp_bytes);
+                    self.signed_image.extend_from_slice(signature.as_slice());
+                }
+                SigningAlgorithm::EcdsaNistP384Sha384(ecdsa_keypair) => {
+                    let public_key = ecdsa_keypair.public_key().as_ref();
+                    // 0x4 -- Uncompressed
+                    // 0x0 -- Compressed
+                    if public_key[0] != 0x4 {
+                        error!("Invalid ECDSA data format: {}", public_key[0],);
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "Invalid ECDSA data format",
+                        ));
+                    }
+
+                    let signature = ecdsa_keypair
+                        .sign(&rng, self.signed_image.as_slice())
+                        .map_err(|e| {
+                            error!("Failed to sign message with ECDSA: {}", e);
+                            io::Error::new(io::ErrorKind::Other, "failed to sign message")
+                        })?;
+
+                    self.signed_image.extend_from_slice(&public_key[1..]);
+                    self.signed_image.extend_from_slice(signature.as_ref());
+                }
+            }
+
+            Ok(self.signed_image.as_slice())
+        }
+
+        pub fn build_header(&self, payload_version: u64, payload_svn: u64) -> PayloadSignHeader {
+            let signing_algorithm = match self.algorithm {
+                SigningAlgorithm::EcdsaNistP384Sha384(_) => 1,
+                SigningAlgorithm::Rsapss3072Sha384(_) => 2,
+            };
+            let length = (self.raw_image.len() + size_of::<PayloadSignHeader>()) as u32;
+
+            PayloadSignHeader {
+                type_guid: *TD_PAYLOAD_SIGN_HEADER_GUID.as_bytes(),
+                struct_version: 0x1,
+                length,
+                payload_version,
+                payload_svn,
+                signing_algorithm,
+                reserved: 0,
+            }
         }
     }
 }

--- a/td-shim-sign-payload/src/main.rs
+++ b/td-shim-sign-payload/src/main.rs
@@ -12,9 +12,9 @@ use env_logger::Env;
 use log::{error, trace, LevelFilter};
 use ring::signature::{EcdsaKeyPair, RsaKeyPair, ECDSA_P384_SHA384_FIXED_SIGNING};
 use td_layout::build_time::TD_SHIM_PAYLOAD_SIZE;
-use td_shim_ld::{InputData, OutputFile};
+use td_shim_ld::linker::{InputData, OutputFile};
 
-use td_shim_sign_payload::*;
+use td_shim_sign_payload::signer::{PayloadSigner, SigningAlgorithm};
 
 const SIGNED_TDPAYLOAD_NAME: &str = "td-payload-signed";
 


### PR DESCRIPTION
The second part of td-shim refactor:
1) share common code among td-shim-ld. td-shim-enroll-key, td-shim-sign-payload and rust-tdshim/verifier.
2) refine tcg/verifier.
3) add feature "tdx" to rust-tdshim.