### PR TITLE
[main] td-logger: a simple logger backend for td-shim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
 	"devtools/test-runner-client",
 	"devtools/test-runner-server",
 	"td-layout",
+	"td-logger",
 	"td-paging",
 	"td-uefi-pi",
 	"tdx-tdcall",

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ else
 	export BUILD_TYPE_FLAG=
 endif
 
-GENERIC_LIB_CRATES = td-layout td-uefi-pi
+GENERIC_LIB_CRATES = td-layout td-logger td-uefi-pi
 NIGHTLY_LIB_CRATES = td-paging tdx-tdcall
 SHIM_CRATES = 
 TEST_CRATES = 

--- a/td-logger/Cargo.toml
+++ b/td-logger/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "td-logger"
+version = "0.1.0"
+description = "Simple logger backend for td-shim"
+repository = "https://github.com/confidential-containers/td-shim"
+homepage = "https://github.com/confidential-containers"
+license = "BSD-2-Clause-Patent"
+edition = "2018"
+
+[dependencies]
+lazy_static = { version = "1.0", features = ["spin_no_std"] }
+log = "0.4.13"
+spin = "0.9.2"
+tdx-tdcall = { path = "../tdx-tdcall", optional = true }
+# Lock down to 0.44, otherwise it depends on inline asm
+x86 = { version = "0.44.0", optional = true }
+
+[features]
+tdx = ["tdx-tdcall"]
+serial-port = ["x86"]

--- a/td-logger/src/lib.rs
+++ b/td-logger/src/lib.rs
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_std]
+
+use log::{Level, Metadata, Record};
+use log::{LevelFilter, SetLoggerError};
+
+mod logger;
+pub use logger::*;
+
+macro_rules! tdlog {
+    ($($arg:tt)*) => (crate::logger::_log_ex(crate::logger::LOG_LEVEL_INFO, crate::logger::LOG_MASK_ALL, format_args!($($arg)*)));
+}
+
+/// Logger backend for td-shim.
+pub struct LoggerBackend;
+
+impl log::Log for LoggerBackend {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Info
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            tdlog!("{} - {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// Logger backend for the log crate
+static LOGGER_BACKEND: LoggerBackend = LoggerBackend;
+
+pub fn init() -> Result<(), SetLoggerError> {
+    dbg_write_string("logger init\n");
+    log::set_logger(&LOGGER_BACKEND).map(|()| log::set_max_level(LevelFilter::Info))
+}
+
+/// Write a byte to the debug port, converting `\n' to '\r\n`.
+pub fn dbg_write_byte(byte: u8) {
+    if byte == b'\n' {
+        dbg_port_write(b'\r')
+    }
+    dbg_port_write(byte)
+}
+
+/// Write a string to the debug port.
+pub fn dbg_write_string(s: &str) {
+    for c in s.chars() {
+        dbg_write_byte(c as u8);
+    }
+}
+
+#[cfg(any(feature = "tdx", feature = "serial-port"))]
+const SERIAL_IO_PORT: u16 = 0x3F8;
+
+#[cfg(feature = "tdx")]
+fn dbg_port_write(byte: u8) {
+    tdx_tdcall::tdx::tdvmcall_io_write_8(SERIAL_IO_PORT, byte);
+}
+
+#[cfg(all(not(feature = "tdx"), feature = "serial-port"))]
+fn dbg_port_write(byte: u8) {
+    unsafe { x86::io::outb(SERIAL_IO_PORT, byte) };
+}
+
+#[cfg(all(not(feature = "tdx"), not(feature = "serial-port")))]
+fn dbg_port_write(_byte: u8) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_logger() {
+        init().unwrap();
+
+        assert_eq!(LOGGER.lock().get_level(), LOG_LEVEL_INFO);
+        LOGGER.lock().set_level(LOG_LEVEL_ERROR);
+        assert_eq!(LOGGER.lock().get_level(), LOG_LEVEL_ERROR);
+
+        assert_eq!(LOGGER.lock().get_mask(), LOG_MASK_ALL);
+        LOGGER.lock().set_mask(LOG_MASK_COMMON);
+        assert_eq!(LOGGER.lock().get_mask(), LOG_MASK_COMMON);
+
+        log::error!("just a test");
+    }
+}

--- a/td-logger/src/logger.rs
+++ b/td-logger/src/logger.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! A standalone logger to directly log messages, independent of the log crate.
+
+use core::fmt::{self, Write};
+use lazy_static::lazy_static;
+use spin::Mutex;
+
+use crate::{dbg_port_write, dbg_write_string};
+
+pub const LOG_LEVEL_TRACE: usize = 5;
+pub const LOG_LEVEL_DEBUG: usize = 4;
+pub const LOG_LEVEL_INFO: usize = 3;
+pub const LOG_LEVEL_WARN: usize = 2;
+pub const LOG_LEVEL_ERROR: usize = 1;
+pub const LOG_LEVEL_NONE: usize = 0;
+
+pub const LOG_MASK_COMMON: u64 = 0x1;
+pub const LOG_MASK_ALL: u64 = 0xFFFFFFFFFFFFFFFF;
+
+// Use lazy_static here to prevent potential problems caused by compiler/linker optimization.
+lazy_static! {
+    pub static ref LOGGER: Mutex<Logger> = Mutex::new(Logger {
+        level: LOG_LEVEL_INFO,
+        mask: LOG_MASK_ALL,
+    });
+}
+
+pub struct Logger {
+    level: usize,
+    mask: u64,
+}
+
+impl Logger {
+    pub fn write_byte(&mut self, byte: u8) {
+        dbg_port_write(byte);
+    }
+
+    pub fn write_string(&mut self, s: &str) {
+        dbg_write_string(s);
+    }
+
+    pub fn get_level(&self) -> usize {
+        self.level
+    }
+
+    pub fn set_level(&mut self, level: usize) {
+        self.level = level;
+    }
+
+    pub fn get_mask(&self) -> u64 {
+        self.mask
+    }
+
+    pub fn set_mask(&mut self, mask: u64) {
+        self.mask = mask;
+    }
+}
+
+impl fmt::Write for Logger {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.write_string(s);
+        Ok(())
+    }
+}
+
+/// Log the message with level and subsystem filtering.
+pub fn _log_ex(level: usize, mask: u64, args: fmt::Arguments) {
+    let mut logger = LOGGER.lock();
+    if level <= logger.get_level() && mask & logger.get_mask() != 0 {
+        logger.write_fmt(args).unwrap();
+    }
+}
+
+/// Log the message without level and subsystem filtering.
+pub fn _log(args: fmt::Arguments) {
+    LOGGER.lock().write_fmt(args).unwrap();
+}


### PR DESCRIPTION
A simple logger backend for td-shim, based on serial port.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>
Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>