### PR TITLE
clap: use command!() instead of deprecated app_from_crate!()

### DIFF
--- a/devtools/test-runner-server/src/main.rs
+++ b/devtools/test-runner-server/src/main.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::{app_from_crate, arg};
+use clap::{arg, command};
 use std::{
     io,
     path::{Path, PathBuf},
@@ -33,7 +33,7 @@ const TEST_ARGS: &[&str] = &[
 const TEST_TIMEOUT_SECS: u64 = 10;
 
 fn main() {
-    let matches = app_from_crate!()
+    let matches = command!()
         .arg(
             arg!([kernel] "Path of kernel file be executed by the virtual machine")
                 .required(true)

--- a/td-shim-tools/src/bin/td-shim-enroll-key/main.rs
+++ b/td-shim-tools/src/bin/td-shim-enroll-key/main.rs
@@ -21,7 +21,7 @@ fn main() -> io::Result<()> {
         .write_style_or("MY_LOG_STYLE", "always");
     env_logger::init_from_env(env);
 
-    let matches = app_from_crate!()
+    let matches = command!()
         .about("Enroll hash value of a public key into shim binary for secure boot")
         .arg(
             arg!([tdshim] "shim binary file")

--- a/td-shim-tools/src/bin/td-shim-ld/main.rs
+++ b/td-shim-tools/src/bin/td-shim-ld/main.rs
@@ -19,7 +19,7 @@ fn main() -> io::Result<()> {
         .write_style_or("MY_LOG_STYLE", "always");
     env_logger::init_from_env(env);
 
-    let matches = app_from_crate!()
+    let matches = command!()
         .about("Link multiple shim objects into shim binary")
         .arg(
             arg!([reset_vector] "Reset_vector binary file")

--- a/td-shim-tools/src/bin/td-shim-sign-payload/main.rs
+++ b/td-shim-tools/src/bin/td-shim-sign-payload/main.rs
@@ -23,7 +23,7 @@ fn main() -> io::Result<()> {
         .write_style_or("MY_LOG_STYLE", "always");
     env_logger::init_from_env(env);
 
-    let matches = app_from_crate!()
+    let matches = command!()
         .about("Sign shim payload with given private key")
         .arg(
             arg!([key] "private key file to sign the payload")


### PR DESCRIPTION
Use command!() instead of deprecated app_from_crate!() to avoid clippy
warnings.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>