### PR TITLE
[main] td-uefi-pi: a simple wrapper over r-efi for td-shim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 	"devtools/test-runner-server",
 	"td-layout",
 	"td-paging",
+	"td-uefi-pi",
 	"tdx-tdcall",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ else
 	export BUILD_TYPE_FLAG=
 endif
 
-GENERIC_LIB_CRATES = td-layout
+GENERIC_LIB_CRATES = td-layout td-uefi-pi
 NIGHTLY_LIB_CRATES = td-paging tdx-tdcall
 SHIM_CRATES = 
 TEST_CRATES = 

--- a/td-uefi-pi/Cargo.toml
+++ b/td-uefi-pi/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "td-uefi-pi"
+version = "0.1.0"
+description = "UEFI Platform Initializaiton data structures and accessors"
+repository = "https://github.com/confidential-containers/td-shim"
+homepage = "https://github.com/confidential-containers"
+license = "BSD-2-Clause-Patent"
+edition = "2018"
+
+[dependencies]
+log = "0.4.13"
+r-efi = "3.2.0"
+scroll = { version = "0.10", default-features = false, features = ["derive"] }

--- a/td-uefi-pi/src/fv.rs
+++ b/td-uefi-pi/src/fv.rs
@@ -1,0 +1,147 @@
+// Copyright © 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Functions to access UEFI-PI defined `Firmware Volumes`.
+
+use r_efi::efi::Guid;
+use scroll::Pread;
+
+use crate::pi::fv::*;
+
+pub fn get_image_from_fv(
+    fv_data: &[u8],
+    fv_file_type: FvFileType,
+    section_type: SectionType,
+) -> Option<&[u8]> {
+    let fv_header: FirmwareVolumeHeader = fv_data.pread(0).ok()?;
+    if fv_header.signature != FVH_SIGNATURE {
+        return None;
+    }
+
+    let files = Files::parse(fv_data, fv_header.header_length as usize)?;
+    for (file_header, file_data) in files {
+        if file_header.r#type == fv_file_type {
+            return get_image_from_sections(file_data, section_type);
+        }
+    }
+
+    None
+}
+
+pub fn get_file_from_fv(
+    fv_data: &[u8],
+    fv_file_type: FvFileType,
+    file_name: Guid,
+) -> Option<&[u8]> {
+    let fv_header: FirmwareVolumeHeader = fv_data.pread(0).ok()?;
+    if fv_header.signature != FVH_SIGNATURE {
+        return None;
+    }
+
+    let files = Files::parse(fv_data, fv_header.header_length as usize)?;
+    for (file_header, file_data) in files {
+        if file_header.r#type == fv_file_type && &file_header.name == file_name.as_bytes() {
+            return Some(file_data);
+        }
+    }
+
+    None
+}
+
+fn get_image_from_sections(sections_data: &[u8], section_type: SectionType) -> Option<&[u8]> {
+    let sections = Sections::parse(sections_data, 0)?;
+
+    for (section_header, section_data) in sections {
+        if section_header.r#type == section_type {
+            return Some(section_data);
+        }
+    }
+
+    None
+}
+
+struct Sections<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> Sections<'a> {
+    pub fn parse(sections_buffer: &'a [u8], offset: usize) -> Option<Self> {
+        Some(Sections {
+            buffer: &sections_buffer[offset..],
+        })
+    }
+}
+
+impl<'a> Iterator for Sections<'a> {
+    type Item = (CommonSectionHeader, &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        const HEADER_SIZE: usize = core::mem::size_of::<CommonSectionHeader>();
+        let header: CommonSectionHeader = self.buffer.pread(0).ok()?;
+        let section_size = header.size[0] as usize
+            + ((header.size[1] as usize) << 8)
+            + ((header.size[2] as usize) << 16);
+        section_size.checked_sub(HEADER_SIZE)?;
+        self.buffer.len().checked_sub(section_size)?;
+        let buf = &self.buffer[HEADER_SIZE..section_size];
+
+        // Align to 4 bytes.
+        let section_size = (section_size + 3) & !3;
+        if section_size < self.buffer.len() {
+            self.buffer = &self.buffer[section_size..];
+        } else {
+            self.buffer = &self.buffer[0..0];
+        }
+
+        Some((header, buf))
+    }
+}
+
+struct Files<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> Files<'a> {
+    pub fn parse(fv_buffer: &'a [u8], fv_header_size: usize) -> Option<Self> {
+        Some(Files {
+            buffer: &fv_buffer[fv_header_size..],
+        })
+    }
+}
+
+impl<'a> Iterator for Files<'a> {
+    type Item = (FfsFileHeader, &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        const HEADER_SIZE: usize = core::mem::size_of::<FfsFileHeader>();
+
+        let header: FfsFileHeader = self.buffer.pread(0).ok()?;
+        let data_size = header.size[0] as usize
+            + ((header.size[1] as usize) << 8)
+            + ((header.size[2] as usize) << 16);
+        data_size.checked_sub(HEADER_SIZE)?;
+        self.buffer.len().checked_sub(data_size)?;
+        let buf = &self.buffer[HEADER_SIZE..data_size];
+
+        // Align to 8 bytes.
+        let data_size = (data_size + 7) & !7;
+        if data_size < self.buffer.len() {
+            self.buffer = &self.buffer[data_size..];
+        } else {
+            self.buffer = &self.buffer[0..0];
+        }
+
+        Some((header, buf))
+    }
+}

--- a/td-uefi-pi/src/hob.rs
+++ b/td-uefi-pi/src/hob.rs
@@ -1,0 +1,453 @@
+// Copyright © 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Functions to access UEFI-PI defined `Hand-Off Block` (HOB) list.
+
+use core::mem::size_of;
+use scroll::Pread;
+
+use crate::pi::hob::*;
+
+const SIZE_4G: u64 = 0x100000000u64;
+
+/// Validate and align to next HOB header position.
+pub fn align_to_next_hob_offset(cap: usize, offset: usize, length: u16) -> Option<usize> {
+    if length == 0 || length > (u16::MAX - 7) {
+        None
+    } else {
+        let offset = offset.checked_add((length as usize + 7) / 8 * 8)?;
+        if offset < cap {
+            Some(offset)
+        } else {
+            None
+        }
+    }
+}
+
+/// Seek to next available HOB entry in the buffer.
+pub fn seek_to_next_hob(hob_list: &'_ [u8]) -> Option<&'_ [u8]> {
+    let header: Header = hob_list.pread(0).ok()?;
+    let offset = align_to_next_hob_offset(hob_list.len(), 0, header.length)?;
+
+    Some(&hob_list[offset..])
+}
+
+/// Get size of the HOB list.
+///
+/// The caller needs to verify that the returned size is valid.
+pub fn get_hob_total_size(hob: &[u8]) -> Option<usize> {
+    let phit: HandoffInfoTable = hob.pread(0).ok()?;
+    if phit.header.r#type == HOB_TYPE_HANDOFF
+        && phit.header.length as usize >= size_of::<HandoffInfoTable>()
+    {
+        let end = phit.efi_end_of_hob_list.checked_sub(hob.as_ptr() as u64)?;
+        if end < usize::MAX as u64 {
+            Some(end as usize)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+/// Dump the HOB list.
+pub fn dump_hob(hob_list: &[u8]) -> Option<()> {
+    let mut offset = 0;
+
+    loop {
+        let hob = &hob_list[offset..];
+        let header: Header = hob.pread(0).ok()?;
+
+        match header.r#type {
+            HOB_TYPE_HANDOFF => {
+                let phit_hob: HandoffInfoTable = hob.pread(0).ok()?;
+                phit_hob.dump();
+            }
+            HOB_TYPE_RESOURCE_DESCRIPTOR => {
+                let resource_hob: ResourceDescription = hob.pread(0).ok()?;
+                resource_hob.dump();
+            }
+            HOB_TYPE_MEMORY_ALLOCATION => {
+                let allocation_hob: MemoryAllocation = hob.pread(0).ok()?;
+                allocation_hob.dump();
+            }
+            HOB_TYPE_FV => {
+                let fv_hob: FirmwareVolume = hob.pread(0).ok()?;
+                fv_hob.dump();
+            }
+            HOB_TYPE_CPU => {
+                let cpu_hob: Cpu = hob.pread(0).ok()?;
+                cpu_hob.dump();
+            }
+            HOB_TYPE_END_OF_HOB_LIST => return Some(()),
+            _ => header.dump(),
+        }
+
+        offset = align_to_next_hob_offset(hob_list.len(), offset, header.length)?;
+    }
+}
+
+/// Find Top of Lower Memory, which is the highest system memory address below 4G.
+///
+/// The low memory will be used for data storage (stack/heap/pagetable/eventlog/...)
+pub fn get_system_memory_size_below_4gb(hob_list: &[u8]) -> Option<u64> {
+    let mut low_mem_top = 0u64; // TOLUD (top of low usable dram)
+    let mut offset = 0;
+
+    loop {
+        let hob = &hob_list[offset..];
+        let header: Header = hob.pread(0).ok()?;
+
+        match header.r#type {
+            HOB_TYPE_RESOURCE_DESCRIPTOR => {
+                let resource_hob: ResourceDescription = hob.pread(0).ok()?;
+                if resource_hob.resource_type == RESOURCE_SYSTEM_MEMORY {
+                    let end = resource_hob
+                        .physical_start
+                        .checked_add(resource_hob.resource_length)?;
+                    if end < SIZE_4G && end > low_mem_top {
+                        low_mem_top = end;
+                    }
+                }
+            }
+            HOB_TYPE_END_OF_HOB_LIST => break,
+            _ => {}
+        }
+
+        offset = align_to_next_hob_offset(hob_list.len(), offset, header.length)?;
+    }
+
+    Some(low_mem_top)
+}
+
+/// Find Top of Memory, which is the highest system memory address below 4G.
+pub fn get_total_memory_top(hob_list: &[u8]) -> Option<u64> {
+    let mut mem_top = 0; // TOM (top of memory)
+    let mut offset = 0;
+
+    loop {
+        let hob = &hob_list[offset..];
+        let header: Header = hob.pread(0).ok()?;
+
+        match header.r#type {
+            HOB_TYPE_RESOURCE_DESCRIPTOR => {
+                let resource_hob: ResourceDescription = hob.pread(0).ok()?;
+                // TODO: why is RESOURCE_MEMORY_MAPPED_IO included for memory?
+                if resource_hob.resource_type == RESOURCE_SYSTEM_MEMORY
+                    || resource_hob.resource_type == RESOURCE_MEMORY_MAPPED_IO
+                {
+                    let end = resource_hob
+                        .physical_start
+                        .checked_add(resource_hob.resource_length)?;
+                    if end > mem_top {
+                        mem_top = end;
+                    }
+                }
+            }
+            HOB_TYPE_END_OF_HOB_LIST => break,
+            _ => {}
+        }
+        offset = align_to_next_hob_offset(hob_list.len(), offset, header.length)?;
+    }
+
+    Some(mem_top)
+}
+
+pub fn get_fv(hob_list: &[u8]) -> Option<FirmwareVolume> {
+    let mut offset = 0;
+
+    loop {
+        let hob = &hob_list[offset..];
+        let header: Header = hob.pread(0).ok()?;
+        match header.r#type {
+            HOB_TYPE_FV => {
+                let fv_hob: FirmwareVolume = hob.pread(0).ok()?;
+                return Some(fv_hob);
+            }
+            HOB_TYPE_END_OF_HOB_LIST => break,
+            _ => {}
+        }
+        offset = align_to_next_hob_offset(hob_list.len(), offset, header.length)?;
+    }
+
+    None
+}
+
+/// Find a GUID HOB entry matching `guid`.
+pub fn get_next_extension_guid_hob<'a>(hob_list: &'a [u8], guid: &[u8]) -> Option<&'a [u8]> {
+    let mut offset = 0;
+
+    loop {
+        let hob = &hob_list[offset..];
+        let header: Header = hob.pread(0).ok()?;
+
+        match header.r#type {
+            HOB_TYPE_GUID_EXTENSION => {
+                let guid_hob: GuidExtension = hob.pread(0).ok()?;
+                if guid_hob.name == guid {
+                    return Some(hob);
+                }
+            }
+            HOB_TYPE_END_OF_HOB_LIST => break,
+            _ => {}
+        }
+        offset = align_to_next_hob_offset(hob_list.len(), offset, header.length)?;
+    }
+    None
+}
+
+/// Get content of a GUID HOB entry.
+pub fn get_guid_data(hob_list: &[u8]) -> Option<&[u8]> {
+    let guid_hob: GuidExtension = hob_list.pread(0).ok()?;
+    let offset = size_of::<GuidExtension>();
+    let end = guid_hob.header.length as usize;
+
+    if end >= offset && end <= hob_list.len() {
+        Some(&hob_list[offset..end])
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::ptr::slice_from_raw_parts;
+
+    #[test]
+    fn test_align_to_next_hob() {
+        assert!(align_to_next_hob_offset(usize::MAX, 0, 0).is_none());
+        assert!(align_to_next_hob_offset(8, 8, 1).is_none());
+        assert_eq!(align_to_next_hob_offset(usize::MAX, 8, 1), Some(16));
+        assert_eq!(align_to_next_hob_offset(usize::MAX, 8, 9), Some(24));
+        assert_eq!(
+            align_to_next_hob_offset(usize::MAX, 0, u16::MAX - 8),
+            Some(u16::MAX as usize - 7)
+        );
+        assert_eq!(
+            align_to_next_hob_offset(usize::MAX, 0, u16::MAX - 7),
+            Some(u16::MAX as usize - 7)
+        );
+        assert_eq!(
+            align_to_next_hob_offset(usize::MAX, 8, u16::MAX - 7),
+            Some(u16::MAX as usize + 1)
+        );
+        assert!(align_to_next_hob_offset(usize::MAX, 0, u16::MAX - 6).is_none());
+        assert!(align_to_next_hob_offset(usize::MAX, 8, u16::MAX).is_none());
+    }
+
+    #[test]
+    fn test_get_hob_total_size() {
+        assert!(get_hob_total_size(&[]).is_none());
+
+        let mut tbl = HandoffInfoTable {
+            header: Header {
+                r#type: HOB_TYPE_HANDOFF,
+                length: size_of::<HandoffInfoTable>() as u16,
+                reserved: 0,
+            },
+            version: 1,
+            boot_mode: 0,
+            efi_memory_top: 0x2_0000_0000,
+            efi_memory_bottom: 0xc000_0000,
+            efi_free_memory_top: 0,
+            efi_free_memory_bottom: 0,
+            efi_end_of_hob_list: 0,
+        };
+        let buf = unsafe {
+            &*slice_from_raw_parts(
+                &tbl as *const HandoffInfoTable as *const u8,
+                size_of::<HandoffInfoTable>(),
+            )
+        };
+        assert!(get_hob_total_size(buf).is_none());
+
+        let end = &tbl as *const HandoffInfoTable as *const u8 as usize as u64 + 0x10000;
+        tbl.efi_end_of_hob_list = end;
+        assert_eq!(get_hob_total_size(buf), Some(0x10000));
+    }
+
+    #[test]
+    fn test_dump_hob() {
+        assert!(dump_hob(&[]).is_none());
+        assert!(dump_hob(&[0u8]).is_none());
+    }
+
+    #[test]
+    fn test_get_system_memory_size_below_4gb() {
+        assert!(get_system_memory_size_below_4gb(&[]).is_none());
+
+        let mut buf = [0u8; 1024];
+        let res = ResourceDescription {
+            header: Header {
+                r#type: HOB_TYPE_RESOURCE_DESCRIPTOR,
+                length: size_of::<ResourceDescription>() as u16,
+                reserved: 0,
+            },
+            owner: [0u8; 16],
+            resource_type: RESOURCE_SYSTEM_MEMORY,
+            resource_attribute: 0,
+            physical_start: 0,
+            resource_length: 0x200_0000,
+        };
+        let buf1 = unsafe {
+            &*slice_from_raw_parts(
+                &res as *const ResourceDescription as *const u8,
+                size_of::<ResourceDescription>(),
+            )
+        };
+        buf[..size_of::<ResourceDescription>()].copy_from_slice(buf1);
+        let res = ResourceDescription {
+            header: Header {
+                r#type: HOB_TYPE_RESOURCE_DESCRIPTOR,
+                length: size_of::<ResourceDescription>() as u16,
+                reserved: 0,
+            },
+            owner: [0u8; 16],
+            resource_type: RESOURCE_SYSTEM_MEMORY,
+            resource_attribute: 0,
+            physical_start: 0x1000_0000,
+            resource_length: 0x200_0000,
+        };
+        let buf1 = unsafe {
+            &*slice_from_raw_parts(
+                &res as *const ResourceDescription as *const u8,
+                size_of::<ResourceDescription>(),
+            )
+        };
+        buf[size_of::<ResourceDescription>()..2 * size_of::<ResourceDescription>()]
+            .copy_from_slice(buf1);
+        let end = Header {
+            r#type: HOB_TYPE_END_OF_HOB_LIST,
+            length: 0,
+            reserved: 0,
+        };
+        let buf2 = unsafe {
+            &*slice_from_raw_parts(&end as *const Header as *const u8, size_of::<Header>())
+        };
+        buf[2 * size_of::<ResourceDescription>()
+            ..2 * size_of::<ResourceDescription>() + size_of::<Header>()]
+            .copy_from_slice(buf2);
+        assert_eq!(get_system_memory_size_below_4gb(&buf), Some(0x1200_0000));
+
+        let res = ResourceDescription {
+            header: Header {
+                r#type: HOB_TYPE_RESOURCE_DESCRIPTOR,
+                length: 0,
+                reserved: 0,
+            },
+            owner: [0u8; 16],
+            resource_type: RESOURCE_SYSTEM_MEMORY,
+            resource_attribute: 0,
+            physical_start: 0,
+            resource_length: 0x200_0000,
+        };
+        let buf1 = unsafe {
+            &*slice_from_raw_parts(
+                &res as *const ResourceDescription as *const u8,
+                size_of::<ResourceDescription>(),
+            )
+        };
+        buf[..size_of::<ResourceDescription>()].copy_from_slice(buf1);
+        assert!(get_system_memory_size_below_4gb(&buf).is_none());
+    }
+
+    #[test]
+    fn test_get_fv() {
+        assert!(get_fv(&[]).is_none());
+
+        let mut buf = [0u8; 1024];
+        let res = FirmwareVolume {
+            header: Header {
+                r#type: HOB_TYPE_FV,
+                length: size_of::<FirmwareVolume>() as u16,
+                reserved: 0,
+            },
+            base_address: 0x1000000,
+            length: 0,
+        };
+        let buf1 = unsafe {
+            &*slice_from_raw_parts(
+                &res as *const FirmwareVolume as *const u8,
+                size_of::<FirmwareVolume>(),
+            )
+        };
+        buf[..size_of::<FirmwareVolume>()].copy_from_slice(buf1);
+        let end = Header {
+            r#type: HOB_TYPE_END_OF_HOB_LIST,
+            length: 0,
+            reserved: 0,
+        };
+        let buf2 = unsafe {
+            &*slice_from_raw_parts(&end as *const Header as *const u8, size_of::<Header>())
+        };
+        buf[size_of::<FirmwareVolume>()..size_of::<FirmwareVolume>() + size_of::<Header>()]
+            .copy_from_slice(buf2);
+        assert!(get_fv(&buf).is_some());
+
+        let res = FirmwareVolume {
+            header: Header {
+                r#type: HOB_TYPE_FV2,
+                length: u16::MAX,
+                reserved: 0,
+            },
+            base_address: 0x1000000,
+            length: 0,
+        };
+        let buf1 = unsafe {
+            &*slice_from_raw_parts(
+                &res as *const FirmwareVolume as *const u8,
+                size_of::<FirmwareVolume>(),
+            )
+        };
+        buf[..size_of::<FirmwareVolume>()].copy_from_slice(buf1);
+        assert!(get_fv(&buf).is_none());
+    }
+
+    #[test]
+    fn test_get_guid() {
+        assert!(get_next_extension_guid_hob(&[], &[0u8; 16]).is_none());
+
+        let mut buf = [0xaau8; 128];
+        let res = GuidExtension {
+            header: Header {
+                r#type: HOB_TYPE_GUID_EXTENSION,
+                length: size_of::<GuidExtension>() as u16 + 16,
+                reserved: 0,
+            },
+            name: [0xa5u8; 16],
+        };
+        let buf1 = unsafe {
+            &*slice_from_raw_parts(
+                &res as *const GuidExtension as *const u8,
+                size_of::<GuidExtension>(),
+            )
+        };
+        buf[..size_of::<GuidExtension>()].copy_from_slice(buf1);
+        let end = Header {
+            r#type: HOB_TYPE_END_OF_HOB_LIST,
+            length: 0,
+            reserved: 0,
+        };
+        let buf2 = unsafe {
+            &*slice_from_raw_parts(&end as *const Header as *const u8, size_of::<Header>())
+        };
+        buf[size_of::<GuidExtension>() + 16..size_of::<GuidExtension>() + 16 + size_of::<Header>()]
+            .copy_from_slice(buf2);
+        let guid = get_next_extension_guid_hob(&buf, &[0xa5u8; 16]).unwrap();
+        let data = get_guid_data(guid).unwrap();
+        assert_eq!(data, &[0xaa; 16]);
+    }
+}

--- a/td-uefi-pi/src/lib.rs
+++ b/td-uefi-pi/src/lib.rs
@@ -1,0 +1,28 @@
+// Copyright © 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! UEFI Platform Initialization data structures and accessors.
+//!
+//! This crate defines constants and data structures defined by the
+//! [UEFI-PI Spec](https://uefi.org/sites/default/files/resources/PI_Spec_1_6.pdf)
+//! and needed by the `td-shim` project. It also provides functions to parse those data structures
+//! from raw data buffer.
+//!
+//! Constants and data structures defined by [UEFI PI Spec] are hosted by [crate::pi], functions
+//! to access them are hosted by [crate::fv] and [crate::hob].
+#![no_std]
+
+pub mod fv;
+pub mod hob;
+pub mod pi;

--- a/td-uefi-pi/src/pi/boot_mode.rs
+++ b/td-uefi-pi/src/pi/boot_mode.rs
@@ -1,0 +1,30 @@
+// Copyright © 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Boot mode defined in [UEFI-PI Spec](https://uefi.org/sites/default/files/resources/PI_Spec_1_6.pdf),
+//! section "4.3 Boot Mode Services".
+pub type BootMode = u32;
+
+pub const BOOT_WITH_FULL_CONFIGURATION: u32 = 0x00;
+pub const BOOT_WITH_MINIMAL_CONFIGURATION: u32 = 0x01;
+pub const BOOT_ASSUMING_NO_CONFIGURATION_CHANGES: u32 = 0x02;
+pub const BOOT_WITH_FULL_CONFIGURATION_PLUS_DIAGNOSTICS: u32 = 0x03;
+pub const BOOT_WITH_DEFAULT_SETTINGS: u32 = 0x04;
+pub const BOOT_ON_S4_RESUME: u32 = 0x05;
+pub const BOOT_ON_S5_RESUME: u32 = 0x06;
+pub const BOOT_WITH_MFG_MODE_SETTINGS: u32 = 0x07;
+pub const BOOT_ON_S2_RESUME: u32 = 0x10;
+pub const BOOT_ON_S3_RESUME: u32 = 0x11;
+pub const BOOT_ON_FLASH_UPDATE: u32 = 0x12;
+pub const BOOT_IN_RECOVERY_MODE: u32 = 0x20;

--- a/td-uefi-pi/src/pi/fv.rs
+++ b/td-uefi-pi/src/pi/fv.rs
@@ -1,0 +1,268 @@
+// Copyright © 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! UEFI-PI storage service.
+//!
+//! The UEFI storage service is composed of Firmware Volume, Firmware Filesystem, File and Section.
+//!
+//! A Firmware Volume (FV) is a logical firmware device. In this specification, the basic storage
+//! repository for data and/or code is the firmware volume. Each firmware volume is organized into
+//! a  file system. As such, the file is the base unit of storage for firmware.
+//!
+//! A firmware file system (FFS) describes the organization of files and (optionally) free space
+//! within the firmware volume. Each firmware file system has a unique GUID, which is used by the
+//! firmware to associate a driver with a newly exposed firmware volume.
+//!
+//! Firmware files are code and/or data stored in firmware volumes. A firmware file may contain
+//! multiple sections.
+//!
+//! Firmware file sections are separate discrete “parts” within certain file types.
+use core::mem::size_of;
+use core::ptr::slice_from_raw_parts;
+use r_efi::efi::Guid;
+use scroll::{Pread, Pwrite};
+
+pub type FvbAttributes2 = u32;
+
+/// Firmware volume signature defined in [UEFI-PI] section 3.2.1
+pub const FVH_SIGNATURE: u32 = 0x4856465F; // '_','F','V','H'
+
+/// Firmware volume header defined in [UEFI-PI] section "3.2.1 Firmware Volume".
+///
+/// A firmware volume based on a block device begins with a header that describes the features and
+/// layout of the firmware volume. This header includes a description of the capabilities, state,
+/// and block map of the device.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite, Default)]
+pub struct FirmwareVolumeHeader {
+    pub zero_vector: [u8; 16],
+    pub file_system_guid: [u8; 16], // Guid
+    pub fv_length: u64,
+    pub signature: u32,
+    pub attributes: FvbAttributes2,
+    pub header_length: u16,
+    pub checksum: u16,
+    pub ext_header_offset: u16,
+    pub reserved: u8,
+    pub revision: u8,
+}
+
+impl FirmwareVolumeHeader {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// Firmware block map.
+///
+/// The block map is a run-length-encoded array of logical block definitions. This design allows a
+/// reasonable mechanism of describing the block layout of typical firmware devices. Each block can
+/// be referenced by its logical block address (LBA). The LBA is a zero-based enumeration of all of
+/// the blocks—i.e., LBA 0 is the first block, LBA 1 is the second block, and LBA n is the (n-1)
+/// device. The header is always located at the beginning of LBA 0.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite, Default)]
+pub struct FvBlockMap {
+    pub num_blocks: u32,
+    pub length: u32,
+}
+
+impl FvBlockMap {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// Firmware Volume Extended Header pointed to by `FirmwareVolumeHeader::ext_header_offset`.
+///
+/// The extended header is followed by zero or more variable length extension entries.
+/// Each extension entry is prefixed with the EFI_FIRMWARE_VOLUME_EXT_ENTRY structure, which
+/// defines the type and size of the extension entry. The extended header is always 32-bit aligned
+/// relative to the start of the FIRMWARE VOLUME.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite, Default)]
+pub struct FirmwareVolumeExtHeader {
+    pub fv_name: [u8; 16], // Guid
+    pub ext_header_size: u32,
+}
+
+impl FirmwareVolumeExtHeader {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// Firmware volume extension entry.
+///
+/// After the extension header, there is an array of variable-length extension header entries,
+/// each prefixed with the EFI_FIRMWARE_VOLUME_EXT_ENTRY structure.
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct FirmwareVolumeExtEntry {
+    pub ext_entry_size: u16,
+    pub ext_entry_type: u32,
+}
+
+impl FirmwareVolumeExtEntry {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// EFI_FIRMWARE_FILE_SYSTEM2_GUID defined in [UEFI-PI Spec], section 3.2.2
+pub const FIRMWARE_FILE_SYSTEM2_GUID: r_efi::base::Guid = r_efi::base::Guid::from_fields(
+    0x8c8ce578,
+    0x8a3d,
+    0x4f1c,
+    0x99,
+    0x35,
+    &[0x89, 0x61, 0x85, 0xc3, 0x2d, 0xd3],
+);
+
+/// EFI_FIRMWARE_FILE_SYSTEM3_GUID defined in [UEFI-PI Spec], section 3.2.2
+pub const FIRMWARE_FILE_SYSTEM3_GUID: r_efi::base::Guid = r_efi::base::Guid::from_fields(
+    0x5473c07a,
+    0x3dcb,
+    0x4dca,
+    0xbd,
+    0x6f,
+    &[0x1e, 0x96, 0x89, 0xe7, 0x34, 0x9a],
+);
+
+/// Firmware File Types defined in [UEFI-PI], section 2.1.4.1
+pub type FvFileType = u8;
+
+pub const FV_FILETYPE_RAW: u8 = 0x01;
+pub const FV_FILETYPE_FREEFORM: u8 = 0x02;
+pub const FV_FILETYPE_SECURITY_CORE: u8 = 0x03;
+pub const FV_FILETYPE_PEI_CORE: u8 = 0x04;
+pub const FV_FILETYPE_DXE_CORE: u8 = 0x05;
+pub const FV_FILETYPE_PEIM: u8 = 0x06;
+pub const FV_FILETYPE_DRIVER: u8 = 0x07;
+pub const FV_FILETYPE_COMBINED_PEIM_DRIVER: u8 = 0x08;
+pub const FV_FILETYPE_APPLICATION: u8 = 0x09;
+pub const FV_FILETYPE_MM: u8 = 0x0A;
+pub const FV_FILETYPE_FIRMWARE_VOLUME_IMAGE: u8 = 0x0B;
+pub const FV_FILETYPE_COMBINED_MM_DXE: u8 = 0x0C;
+pub const FV_FILETYPE_MM_CORE: u8 = 0x0D;
+pub const FV_FILETYPE_MM_STANDALONE: u8 = 0x0E;
+pub const FV_FILETYPE_MM_CORE_STANDALONE: u8 = 0x0F;
+pub const FV_FILETYPE_FFS_PAD: u8 = 0xF0;
+
+pub type FfsFileAttributes = u8;
+pub type FfsFileState = u8;
+
+/// File Header for files smaller than 16Mb, define in [UEFI-PI Spec] section 2.2.3
+///
+/// All FFS files begin with a header that is aligned on an 8-byteboundry with respect to the
+/// beginning of the firmware volume. FFS files can contain the following parts: Header and Data.
+/// It is possible to create a file that has only a header and no data, which consumes 24 bytes
+/// of space. This type of file is known as a zero-length file. If the file contains data,
+/// the data immediately follows the header. The format of the data within a file is defined by the
+/// Type field in the header, either EFI_FFS_FILE_HEADER or EFI_FFS_FILE_HEADER2.
+/// If the file length is bigger than 16MB, EFI_FFS_FILE_HEADER2 must be used.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite, Default)]
+pub struct FfsFileHeader {
+    pub name: [u8; 16], // Guid,
+    pub integrity_check: u16,
+    pub r#type: FvFileType,
+    pub attributes: FfsFileAttributes,
+    pub size: [u8; 3],
+    pub state: FfsFileState,
+}
+
+impl FfsFileHeader {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// File Header 2 for files larger than 16Mb, define in [UEFI-PI Spec] section 2.2.3
+///
+/// All FFS files begin with a header that is aligned on an 8-byteboundry with respect to the
+/// beginning of the firmware volume. FFS files can contain the following parts: Header and Data.
+/// It is possible to create a file that has only a header and no data, which consumes 24 bytes
+/// of space. This type of file is known as a zero-length file. If the file contains data,
+/// the data immediately follows the header. The format of the data within a file is defined by the
+/// Type field in the header, either EFI_FFS_FILE_HEADER or EFI_FFS_FILE_HEADER2.
+/// If the file length is bigger than 16MB, EFI_FFS_FILE_HEADER2 must be used.
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct FfsFileHeader2 {
+    pub name: Guid,
+    pub integrity_check: u16,
+    pub r#type: FvFileType,
+    pub attributes: FfsFileAttributes,
+    pub size: [u8; 3],
+    pub state: FfsFileState,
+    pub extended_size: u32,
+}
+
+impl FfsFileHeader2 {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// Firmware File Section Types defined in [UEFI-PI], section 2.1.5.1
+pub type SectionType = u8;
+
+pub const SECTION_ALL: u8 = 0x00;
+
+pub const SECTION_COMPRESSION: u8 = 0x01;
+pub const SECTION_GUID_DEFINED: u8 = 0x02;
+pub const SECTION_DISPOSABLE: u8 = 0x03;
+
+pub const SECTION_PE32: u8 = 0x10;
+pub const SECTION_PIC: u8 = 0x11;
+pub const SECTION_TE: u8 = 0x12;
+pub const SECTION_DXE_DEPEX: u8 = 0x13;
+pub const SECTION_VERSION: u8 = 0x14;
+pub const SECTION_USER_INTERFACE: u8 = 0x15;
+pub const SECTION_COMPATIBILITY16: u8 = 0x16;
+pub const SECTION_FIRMWARE_VOLUME_IMAGE: u8 = 0x17;
+pub const SECTION_FREEFORM_SUBTYPE_GUID: u8 = 0x18;
+pub const SECTION_RAW: u8 = 0x19;
+pub const SECTION_PEI_DEPEX: u8 = 0x1B;
+pub const SECTION_MM_DEPEX: u8 = 0x1C;
+
+/// Section Header for files smaller than 16Mb, define in [UEFI-PI Spec] section 2.2.4
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite, Default)]
+pub struct CommonSectionHeader {
+    pub size: [u8; 3],
+    pub r#type: SectionType,
+}
+
+impl CommonSectionHeader {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// Section Header 2 for files larger than 16Mb, define in [UEFI-PI Spec] section 2.2.4
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct CommonSectionHeader2 {
+    pub size: [u8; 3],
+    pub r#type: SectionType,
+    pub extended_size: u32,
+}
+
+impl CommonSectionHeader2 {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}

--- a/td-uefi-pi/src/pi/hob.rs
+++ b/td-uefi-pi/src/pi/hob.rs
@@ -1,0 +1,356 @@
+// Copyright © 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::mem::size_of;
+use core::ptr::slice_from_raw_parts;
+use r_efi::efi::{Guid, PhysicalAddress};
+use scroll::{Pread, Pwrite};
+
+use super::boot_mode::BootMode;
+
+/// GUID for HOB list, defined in [UEFI-PI Spec], section "B.2 HOB List GUID".
+pub const HOB_LIST_GUID: Guid = Guid::from_fields(
+    0x7739F24C,
+    0x93D7,
+    0x11D4,
+    0x9A,
+    0x3A,
+    &[0x00, 0x90, 0x27, 0x3F, 0xC1, 0x4D],
+);
+
+/// HOB Generic Header, defined in [UEFI-PI Spec], section 5.2
+///
+/// Describes the format and size of the data inside the HOB. All HOBs must contain this generic
+/// HOB header.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite)]
+pub struct Header {
+    pub r#type: u16,
+    pub length: u16,
+    pub reserved: u32,
+}
+
+impl Header {
+    pub fn dump(&self) {
+        log::info!("Hob:\n");
+        log::info!("  header.type            - 0x{:x}\n", self.r#type);
+        log::info!("  header.length          - 0x{:x}\n", self.length);
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+pub const HOB_TYPE_HANDOFF: u16 = 0x0001;
+pub const HOB_TYPE_MEMORY_ALLOCATION: u16 = 0x0002;
+pub const HOB_TYPE_RESOURCE_DESCRIPTOR: u16 = 0x0003;
+pub const HOB_TYPE_GUID_EXTENSION: u16 = 0x0004;
+pub const HOB_TYPE_FV: u16 = 0x0005;
+pub const HOB_TYPE_CPU: u16 = 0x0006;
+pub const HOB_TYPE_MEMORY_POOL: u16 = 0x0007;
+pub const HOB_TYPE_FV2: u16 = 0x0009;
+pub const HOB_TYPE_LOAD_PEIM_UNUSED: u16 = 0x000A;
+pub const HOB_TYPE_UEFI_CAPSULE: u16 = 0x000B;
+pub const HOB_TYPE_FV3: u16 = 0x000C;
+pub const HOB_TYPE_UNUSED: u16 = 0xfffe;
+pub const HOB_TYPE_END_OF_HOB_LIST: u16 = 0xffff;
+
+/// HOB Hand Off Information Table, defined in [UEFI-PI Spec], section 5.3
+///
+/// Contains general state information used by the HOB producer phase. This HOB must be the first
+/// one in the HOB list.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite)]
+pub struct HandoffInfoTable {
+    pub header: Header,
+    pub version: u32,
+    pub boot_mode: BootMode,
+    pub efi_memory_top: PhysicalAddress,
+    pub efi_memory_bottom: PhysicalAddress,
+    pub efi_free_memory_top: PhysicalAddress,
+    pub efi_free_memory_bottom: PhysicalAddress,
+    pub efi_end_of_hob_list: PhysicalAddress,
+}
+
+impl HandoffInfoTable {
+    pub fn dump(&self) {
+        log::info!("PhitHob:\n");
+        log::info!("  version                - 0x{:x}\n", self.version);
+        log::info!("  boot_mode              - 0x{:x}\n", self.boot_mode);
+        log::info!(
+            "  efi_memory_top         - 0x{:016x}\n",
+            self.efi_memory_top
+        );
+        log::info!(
+            "  efi_memory_bottom      - 0x{:016x}\n",
+            self.efi_memory_bottom
+        );
+        log::info!(
+            "  efi_free_memory_top    - 0x{:016x}\n",
+            self.efi_free_memory_top
+        );
+        log::info!(
+            "  efi_free_memory_bottom - 0x{:016x}\n",
+            self.efi_free_memory_bottom
+        );
+        log::info!(
+            "  efi_end_of_hob_list    - 0x{:016x}\n",
+            self.efi_end_of_hob_list
+        );
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// Memory Allocation Hob Header, defined in [UEFI-PI Spec], section 5.4
+///
+/// Describes all memory ranges used during the HOB producer phase that exist outside the HOB list.
+/// This HOB type describes how memory is used, not the physical attributes of memory.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite)]
+pub struct MemoryAllocationHeader {
+    pub name: [u8; 16], // Guid
+    pub memory_base_address: PhysicalAddress,
+    pub memory_length: u64,
+    pub memory_type: u32, // MemoryType,
+    pub reserved: [u8; 4],
+}
+
+impl MemoryAllocationHeader {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// Memory Allocation Hob Entry, defined in [UEFI-PI Spec], section 5.4
+///
+///
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite)]
+pub struct MemoryAllocation {
+    pub header: Header,
+    pub alloc_descriptor: MemoryAllocationHeader,
+}
+
+impl MemoryAllocation {
+    pub fn dump(&self) {
+        log::info!(
+            "MemoryAllocation 0x{:08x} : 0x{:016x} - 0x{:016x}\n",
+            self.alloc_descriptor.memory_type as u32,
+            self.alloc_descriptor.memory_base_address,
+            self.alloc_descriptor.memory_base_address + self.alloc_descriptor.memory_length - 1,
+        );
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// Resource Descriptor HOB, defined in [UEFI-PI Spec] section 5.5.
+///
+/// The resource descriptor HOB describes the resource properties of all fixed, nonrelocatable
+/// resource ranges found on the processor host bus during the HOB producer phase. This HOB type
+/// does not describe how memory is used but instead describes the attributes of the physical
+/// memory present.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite)]
+pub struct ResourceDescription {
+    pub header: Header,
+    pub owner: [u8; 16], // Guid
+    pub resource_type: ResourceType,
+    pub resource_attribute: ResourceAttributeType,
+    pub physical_start: PhysicalAddress,
+    pub resource_length: u64,
+}
+
+impl ResourceDescription {
+    pub fn dump(&self) {
+        log::info!(
+            "ResourceDescription 0x{:08x} : 0x{:016x} - 0x{:016x} (0x{:08x})\n",
+            self.resource_type,
+            self.physical_start,
+            self.physical_start + self.resource_length - 1,
+            self.resource_attribute
+        );
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// Resource Type, defined in [UEFI-PI Spec] section 5.5.
+pub type ResourceType = u32;
+
+pub const RESOURCE_SYSTEM_MEMORY: u32 = 0x00;
+pub const RESOURCE_MEMORY_MAPPED_IO: u32 = 0x01;
+pub const RESOURCE_IO: u32 = 0x02;
+pub const RESOURCE_FIRMWARE_DEVICE: u32 = 0x03;
+pub const RESOURCE_MEMORY_MAPPED_IO_PORT: u32 = 0x04;
+pub const RESOURCE_MEMORY_RESERVED: u32 = 0x05;
+pub const RESOURCE_IO_RESERVED: u32 = 0x06;
+
+/// Resource Attribute, defined in [UEFI-PI Spec] section 5.5.
+pub type ResourceAttributeType = u32;
+
+pub const RESOURCE_ATTRIBUTE_PRESENT: u32 = 0x00000001;
+pub const RESOURCE_ATTRIBUTE_INITIALIZED: u32 = 0x00000002;
+pub const RESOURCE_ATTRIBUTE_TESTED: u32 = 0x00000004;
+
+pub const RESOURCE_ATTRIBUTE_READ_PROTECTED: u32 = 0x00000080;
+pub const RESOURCE_ATTRIBUTE_WRITE_PROTECTED: u32 = 0x00000100;
+pub const RESOURCE_ATTRIBUTE_EXECUTION_PROTECTED: u32 = 0x00000200;
+
+pub const RESOURCE_ATTRIBUTE_PERSISTENT: u32 = 0x00800000;
+pub const RESOURCE_ATTRIBUTE_MORE_RELIABLE: u32 = 0x02000000;
+
+pub const RESOURCE_ATTRIBUTE_SINGLE_BIT_ECC: u32 = 0x00000008;
+pub const RESOURCE_ATTRIBUTE_MULTIPLE_BIT_ECC: u32 = 0x00000010;
+pub const RESOURCE_ATTRIBUTE_ECC_RESERVED_1: u32 = 0x00000020;
+pub const RESOURCE_ATTRIBUTE_ECC_RESERVED_2: u32 = 0x00000040;
+
+pub const RESOURCE_ATTRIBUTE_UNCACHEABLE: u32 = 0x00000400;
+pub const RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE: u32 = 0x00000800;
+pub const RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE: u32 = 0x00001000;
+pub const RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE: u32 = 0x00002000;
+
+pub const RESOURCE_ATTRIBUTE_16_BIT_IO: u32 = 0x00004000;
+pub const RESOURCE_ATTRIBUTE_32_BIT_IO: u32 = 0x00008000;
+pub const RESOURCE_ATTRIBUTE_64_BIT_IO: u32 = 0x00010000;
+
+pub const RESOURCE_ATTRIBUTE_UNCACHED_EXPORTED: u32 = 0x00020000;
+pub const RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTED: u32 = 0x00040000;
+
+pub const RESOURCE_ATTRIBUTE_READ_PROTECTABLE: u32 = 0x00100000;
+pub const RESOURCE_ATTRIBUTE_WRITE_PROTECTABLE: u32 = 0x00200000;
+pub const RESOURCE_ATTRIBUTE_EXECUTION_PROTECTABLE: u32 = 0x00400000;
+
+pub const RESOURCE_ATTRIBUTE_PERSISTABLE: u32 = 0x01000000;
+pub const RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTABLE: u32 = 0x00080000;
+
+/// Firmware Volume HOB, defined in [UEFI-PI Spec], section 5.7
+///
+/// Details the location of firmware volumes that contain firmware files.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite)]
+pub struct FirmwareVolume {
+    pub header: Header,
+    pub base_address: PhysicalAddress,
+    pub length: u64,
+}
+
+impl FirmwareVolume {
+    pub fn dump(&self) {
+        log::info!(
+            "FirmwareVolume : 0x{:016x} - 0x{:016x}\n",
+            self.base_address,
+            self.base_address + self.length - 1
+        );
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// Firmware Volume 2 HOB, defined in [UEFI-PI Spec], section 5.7
+///
+/// Details the location of a firmware volume which was extracted from a file within another
+/// firmware volume.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite)]
+pub struct FirmwareVolume2 {
+    pub header: Header,
+    pub base_address: PhysicalAddress,
+    pub length: u64,
+    pub fv_name: [u8; 16],   // Guid
+    pub file_name: [u8; 16], // Guid
+}
+
+impl FirmwareVolume2 {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// Firmware Volume 3 HOB, defined in [UEFI-PI Spec], section 5.7
+///
+/// Details the location of a firmware volume including authentication information, for both
+/// standalone and extracted firmware volumes.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite)]
+pub struct FirmwareVolume3 {
+    pub header: Header,
+    pub base_address: PhysicalAddress,
+    pub length: u64,
+    pub authentication_status: u32,
+    pub extracted_fv: u8,    // Boolean
+    pub fv_name: [u8; 16],   // Guid
+    pub file_name: [u8; 16], // Guid
+}
+
+impl FirmwareVolume3 {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// CPU HOB, defined in [UEFI-PI Spec], section 5.8
+///
+///
+/// Describes processor information, such as address space and I/O space capabilities.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Pread, Pwrite)]
+pub struct Cpu {
+    pub header: Header,
+    pub size_of_memory_space: u8,
+    pub size_of_io_space: u8,
+    pub reserved: [u8; 6],
+}
+
+impl Cpu {
+    pub fn dump(&self) {
+        log::info!(
+            "Cpu : mem size {} , io size {}\n",
+            self.size_of_memory_space,
+            self.size_of_io_space
+        );
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}
+
+/// GUID Extension HOB, defined in [UEFI-PI Spec], section 5.6
+///
+/// Allows writers of executable content in the HOB producer phase to maintain and manage HOBs
+/// whose types are not included in this specification. Specifically, writers of executable content
+/// in the HOB producer phase can generate a GUID and name their own HOB entries using this
+/// module specific value.
+#[derive(Copy, Clone, Debug, Pread, Pwrite)]
+pub struct GuidExtension {
+    pub header: Header,
+    pub name: [u8; 16], // Guid
+}
+
+impl GuidExtension {
+    pub fn as_bytes(&self) -> &[u8] {
+        unsafe { &*slice_from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+}

--- a/td-uefi-pi/src/pi/mod.rs
+++ b/td-uefi-pi/src/pi/mod.rs
@@ -1,0 +1,19 @@
+// Copyright © 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Constants and Structures defined by the UEFI Platform Initialization (UEFI-PI) Spec.
+
+pub mod boot_mode;
+pub mod fv;
+pub mod hob;


### PR DESCRIPTION
The td-uefi-pi is a simple wrapper crate over r-efi, which provides:
1) constants and structures defined by the uefi specification
2) helper methods to handle uefi firmware volumes
3) helper methods to handle uefi HOB list.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>