### PR TITLE
[main] td-exception: manage x86 exceptions for td-shim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 	"devtools/td-layout-config",
 	"devtools/test-runner-client",
 	"devtools/test-runner-server",
+	"td-exception",
 	"td-layout",
 	"td-logger",
 	"td-paging",

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else
 endif
 
 GENERIC_LIB_CRATES = td-layout td-logger td-uefi-pi
-NIGHTLY_LIB_CRATES = td-paging tdx-tdcall
+NIGHTLY_LIB_CRATES = td-exception td-paging tdx-tdcall
 SHIM_CRATES = 
 TEST_CRATES = 
 TOOL_CRATES = 

--- a/td-exception/Cargo.toml
+++ b/td-exception/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "td-exception"
+version = "0.1.0"
+description = "Setup Interrupt Descriptor Table for td-shim"
+repository = "https://github.com/confidential-containers/td-shim"
+homepage = "https://github.com/confidential-containers"
+license = "Apache 2.0"
+edition = "2018"
+
+[dependencies]
+bitflags = "1.2.1"
+lazy_static = { version = "1.0", features = ["spin_no_std"] }
+log = "0.4.13"
+tdx-tdcall =  { path = "../tdx-tdcall", optional = true }
+x86_64 = "=0.14.6"
+
+[features]
+tdx = ["tdx-tdcall"]
+integration-test = []

--- a/td-exception/src/asm/idt.asm
+++ b/td-exception/src/asm/idt.asm
@@ -1,0 +1,43 @@
+# Copyright (c) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+.section .text
+
+#  sidt_call (
+#        OUT UINT64 addr
+# )
+.global sidt_call
+sidt_call:
+    sidt    [rcx]
+    ret
+
+
+#  lidt_call (
+#        IN UINT64 addr
+# )
+.global lidt_call
+lidt_call:
+    lidt    [rcx]
+    ret
+
+
+.global read_cs_call
+read_cs_call:
+    mov   eax, cs
+    ret
+
+.global read_cr0_call
+read_cr0_call:
+    mov   rax, cr0
+    ret
+
+.global read_rflags_call
+read_rflags_call:
+    pushf
+    pop  rax
+    ret
+
+.global read_cr4_call
+read_cr4_call:
+    mov   rax, cr4
+    ret

--- a/td-exception/src/asm/mod.rs
+++ b/td-exception/src/asm/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+global_asm!(include_str!("idt.asm"));

--- a/td-exception/src/idt.rs
+++ b/td-exception/src/idt.rs
@@ -1,0 +1,192 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! Manipulate x86_64 Interrupt Descriptor Table (IDT).
+//!
+//! Setup a stub IDT for td-shim, which assumes 1:1 mapping between physical address and virtual
+//! address in identity mapping mode.
+//!
+//! It also handles Virtualization Interrupt for Intel TDX technology.
+
+use core::mem::{self, size_of};
+use core::slice::from_raw_parts_mut;
+
+use bitflags::bitflags;
+use lazy_static::lazy_static;
+
+use crate::interrupt;
+
+extern "win64" {
+    fn sidt_call(addr: usize);
+    fn lidt_call(addr: usize);
+    fn read_cs_call() -> u16;
+}
+
+lazy_static! {
+    static ref INIT_IDT: Idt = Idt::new();
+}
+
+#[repr(C, packed)]
+pub struct DescriptorTablePointer {
+    limit: u16,
+    base: u64,
+}
+
+#[no_mangle]
+/// # Safety
+///
+/// This function is unsafe because of the lidt_call()
+pub unsafe fn init() {
+    let mut idtr = DescriptorTablePointer { limit: 1, base: 0 };
+    let current_idt = &INIT_IDT.entries;
+
+    idtr.limit = (current_idt.len() * mem::size_of::<IdtEntry>() - 1) as u16;
+    idtr.base = current_idt.as_ptr() as u64;
+
+    lidt_call(&idtr as *const DescriptorTablePointer as usize);
+}
+
+pub type IdtEntries = [IdtEntry; 256];
+
+// 8 alignment required
+#[repr(C, align(8))]
+pub struct Idt {
+    pub entries: IdtEntries,
+}
+
+impl Default for Idt {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Idt {
+    pub fn new() -> Self {
+        let mut idt = Self {
+            entries: [IdtEntry::new(); 256],
+        };
+        idt.init();
+        idt
+    }
+
+    pub fn init(&mut self) {
+        let current_idt = &mut self.entries;
+
+        // Set up exceptions
+        current_idt[0].set_func(interrupt::divide_by_zero);
+        current_idt[1].set_func(interrupt::debug);
+        current_idt[2].set_func(interrupt::non_maskable);
+        current_idt[3].set_func(interrupt::breakpoint);
+        current_idt[4].set_func(interrupt::overflow);
+        current_idt[5].set_func(interrupt::bound_range);
+        current_idt[6].set_func(interrupt::invalid_opcode);
+        current_idt[7].set_func(interrupt::device_not_available);
+        current_idt[8].set_func(interrupt::double_fault);
+        // 9 no longer available
+        current_idt[10].set_func(interrupt::invalid_tss);
+        current_idt[11].set_func(interrupt::segment_not_present);
+        current_idt[12].set_func(interrupt::stack_segment);
+        current_idt[13].set_func(interrupt::protection);
+        current_idt[14].set_func(interrupt::page);
+        // 15 reserved
+        current_idt[16].set_func(interrupt::fpu);
+        current_idt[17].set_func(interrupt::alignment_check);
+        current_idt[18].set_func(interrupt::machine_check);
+        current_idt[19].set_func(interrupt::simd);
+        #[cfg(feature = "tdx")]
+        current_idt[20].set_func(interrupt::virtualization);
+    }
+}
+
+bitflags! {
+    pub struct IdtFlags: u8 {
+        const PRESENT = 1 << 7;
+        const RING_0 = 0 << 5;
+        const RING_1 = 1 << 5;
+        const RING_2 = 2 << 5;
+        const RING_3 = 3 << 5;
+        const SS = 1 << 4;
+        const INTERRUPT = 0xE;
+        const TRAP = 0xF;
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+#[repr(C, packed)]
+pub struct IdtEntry {
+    offsetl: u16,
+    selector: u16,
+    zero: u8,
+    attribute: u8,
+    offsetm: u16,
+    offseth: u32,
+    zero2: u32,
+}
+
+impl IdtEntry {
+    pub const fn new() -> IdtEntry {
+        IdtEntry {
+            offsetl: 0,
+            selector: 0,
+            zero: 0,
+            attribute: 0,
+            offsetm: 0,
+            offseth: 0,
+            zero2: 0,
+        }
+    }
+
+    pub fn set_flags(&mut self, flags: IdtFlags) {
+        self.attribute = flags.bits;
+    }
+
+    pub fn set_offset(&mut self, selector: u16, base: usize) {
+        self.selector = selector;
+        self.offsetl = base as u16;
+        self.offsetm = (base >> 16) as u16;
+        self.offseth = (base >> 32) as u32;
+    }
+
+    // A function to set the offset more easily
+    pub fn set_func(&mut self, func: unsafe extern "C" fn()) {
+        self.set_flags(IdtFlags::PRESENT | IdtFlags::RING_0 | IdtFlags::INTERRUPT);
+        self.set_offset(unsafe { read_cs_call() }, func as usize); // GDT_KERNEL_CODE 1u16
+    }
+
+    pub fn set_ist(&mut self, index: u8) {
+        // IST: [2..0] of field zero
+        self.zero = 0x07 & index;
+    }
+}
+
+pub fn store_idtr() -> DescriptorTablePointer {
+    let mut idtr = DescriptorTablePointer { limit: 0, base: 0 };
+    unsafe {
+        sidt_call(&mut idtr as *mut DescriptorTablePointer as usize);
+    }
+    idtr
+}
+
+/// Get the Interrupt Descriptor Table from the DescriptorTablePointer.
+///
+/// ### Safety
+///
+/// The caller needs to ensure/protect from:
+/// - the DescriptorTablePointer is valid
+/// - the lifetime of the return reference
+/// - concurrent access to the returned reference
+pub unsafe fn read_idt(idtr: &DescriptorTablePointer) -> &'static mut [IdtEntry] {
+    let addr = idtr.base as *mut IdtEntry;
+    let size = (idtr.limit + 1) as usize / size_of::<IdtEntry>();
+    from_raw_parts_mut(addr, size)
+}
+
+/// Load DescriptorTablePointer `idtr` into the Interrupt Descriptor Table Register.
+///
+/// ### Safety
+///
+/// Caller needs to ensure that `idtr` is valid, otherwise behavior is undefined.
+pub unsafe fn load_idtr(idtr: &DescriptorTablePointer) {
+    lidt_call(idtr as *const DescriptorTablePointer as usize);
+}

--- a/td-exception/src/interrupt.rs
+++ b/td-exception/src/interrupt.rs
@@ -1,0 +1,414 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#[cfg(feature = "tdx")]
+use tdx_tdcall::tdx;
+
+#[repr(C, packed)]
+struct ScratchRegisters {
+    r11: usize,
+    r10: usize,
+    r9: usize,
+    r8: usize,
+    rsi: usize,
+    rdi: usize,
+    rdx: usize,
+    rcx: usize,
+    rax: usize,
+}
+
+impl ScratchRegisters {
+    fn dump(&self) {
+        log::info!("RAX:   {:>016X}\n", { self.rax });
+        log::info!("RCX:   {:>016X}\n", { self.rcx });
+        log::info!("RDX:   {:>016X}\n", { self.rdx });
+        log::info!("RDI:   {:>016X}\n", { self.rdi });
+        log::info!("RSI:   {:>016X}\n", { self.rsi });
+        log::info!("R8:    {:>016X}\n", { self.r8 });
+        log::info!("R9:    {:>016X}\n", { self.r9 });
+        log::info!("R10:   {:>016X}\n", { self.r10 });
+        log::info!("R11:   {:>016X}\n", { self.r11 });
+    }
+}
+
+macro_rules! scratch_push {
+    () => {
+        "
+        push rax
+        push rcx
+        push rdx
+        push rdi
+        push rsi
+        push r8
+        push r9
+        push r10
+        push r11
+    "
+    };
+}
+
+macro_rules! scratch_pop {
+    () => {
+        "
+        pop r11
+        pop r10
+        pop r9
+        pop r8
+        pop rsi
+        pop rdi
+        pop rdx
+        pop rcx
+        pop rax
+    "
+    };
+}
+
+#[repr(C, packed)]
+struct PreservedRegisters {
+    r15: usize,
+    r14: usize,
+    r13: usize,
+    r12: usize,
+    rbp: usize,
+    rbx: usize,
+}
+
+impl PreservedRegisters {
+    fn dump(&self) {
+        log::info!("RBX:   {:>016X}\n", { self.rbx });
+        log::info!("RBP:   {:>016X}\n", { self.rbp });
+        log::info!("R12:   {:>016X}\n", { self.r12 });
+        log::info!("R13:   {:>016X}\n", { self.r13 });
+        log::info!("R14:   {:>016X}\n", { self.r14 });
+        log::info!("R15:   {:>016X}\n", { self.r15 });
+    }
+}
+
+macro_rules! preserved_push {
+    () => {
+        "
+        push rbx
+        push rbp
+        push r12
+        push r13
+        push r14
+        push r15
+    "
+    };
+}
+
+macro_rules! preserved_pop {
+    () => {
+        "
+        pop r15
+        pop r14
+        pop r13
+        pop r12
+        pop rbp
+        pop rbx
+    "
+    };
+}
+
+#[repr(packed)]
+struct IretRegisters {
+    rip: usize,
+    cs: usize,
+    rflags: usize,
+}
+
+impl IretRegisters {
+    fn dump(&self) {
+        log::info!("RFLAG: {:>016X}\n", { self.rflags });
+        log::info!("CS:    {:>016X}\n", { self.cs });
+        log::info!("RIP:   {:>016X}\n", { self.rip });
+    }
+}
+
+#[repr(packed)]
+struct InterruptNoErrorStack {
+    preserved: PreservedRegisters,
+    scratch: ScratchRegisters,
+    iret: IretRegisters,
+}
+
+impl InterruptNoErrorStack {
+    fn dump(&self) {
+        self.iret.dump();
+        self.scratch.dump();
+        self.preserved.dump();
+    }
+}
+
+#[repr(packed)]
+struct InterruptErrorStack {
+    preserved: PreservedRegisters,
+    scratch: ScratchRegisters,
+    code: usize,
+    iret: IretRegisters,
+}
+
+impl InterruptErrorStack {
+    fn dump(&self) {
+        self.iret.dump();
+        log::info!("CODE:  {:>016X}\n", { self.code });
+        self.scratch.dump();
+        self.preserved.dump();
+    }
+}
+
+#[macro_export]
+macro_rules! interrupt_no_error {
+    ($name:ident, $stack: ident, $func:block) => {
+        #[naked]
+        #[no_mangle]
+        pub unsafe extern fn $name () {
+            #[inline(never)]
+            unsafe extern "win64" fn inner($stack: &mut InterruptNoErrorStack) {
+                $func
+            }
+
+            // Push scratch registers
+            asm!( concat!(
+                scratch_push!(),
+                preserved_push!(),
+                "
+                mov rcx, rsp
+                call {inner}
+                ",
+                preserved_pop!(),
+                scratch_pop!(),
+                "iret"
+                ),
+                inner = sym inner,
+                options(noreturn),
+            )
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! interrupt_error {
+    ($name:ident, $stack:ident, $func:block) => {
+        #[naked]
+        #[no_mangle]
+        pub unsafe extern fn $name () {
+            #[inline(never)]
+            unsafe extern "win64" fn inner($stack: &mut InterruptErrorStack) {
+                $func
+            }
+            // Push scratch registers
+            asm!( concat!(
+                scratch_push!(),
+                preserved_push!(),
+                "
+                mov rcx, rsp
+                call {inner}
+                ",
+                preserved_pop!(),
+                scratch_pop!(),
+                "
+                add rsp, 8
+                iret
+                "
+                ),
+                inner = sym inner,
+                options(noreturn),
+            )
+        }
+    };
+}
+
+#[cfg(feature = "integration-test")]
+interrupt_no_error!(divide_by_zero, stack, {
+    log::info!("Divide by zero\n");
+    crate::DIVIDED_BY_ZERO_EVENT_COUNT.fetch_add(1, core::sync::atomic::Ordering::AcqRel);
+    stack.iret.rip += 7;
+    log::info!("divide_by_zero done\n");
+    return;
+});
+
+#[cfg(not(feature = "integration-test"))]
+interrupt_no_error!(divide_by_zero, stack, {
+    log::info!("Divide by zero\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_no_error!(debug, stack, {
+    log::info!("Debug trap\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_no_error!(non_maskable, stack, {
+    log::info!("Non-maskable interrupt\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_no_error!(breakpoint, stack, {
+    log::info!("Breakpoint trap\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_no_error!(overflow, stack, {
+    log::info!("Overflow trap\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_no_error!(bound_range, stack, {
+    log::info!("Bound range exceeded fault\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_no_error!(invalid_opcode, stack, {
+    log::info!("Invalid opcode fault\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_no_error!(device_not_available, stack, {
+    log::info!("Device not available fault\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_error!(double_fault, stack, {
+    log::info!("Double fault\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_error!(invalid_tss, stack, {
+    log::info!("Invalid TSS fault\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_error!(segment_not_present, stack, {
+    log::info!("Segment not present fault\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_error!(stack_segment, stack, {
+    log::info!("Stack segment fault\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_error!(protection, stack, {
+    log::info!("Protection fault\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_error!(page, stack, {
+    let cr2: usize;
+    asm!("mov {}, cr2",  out(reg) cr2);
+    log::info!("Page fault: {:>016X}\n", cr2);
+    stack.dump();
+    deadloop();
+});
+
+interrupt_no_error!(fpu, stack, {
+    log::info!("FPU floating point fault\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_error!(alignment_check, stack, {
+    log::info!("Alignment check fault");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_no_error!(machine_check, stack, {
+    log::info!("Machine check fault\n");
+    stack.dump();
+    deadloop();
+});
+
+interrupt_no_error!(simd, stack, {
+    log::info!("SIMD floating point fault\n");
+    stack.dump();
+    deadloop();
+});
+
+#[cfg(feature = "tdx")]
+interrupt_no_error!(virtualization, stack, {
+    let op_code: u8 = *(stack.iret.rip as *const u8);
+    match op_code {
+        // IN
+        0xE4 => {
+            log::info!("<IN AL, IMM8>")
+        }
+        0xE5 => {
+            log::info!("<IN EAX, IMM8>")
+        }
+        0xEC => {
+            // log::info!("<IN AL, DX>\n");
+            let al = tdx::tdvmcall_io_read_8((stack.scratch.rdx & 0xFFFF) as u16);
+            stack.scratch.rax = (stack.scratch.rax & 0xFFFF_FFFF_FFFF_FF00_usize) | al as usize;
+            stack.iret.rip += 1;
+            // log::info!("Fault done\n");
+            return;
+        }
+        0xED => {
+            log::info!("<IN EAX, DX>");
+            let al = tdx::tdvmcall_io_read_32((stack.scratch.rdx & 0xFFFF) as u16);
+            stack.scratch.rax = (stack.scratch.rax & 0xFFFF_FFFF_0000_0000_usize) | al as usize;
+            stack.iret.rip += 1;
+            log::info!("Fault done\n");
+            return;
+        }
+        // OUT
+        0xE6 => {
+            log::info!("<OUT IMM8, AL>")
+        }
+        0xE7 => {
+            log::info!("<OUT IMM8, EAX>")
+        }
+        0xEE => {
+            // log::info!("<OUT DX, AL>\n");
+            tdx::tdvmcall_io_write_8(
+                (stack.scratch.rdx & 0xFFFF) as u16,
+                (stack.scratch.rax & 0xFF) as u8,
+            );
+            stack.iret.rip += 1;
+            // log::info!("Fault done\n");
+            return;
+        }
+        0xEF => {
+            log::info!("<OUT DX, EAX>");
+            tdx::tdvmcall_io_write_32(
+                (stack.scratch.rdx & 0xFFFF) as u16,
+                (stack.scratch.rax & 0xFFFFFFFF) as u32,
+            );
+            stack.iret.rip += 1;
+            log::info!("Fault done\n");
+            return;
+        }
+        // Unknown
+        _ => {}
+    };
+    log::info!("Virtualization fault\n");
+    stack.dump();
+    deadloop();
+});
+
+fn deadloop() {
+    // TBD: empty `loop {}` wastes CPU cycles
+    #[allow(clippy::empty_loop)]
+    loop {
+        // // Keep the same as before refactoring.
+        // x86_64::instructions::interrupts::enable();
+        // x86_64::instructions::hlt();
+        //
+    }
+}

--- a/td-exception/src/lib.rs
+++ b/td-exception/src/lib.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2020-2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! X86 exception and interrupt manager.
+//!
+//! The `td-exception` crate manages x86 exceptions and interrupts for td-shim, which implements:
+//! - interrupt/exception handlers
+//! - IDT(interrupt descriptor table) manager
+
+#![no_std]
+#![feature(asm)]
+#![feature(naked_functions)]
+#![feature(global_asm)]
+
+pub mod asm;
+pub mod idt;
+
+pub(crate) mod interrupt;
+
+/// Initialize exception/interrupt handlers.
+pub fn setup_exception_handlers() {
+    unsafe { idt::init() };
+}
+
+#[cfg(feature = "integration-test")]
+lazy_static::lazy_static! {
+    pub static ref DIVIDED_BY_ZERO_EVENT_COUNT: core::sync::atomic::AtomicU32 = core::sync::atomic::AtomicU32::new(0);
+}


### PR DESCRIPTION
The td-exception crate manages x86 exceptions for td-shim, which
provides:
1) interrupt handlers
2) interrupt table manager

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>
Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>