### PR TITLE
td-shim: Check build tooling

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,6 +2,11 @@ on: [push, pull_request]
 
 name: Format and Clippy
 
+env:
+  AR: llvm-ar
+  AS: nasm
+  CC: clang
+
 jobs:
   clippy:
     name: Clippy
@@ -9,6 +14,13 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
+      # Install first since it's needed to build NASM
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "10.0"
+          directory: ${{ runner.temp }}/llvm
 
       - name: install NASM
         uses: ilammy/setup-nasm@v1
@@ -28,6 +40,13 @@ jobs:
     name: Format
     runs-on: ubuntu-20.04
     steps:
+
+      # Install first since it's needed to build NASM
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "10.0"
+          directory: ${{ runner.temp }}/llvm
 
       - name: install NASM
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,9 @@ on:
 name: Ingetration Test
 
 env:
+  AR: llvm-ar
+  AS: nasm
+  CC: clang
   RUST_TOOLCHAIN: nightly-2021-08-20
   TOOLCHAIN_PROFILE: minimal
 
@@ -25,14 +28,15 @@ jobs:
           - ubuntu-20.04
 #          - windows-2019
     steps:
-      - name: install NASM
-        uses: ilammy/setup-nasm@v1
-
+      # Install first since it's needed to build NASM
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: "10.0"
           directory: ${{ runner.temp }}/llvm
+
+      - name: install NASM
+        uses: ilammy/setup-nasm@v1
 
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -10,6 +10,9 @@ on:
 name: Library Crates
 
 env:
+  AR: llvm-ar
+  AS: nasm
+  CC: clang
   RUST_TOOLCHAIN: nightly-2021-08-20
   TOOLCHAIN_PROFILE: minimal
 
@@ -25,14 +28,15 @@ jobs:
           - ubuntu-20.04
           - windows-2019
     steps:
-      - name: install NASM
-        uses: ilammy/setup-nasm@v1
-
+      # Install first since it's needed to build NASM
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: "10.0"
           directory: ${{ runner.temp }}/llvm
+
+      - name: install NASM
+        uses: ilammy/setup-nasm@v1
 
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
 name: RUN CODE
 
 env:
+  AR: llvm-ar
+  AS: nasm
+  CC: clang
   RUST_TOOLCHAIN: nightly-2021-08-20
   TOOLCHAIN_PROFILE: minimal
 
@@ -25,14 +28,15 @@ jobs:
           - ubuntu-20.04
           - windows-2019
     steps:
-      - name: install NASM
-        uses: ilammy/setup-nasm@v1
-
+      # Install first since it's needed to build NASM
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: "10.0"
           directory: ${{ runner.temp }}/llvm
+
+      - name: install NASM
+        uses: ilammy/setup-nasm@v1
 
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -56,9 +60,6 @@ jobs:
 
       - name: Build TdShim
         uses: actions-rs/cargo@v1
-        env:
-          CC: clang
-          AR: llvm-ar
         with:
           command: xbuild
           args: -p td-shim --target x86_64-unknown-uefi --release --features=main,tdx

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -11,9 +11,11 @@ name = "td-shim"
 required-features = ["main"]
 
 [build-dependencies]
+anyhow = "1.0.55"
 cc = { git = "https://github.com/jyao1/cc-rs.git", branch = "uefi_support" }
 td-layout = { path = "../td-layout" }
 tdx-tdcall = { path = "../tdx-tdcall" }
+which = "4.2.4"
 
 [dependencies]
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }

--- a/td-shim/build.rs
+++ b/td-shim/build.rs
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
+type Result<T> = std::result::Result<T, String>;
+
 use std::{
     env, format,
     path::{Path, PathBuf},
-    process::Command,
+    process::{exit, Command},
 };
 
 use td_layout::build_time;
@@ -40,7 +42,7 @@ fn run_command(mut cmd: Command) {
     }
 }
 
-fn main() {
+fn real_main() -> Result<()> {
     // tell cargo when to re-run the script
     println!("cargo:rerun-if-changed=build.rs");
     println!(
@@ -111,6 +113,8 @@ fn main() {
             &loaded_sec_core_size,
         ],
     ));
+
+    Ok(())
 }
 
 fn get_target_output_dir() -> PathBuf {
@@ -128,4 +132,11 @@ fn get_cargo_manifest_dir() -> PathBuf {
     // Environment variables Cargo sets for crates
     // The directory containing the manifest of your package.
     PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
+}
+
+fn main() {
+    if let Err(e) = real_main() {
+        eprintln!("ERROR: {:#}", e);
+        exit(1);
+    }
 }


### PR DESCRIPTION
Although the required tooling is documented in the README, it's too easy
to end up with a failed build due to missing tooling.

Add a new function to the build script to check for all dependencies and
fail with helpful messages on error.

Fixes: #110.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>