### PR TITLE
td-shim: add more kernel image type to KernelInfo HOB

### DIFF
--- a/doc/tdshim_spec.md
+++ b/doc/tdshim_spec.md
@@ -363,10 +363,13 @@ typedef enum {
   //   plus 0x200
   PayloadImageTypeBzImage,
 
+  // Payload Binary is vmlinux, follow Linux boot protocol.
+  // It's an ELF64 binary image.
+  PayloadImageTypeVmLinux,
+
   // Payload Binary is VMM loaded vmLinux, follow Linux boot protocol.
   // The entrypoint is defined at HOB_PAYLOAD_INFO_TABLE.Entrypoint.
   PayloadImageTypeRawVmLinux,
-
 
 } PAYLOAD_IMAGE_TYPE;
 


### PR DESCRIPTION
Add more kernel image type to the KernelInfo HOB, for vmlinux and auto-detection.