### PR TITLE
td-shim: set HARDWARE_ENABLED_EXECUTION_DISABLE to be true

### DIFF
--- a/td-shim/src/bin/td-shim/td/tdx.rs
+++ b/td-shim/src/bin/td-shim/td/tdx.rs
@@ -11,7 +11,7 @@ extern "win64" {
 
 const EXTENDED_FUNCTION_INFO: u32 = 0x80000000;
 const EXTENDED_PROCESSOR_INFO: u32 = 0x80000001;
-const HARDWARE_ENABLED_EXECUTION_DISABLE: bool = false;
+const HARDWARE_ENABLED_EXECUTION_DISABLE: bool = true;
 const SHA384_DIGEST_SIZE: usize = 48;
 
 fn is_execute_disable_bit_available() -> bool {


### PR DESCRIPTION
Since EFER MSR cannot be set for now by TD, td-shim will break when
running into enable_execution_disable_bit().

In TDX, NX is enabled by default, so HARDWARE_ENABLED_EXECUTION_DISABLE
should be set to 'true'.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>