### PR TITLE
Relocate mailbox and AP function

### DIFF
--- a/devtools/td-layout-config/config.json
+++ b/devtools/td-layout-config/config.json
@@ -71,6 +71,7 @@
                 +--------------+ <-  0x80000000 (2G) - for example
         */
         "event_log_size": 0x100000,
+        "mailbox_size": 0x2000,
         "acpi_size": 0x100000,
         "hob_size": 0x400000,
         "shadow_stack_size": 0x200000,

--- a/td-layout/src/lib.rs
+++ b/td-layout/src/lib.rs
@@ -37,6 +37,7 @@ pub struct RuntimeMemoryLayout {
 
     pub runtime_event_log_base: u64,
     pub runtime_acpi_base: u64,
+    pub runtime_mailbox_base: u64,
     pub runtime_hob_base: u64,
     pub runtime_shadow_stack_base: u64,
     pub runtime_stack_base: u64,
@@ -60,6 +61,9 @@ impl RuntimeMemoryLayout {
 
         let current_base = current_base - TD_PAYLOAD_EVENT_LOG_SIZE as u64;
         let runtime_event_log_base = current_base;
+
+        let current_base = current_base - TD_PAYLOAD_MAILBOX_SIZE as u64;
+        let runtime_mailbox_base = current_base;
 
         let current_base = current_base - TD_PAYLOAD_ACPI_SIZE as u64;
         let runtime_acpi_base = current_base;
@@ -92,6 +96,7 @@ impl RuntimeMemoryLayout {
             runtime_payload_param_base,
             runtime_payload_base,
             runtime_event_log_base,
+            runtime_mailbox_base,
             runtime_hob_base,
             runtime_acpi_base,
             runtime_shadow_stack_base,

--- a/td-layout/src/memslice.rs
+++ b/td-layout/src/memslice.rs
@@ -8,7 +8,7 @@ use crate::build_time::{
 };
 use crate::runtime::{
     TD_PAYLOAD_ACPI_SIZE, TD_PAYLOAD_BASE, TD_PAYLOAD_EVENT_LOG_SIZE, TD_PAYLOAD_HOB_SIZE,
-    TD_PAYLOAD_SIZE,
+    TD_PAYLOAD_MAILBOX_SIZE, TD_PAYLOAD_SIZE,
 };
 
 /// Type of build time and runtime memory regions.
@@ -25,6 +25,8 @@ pub enum SliceType {
     Payload,
     /// The `TD_HOB` region in runtime memory layout
     PayloadHob,
+    /// The 'Mailbox' region in runtime memory layout
+    RelocatedMailbox,
     /// The `TD_EVENT_LOG` region in runtime memory layout
     EventLog,
     /// The `ACPI` region in runtime memory layout
@@ -95,10 +97,15 @@ pub unsafe fn get_dynamic_mem_slice_mut<'a>(t: SliceType, base_address: usize) -
             base_address as *const u8 as *mut u8,
             TD_PAYLOAD_EVENT_LOG_SIZE as usize,
         ),
+        SliceType::RelocatedMailbox => core::slice::from_raw_parts_mut(
+            base_address as *const u8 as *mut u8,
+            TD_PAYLOAD_MAILBOX_SIZE as usize,
+        ),
         SliceType::Acpi => core::slice::from_raw_parts_mut(
             base_address as *const u8 as *mut u8,
             TD_PAYLOAD_ACPI_SIZE as usize,
         ),
+
         _ => panic!("get_dynamic_mem_slice_mut: not support"),
     }
 }

--- a/td-layout/src/runtime.rs
+++ b/td-layout/src/runtime.rs
@@ -19,18 +19,20 @@
                     |    PAYLOAD   |    (0x02000000)
                     +--------------+
                     |   ........   |
-                    +--------------+ <-  0x7D000000
+                    +--------------+ <-  0x7CFFE000
                     |     DMA      |    (0x01000000)
-                    +--------------+ <-  0x7E000000
+                    +--------------+ <-  0x7DFFE000
                     |     HEAP     |    (0x01000000)
-                    +--------------+ <-  0x7F000000
+                    +--------------+ <-  0x7EFFE000
                     |     STACK    |    (0x00800000)
-                    +--------------+ <-  0x7F800000
+                    +--------------+ <-  0x7F7FE000
                     |      SS      |    (0x00200000)
-                    +--------------+ <-  0x7FA00000
+                    +--------------+ <-  0x7F9FE000
                     |    TD_HOB    |    (0x00400000)
-                    +--------------+ <-  0x7FE00000
+                    +--------------+ <-  0x7FDFE000
                     |     ACPI     |    (0x00100000)
+                    +--------------+ <-  0x7FEFE000
+                    |    MAILBOX   |    (0x00002000)
                     +--------------+ <-  0x7FF00000
                     | TD_EVENT_LOG |    (0x00100000)
                     +--------------+ <-  0x80000000 (2G) - for example
@@ -38,6 +40,7 @@
 
 pub const TD_PAYLOAD_EVENT_LOG_SIZE: u32 = 0x100000;
 pub const TD_PAYLOAD_ACPI_SIZE: u32 = 0x100000;
+pub const TD_PAYLOAD_MAILBOX_SIZE: u32 = 0x2000;
 pub const TD_PAYLOAD_HOB_SIZE: u32 = 0x400000;
 pub const TD_PAYLOAD_SHADOW_STACK_SIZE: u32 = 0x200000;
 pub const TD_PAYLOAD_STACK_SIZE: u32 = 0x800000;

--- a/td-shim/src/bin/td-shim/asm/ap_loop.asm
+++ b/td-shim/src/bin/td-shim/asm/ap_loop.asm
@@ -1,0 +1,90 @@
+# Copyright (c) 2022 Intel Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+.set TDVMCALL_EXPOSE_REGS_MASK,           0xffec
+.set TDVMCALL,                            0x0
+.set INSTRUCTION_CPUID,                   0xa
+
+.set CommandOffset,                       0
+.set ApicIdOffset,                        0x4
+.set WakeupVectorOffset,                  0x8
+
+.set MpProtectedModeWakeupCommandNoop,    0
+.set MpProtectedModeWakeupCommandWakeup,  1
+.set MpProtectedModeWakeupCommandSleep,   2
+
+.set MailboxApicIdInvalid,                0xffffffff
+.set MailboxApicIdBroadcast,              0xfffffffe
+
+.section .text
+#---------------------------------------------------------------------
+#  ap_relocated_func_size (
+#       size: *mut u64, // rcx
+#  );
+#---------------------------------------------------------------------
+.global ap_relocated_func_size
+ap_relocated_func_size:
+    push       rax
+    push       rbx
+    lea        rax, .ap_relocated_func_end
+    lea        rbx, ap_relocated_func
+    sub        rax, rbx
+    mov        qword ptr[rcx], rax
+    pop        rbx
+    pop        rax
+    ret
+
+#--------------------------------------------------------------------
+# ap_relocated_vector
+#
+# rbx:  Relocated mailbox address
+# rbp:  vCpuId
+#--------------------------------------------------------------------
+.global ap_relocated_func
+ap_relocated_func:
+    #
+    # Get the APIC ID via TDVMCALL
+    mov         rax, TDVMCALL
+    mov         rcx, TDVMCALL_EXPOSE_REGS_MASK
+    mov         r10, 0
+    mov         r11, INSTRUCTION_CPUID
+    mov         r12, 0xb
+    mov         r13, 0
+    # TDVMCALL
+    .byte       0x66, 0x0f, 0x01, 0xcc
+    test        rax, rax
+    jnz         .panic
+    #
+    # r8 will hold the APIC ID of current AP
+    mov         r8, r15
+
+.check_apicid:
+    #
+    # Determine if this is a broadcast or directly for my apic-id, if not, ignore
+    cmp     dword ptr[rbx + ApicIdOffset], MailboxApicIdBroadcast
+    je      .check_command
+    cmp     dword ptr[rbx + ApicIdOffset], r8d
+    jne     .check_apicid
+
+.check_command:
+    mov     eax, dword ptr[rbx + CommandOffset]
+    cmp     eax, MpProtectedModeWakeupCommandNoop
+    je      .check_apicid
+
+    cmp     eax, MpProtectedModeWakeupCommandWakeup
+    je      .wakeup
+
+    jmp     .check_apicid
+
+.wakeup:
+    #
+    # BSP sets these variables before unblocking APs
+    mov     rax, 0
+    mov     eax, dword ptr[rbx + WakeupVectorOffset]
+    nop
+    jmp     rax
+
+.panic:
+    ud2
+
+.ap_relocated_func_end:

--- a/td-shim/src/bin/td-shim/asm/mod.rs
+++ b/td-shim/src/bin/td-shim/asm/mod.rs
@@ -1,6 +1,11 @@
-// Copyright (c) 2020 Intel Corporation
+// Copyright (c) 2020-2022 Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
-
 global_asm!(include_str!("switch_stack.asm"));
 global_asm!(include_str!("msr64.asm"));
+global_asm!(include_str!("ap_loop.asm"));
+
+extern "win64" {
+    pub fn ap_relocated_func_size(size: *mut u64);
+    pub fn ap_relocated_func();
+}

--- a/td-shim/src/bin/td-shim/e820.rs
+++ b/td-shim/src/bin/td-shim/e820.rs
@@ -94,8 +94,8 @@ pub fn create_e820_entries(runtime_memory: &RuntimeMemoryLayout) -> E820Table {
     );
     table.add_range(
         E820Type::Nvs,
-        build_time::TD_SHIM_MAILBOX_BASE as u64,
-        build_time::TD_SHIM_MAILBOX_SIZE as u64,
+        runtime_memory.runtime_mailbox_base,
+        runtime::TD_PAYLOAD_MAILBOX_SIZE as u64,
     );
     // TODO: above memory above 4G? Should those memory be reported as `Memory`?
 

--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -119,6 +119,9 @@ pub extern "win64" fn _start(
     let mut mem = memory::Memory::new(&runtime_memory_layout, memory_all);
     mem.setup_paging();
 
+    // Relocate Mailbox along side with the AP function
+    td::relocate_mailbox(runtime_memory_layout.runtime_mailbox_base as u32);
+
     // Set up the TD event log buffer.
     // Safe because it's used to initialize the EventLog subsystem which ensures safety.
     let event_log_buf = unsafe {
@@ -297,10 +300,10 @@ fn prepare_acpi_tables(
     }
 
     let madt = if let Some(vmm_madt) = vmm_madt {
-        mp::create_madt(vmm_madt, build_time::TD_SHIM_MAILBOX_BASE as u64)
+        mp::create_madt(vmm_madt, layout.runtime_mailbox_base as u64)
             .expect("Failed to create ACPI MADT table")
     } else {
-        mp::create_madt_default(vcpus, build_time::TD_SHIM_MAILBOX_BASE as u64)
+        mp::create_madt_default(vcpus, layout.runtime_mailbox_base as u64)
             .expect("Failed to create ACPI MADT table")
     };
 

--- a/td-shim/src/bin/td-shim/td/tdx.rs
+++ b/td-shim/src/bin/td-shim/td/tdx.rs
@@ -22,6 +22,10 @@ pub fn accept_memory_resource_range(mut cpu_num: u32, address: u64, size: u64) {
     super::tdx_mailbox::accept_memory_resource_range(cpu_num, address, size)
 }
 
+pub fn relocate_mailbox(address: u32) {
+    super::tdx_mailbox::relocate_mailbox(address).expect("Unable to relocate mailbox");
+}
+
 pub fn get_num_vcpus() -> u32 {
     let mut td_info = tdx::TdInfoReturnData {
         gpaw: 0,


### PR DESCRIPTION
This PR addresses these issues:
    - Relocate the MAILBOX page to be continuous to the ACPI/event log regions #82
    - Relocate the AP loop function to be continuous to the above area
    - Use APIC ID instead of CPU index to identify AP 

APs are running in the loop waiting for BSP's instruction after they switch to long mode. At before, We assumed that CPU index get from TDCALL is equal to the APIC ID, but these two value may be different in some cases, such as configuring multiple sockets in QEMU.

One solution is to relocate APs' running loop into a new place where they use APIC ID to identify themselves. APs will use TDVMCALL to know their APIC ID and wait for the instructions from BSP to wakeup.

APs will run through two stages:
    - At first stage, APs are waiting for BSP to assign works using CPU index since BSP does not know the APIC ID of APs.
    - After this, BSP will copy a new function into Mailbox memory then wakeup all the APs and instruct them to jump into the new loop where APs will wait for command from OS and use APIC ID to identify themselves with a new mailbox address.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>