### PR TITLE
Refact test-td-payload in tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,3 @@ jobs:
         shell: pwsh
       - name: "Print QEMU Version"
         run: qemu-system-x86_64 --version
-
-      - name: "test td-payload"
-        working-directory: tests/test-td-payload
-        run: cargo xtest --target ../../devtools/rustc-targets/x86_64-custom.json

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 
 LIB_CRATES = td-loader td-exception td-layout td-logger td-paging tdx-tdcall
 SHIM_CRATES = td-shim td-payload
-TEST_CRATES = test-td-exception test-td-paging test-td-payload
+TEST_CRATES = test-td-exception test-td-paging
 TOOL_CRATES = td-shim-tools
 
 # Targets for normal artifacts

--- a/doc/test_with_td_payload.md
+++ b/doc/test_with_td_payload.md
@@ -1,0 +1,90 @@
+# Test with TD Payload
+TD-Shim has some test cases rely on TDX specific environment. Therefore, this simple test framework is created to support the test.
+
+## Test framework code structure
+All codes of test framework are located in [tests/test-td-payload](../tests/test-td-payload).
+
+```
+-- tests
+---- test-td-payload
+------ main.rs
+------ lib.rs
+------ test.json
+------ testtdinfo.rs
+------ ...
+```
+
+[main.rs](../tests/test-td-payload/src/main.rs): It defines strut `TestCases`. Main flow: Init `td_logger`-> Init heap-> Init `TestSuite` -> Build test cases(Parse test configuration data in CFV) -> Add test cases in `TestSuite` -> Run test cases -> Log test result. 
+
+[lib.rs](../tests/test-td-payload/src/lib.rs)：It defines enum `TestResult`、trait `TestCase` 、struct `TestSuite` and `TestSuite.run`. `TestSuite.run` will log result of each test case and count summary test result. 
+
+[test.json](../tests/test-td-payload/src/test.json): This is a json format test configuration data file. The structure should be correspond with struct `TestCases` in main.rs. It will be enrolled in CFV with tool [td-shim-enroll](../td-shim-tools/src/bin/td-shim-enroll/main.rs).
+
+[testtdinfo.rs](../tests/test-td-payload/src/testtdinfo.rs): This is a test case sample. Implement test struture and the `TestCase` trait(`setup` `run` `teardown` `get_name` `get_result`) for test structure.  
+
+## Build Test Image with Test TD Payload
+Refer to [README](../README.md), using PE as example:
+### Build test TD payload
+```
+$ cd tests
+$ cargo xbuild -p test-td-payload --target x86_64-unknown-uefi --release --features=main,tdx --no-default-features
+$ cd ..
+```
+
+### Generate final.bin
+```
+$ cargo xbuild -p td-shim --target x86_64-unknown-uefi --release --features=main,tdx --no-default-features
+$ cargo run -p td-shim-tools --bin td-shim-ld -- target/x86_64-unknown-uefi/release/ResetVector.bin target/x86_64-unknown-uefi/release/td-shim.efi target/x86_64-unknown-uefi/release/test-td-payload.efi -o target/x86_64-unknown-uefi/release/final-pe.bin
+```
+
+### Enroll json file in CFV
+```
+$ cargo run -p td-shim-tools --features="enroller" --bin td-shim-enroll target/x86_64-unknown-uefi/release/final-pe.bin -f F10E684E-3ABD-20E4-5932-8F973C355E57 tests/test-td-payload/src/test.json -o target/x86_64-unknown-uefi/release/final.test.bin
+```
+
+The output file **final.test.bin** with [test.json](../tests/test-td-payload/src/test.json) is located in the same folder with input final.bin. 
+
+## Json Test Configuration Data Example
+```
+{	    
+    "tcs001": {
+        "name": "tdinfo001",
+        "expected": {
+            "gpaw": 52,
+            "attributes": 0,
+            "max_vcpus": 1,
+            "num_vcpus": 1,
+            "rsvd": [0,0,0]
+        },
+        "result": "None",
+        "run": true  
+    }
+}
+```
+
+## Test Result Show
+```
+INFO - ---------------------------------------------
+INFO - Start to run tests.
+INFO - ---------------------------------------------
+INFO - [Test: tdinfo001]
+INFO - td_info data addr: 0x3f7ff9e8
+INFO - gpaw - 52
+INFO - max_vcpus - 1
+INFO - num_vcpus - 1
+INFO - rsvd - [0, 0, 0]
+INFO - [Test: tdinfo001] - Pass
+INFO - ---------------------------------------------
+INFO - [Test: tdinfo002]
+INFO - td_info data addr: 0x3f7ff9e8
+INFO - gpaw - 52
+INFO - Check max_vcpus fail - Expected 8: Actual 1
+INFO - [Test: tdinfo002] - Fail
+INFO - ---------------------------------------------
+INFO - [Test: tdinfo003]
+INFO - td_info data addr: 0x3f7ff9e8
+INFO - Check gpaw fail - Expected 48: Actual 52
+INFO - [Test: tdinfo003] - Fail
+INFO - ---------------------------------------------
+INFO - Test Result: Total run 3 tests; 1 passed; 2 failed
+```

--- a/tests/test-td-payload/Cargo.toml
+++ b/tests/test-td-payload/Cargo.toml
@@ -7,20 +7,28 @@ homepage = "https://github.com/confidential-containers"
 license = "BSD-2-Clause-Patent"
 edition = "2018"
 
-[features]
-tdx = []
-
 [dependencies]
-# Keep it as `dependencies` to satisfy bootloader-locator's requirement, though it should be `dev-dependencies`
-bootloader = "=0.10.9"
-
-[dev-dependencies]
-lazy_static = {version = "1.4.0", features = ["spin_no_std"] }
+spin = "0.9.2"
+r-efi = "3.2.0"
+linked_list_allocator = "0.9.0"
 log = "0.4.13"
-td-payload = { path = "../../td-payload" }
-tdx-tdcall = { path = "../../tdx-tdcall" }
-test-runner-client = { path = "../../devtools/test-runner-client" }
+uefi-pi =  { path = "../../uefi-pi" }
+tdx-tdcall = { path = "../../tdx-tdcall" , optional = true }
+td-logger =  { path = "../../td-logger" }
+td-exception =  { path = "../../td-exception" }
+td-layout = { path = "../../td-layout" }
+scroll = { version = "0.10.0", default-features = false, features = ["derive"]}
+serde = { version = "1.0", default-features = false, features = ["derive"]}
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+
+[dependencies.lazy_static]
+version = "1.0"
+features = ["spin_no_std"]
 
 [package.metadata.bootloader]
 map-physical-memory = true
-map-page-table-recursively = true
+
+[features]
+cet-ss = []
+tdx = ["tdx-tdcall", "td-logger/tdx"]
+main = []

--- a/tests/test-td-payload/src/lib.rs
+++ b/tests/test-td-payload/src/lib.rs
@@ -1,96 +1,60 @@
-// Copyright © 2019 Intel Corporation
+// Copyright (c) 2021 Intel Corporation
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #![no_std]
-#![cfg_attr(test, no_main)]
-// The `custom_test_frameworks` feature allows the use of `#[test_case]` and `#![test_runner]`.
-// Any function, const, or static can be annotated with `#[test_case]` causing it to be aggregated
-// (like #[test]) and be passed to the test runner determined by the `#![test_runner]` crate
-// attribute.
-#![feature(custom_test_frameworks)]
-#![test_runner(test_runner)]
-// Reexport the test harness main function under a different symbol.
-#![reexport_test_harness_main = "test_main"]
+extern crate alloc;
 
-#[cfg(test)]
-use bootloader::{boot_info, entry_point, BootInfo};
-#[cfg(test)]
-use core::ops::Deref;
-#[cfg(test)]
-use test_runner_client::{init_heap, serial_println, test_runner};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use serde::{Deserialize, Serialize};
 
-#[cfg(test)]
-entry_point!(kernel_main);
-
-#[cfg(test)]
-fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
-    // turn the screen gray
-    if let Some(framebuffer) = boot_info.framebuffer.as_mut() {
-        for byte in framebuffer.buffer_mut() {
-            *byte = 0x90;
-        }
-    }
-
-    let memoryregions = boot_info.memory_regions.deref();
-    let offset = boot_info.physical_memory_offset.into_option().unwrap();
-
-    for usable in memoryregions.iter() {
-        if usable.kind == boot_info::MemoryRegionKind::Usable {
-            init_heap((usable.start + offset) as usize, 0x100000);
-            break;
-        }
-    }
-
-    serial_println!("Start to execute test cases...");
-    test_main();
-    panic!("Unexpected return from test_main()!!!");
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+pub enum TestResult {
+    Pass,
+    Fail,
+    None,
 }
 
-#[cfg(test)]
-mod tests {
-    #[test_case]
-    fn trivial_assertion() {
-        assert_eq!(1, 1);
-    }
+pub trait TestCase {
+    fn setup(&mut self);
+    fn run(&mut self);
+    fn teardown(&mut self);
+    fn get_name(&mut self) -> String;
+    fn get_result(&mut self) -> TestResult;
+}
 
-    #[test_case]
-    fn test_json() {
-        td_payload::json_test();
-    }
+pub struct TestSuite {
+    pub testsuite: Vec<Box<dyn TestCase>>,
+    pub passed_cases: u32,
+    pub failed_cases: u32,
+}
 
-    #[cfg(feature = "tdx")]
-    #[test_case]
-    fn test_tdx_call() {
-        use tdx_tdcall::tdx;
+impl TestSuite {
+    pub fn run(&mut self) {
+        for tc in self.testsuite.iter_mut() {
+            log::info!("[Test: {}]\n", String::from(tc.get_name()));
+            tc.setup();
+            tc.run();
+            tc.teardown();
 
-        let mut td_info = tdx::TdInfoReturnData {
-            gpaw: 0,
-            attributes: 0,
-            max_vcpus: 0,
-            num_vcpus: 0,
-            rsvd: [0; 3],
-        };
-        tdx::tdcall_get_td_info(&mut td_info);
+            let res = tc.get_result();
+            match res {
+                TestResult::Pass => {
+                    self.passed_cases += 1;
+                    log::info!("[Test: {0}] - Pass\n", tc.get_name());
+                }
+                TestResult::Fail => {
+                    self.failed_cases += 1;
+                    log::info!("[Test: {0}] - Fail\n", tc.get_name());
+                }
+                TestResult::None => {
+                    log::info!("[Test: {0}] - Skip\n", tc.get_name());
+                }
+            }
 
-        log::info!("gpaw - {:?}\n", td_info.gpaw);
-        log::info!("attributes - {:?}\n", td_info.attributes);
-        log::info!("max_vcpus - {:?}\n", td_info.max_vcpus);
-        log::info!("num_vcpus - {:?}\n", td_info.num_vcpus);
-        log::info!("rsvd - {:?}\n", td_info.rsvd);
-
-        assert!(td_info.gpaw > 32);
-        assert!(td_info.max_vcpus > 0);
-        assert!(td_info.num_vcpus > 0);
+            log::info!("---------------------------------------------\n")
+        }
     }
 }

--- a/tests/test-td-payload/src/main.rs
+++ b/tests/test-td-payload/src/main.rs
@@ -1,0 +1,157 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_std]
+#![no_main]
+#![allow(unused)]
+#![feature(alloc_error_handler)]
+#[macro_use]
+
+mod lib;
+mod testtdinfo;
+
+extern crate alloc;
+use alloc::string::ToString;
+use core::ffi::c_void;
+use core::panic::PanicInfo;
+use linked_list_allocator::LockedHeap;
+use td_layout::memslice;
+use tdx_tdcall::tdx;
+
+use crate::lib::{TestResult, TestSuite};
+use crate::testtdinfo::Tdinfo;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use r_efi::efi::Guid;
+use serde::{Deserialize, Serialize};
+use serde_json::{Result, Value};
+use uefi_pi::{fv, hob, pi};
+
+#[derive(Debug, Serialize, Deserialize)]
+// The test cases' data structure corresponds to the test config json data structure
+pub struct TestCases {
+    pub tcs001: Tdinfo,
+    pub tcs002: Tdinfo,
+    pub tcs003: Tdinfo,
+}
+
+pub const CFV_FFS_HEADER_TEST_CONFIG_GUID: Guid = Guid::from_fields(
+    0xf10e684e,
+    0x3abd,
+    0x20e4,
+    0x59,
+    0x32,
+    &[0x8f, 0x97, 0x3c, 0x35, 0x5e, 0x57],
+); // {F10E684E-3ABD-20E4-5932-8F973C355E57}
+
+#[cfg(not(test))]
+#[panic_handler]
+#[allow(clippy::empty_loop)]
+fn panic(_info: &PanicInfo) -> ! {
+    log::info!("panic ... {:?}\n", _info);
+    loop {}
+}
+
+#[alloc_error_handler]
+#[allow(clippy::empty_loop)]
+fn alloc_error(_info: core::alloc::Layout) -> ! {
+    log::info!("alloc_error ... {:?}\n", _info);
+    panic!("deadloop");
+}
+
+#[cfg(not(test))]
+#[global_allocator]
+static ALLOCATOR: LockedHeap = LockedHeap::empty();
+
+#[cfg(not(test))]
+fn init_heap(heap_start: usize, heap_size: usize) {
+    unsafe {
+        ALLOCATOR.lock().init(heap_start, heap_size);
+    }
+}
+
+#[cfg(not(test))]
+fn build_testcases() -> TestCases {
+    log::info!("Starting get test data from cfv and parse json data\n");
+    let cfv = memslice::get_mem_slice(memslice::SliceType::Config);
+    let json_data = fv::get_file_from_fv(
+        cfv,
+        pi::fv::FV_FILETYPE_RAW,
+        CFV_FFS_HEADER_TEST_CONFIG_GUID,
+    )
+    .unwrap();
+    let json_string = String::from_utf8_lossy(json_data).to_string();
+    // trim zero in json string
+    let json_config = json_string.trim_matches(char::from(0));
+
+    serde_json::from_str(json_config).unwrap()
+}
+
+#[cfg(not(test))]
+#[no_mangle]
+#[cfg_attr(target_os = "uefi", export_name = "efi_main")]
+extern "win64" fn _start(hob: *const c_void) -> ! {
+    use td_layout::runtime::*;
+
+    td_logger::init();
+    log::info!("Starting rust-tdcall-payload hob - {:p}\n", hob);
+
+    // init heap so that we can allocate memory
+    let hob_buffer = unsafe {
+        memslice::get_dynamic_mem_slice_mut(memslice::SliceType::PayloadHob, hob as usize)
+    };
+
+    let hob_size = hob::get_hob_total_size(hob_buffer).unwrap();
+    let hob_list = &hob_buffer[..hob_size];
+
+    init_heap(
+        (hob::get_system_memory_size_below_4gb(hob_list).unwrap() as usize
+            - (TD_PAYLOAD_HOB_SIZE
+                + TD_PAYLOAD_STACK_SIZE
+                + TD_PAYLOAD_SHADOW_STACK_SIZE
+                + TD_PAYLOAD_ACPI_SIZE
+                + TD_PAYLOAD_EVENT_LOG_SIZE) as usize
+            - TD_PAYLOAD_HEAP_SIZE as usize),
+        TD_PAYLOAD_HEAP_SIZE as usize,
+    );
+
+    // create TestSuite to hold the test cases
+    let mut ts = TestSuite {
+        testsuite: Vec::new(),
+        passed_cases: 0,
+        failed_cases: 0,
+    };
+
+    // build test cases with test configuration data in CFV
+    let tcs = build_testcases();
+
+    // Add test cases in ts.testsuite
+    if tcs.tcs001.run {
+        ts.testsuite.push(Box::new(tcs.tcs001));
+    }
+
+    if tcs.tcs002.run {
+        ts.testsuite.push(Box::new(tcs.tcs002));
+    }
+
+    if tcs.tcs003.run {
+        ts.testsuite.push(Box::new(tcs.tcs003));
+    }
+
+    // run the TestSuite which contains the test cases
+    log::info!("---------------------------------------------\n");
+    log::info!("Start to run tests.\n");
+    log::info!("---------------------------------------------\n");
+    ts.run();
+    log::info!(
+        "Test Result: Total run {0} tests; {1} passed; {2} failed\n",
+        ts.testsuite.len(),
+        ts.passed_cases,
+        ts.failed_cases
+    );
+
+    panic!("deadloop");
+}

--- a/tests/test-td-payload/src/test.json
+++ b/tests/test-td-payload/src/test.json
@@ -1,0 +1,38 @@
+{	    
+    "tcs001": {
+        "name": "tdinfo001",
+        "expected": {
+            "gpaw": 52,
+            "attributes": 0,
+            "max_vcpus": 1,
+            "num_vcpus": 1,
+            "rsvd": [0,0,0]
+        },
+        "result": "None",
+        "run": true  
+    },
+    "tcs002": {
+        "name": "tdinfo002",
+        "expected": {
+            "gpaw": 52,
+            "attributes": 0,
+            "max_vcpus": 8,
+            "num_vcpus": 8,
+            "rsvd": [0,0,0]
+        },
+        "result": "None",
+        "run": false  
+    },  
+    "tcs003": {
+        "name": "tdinfo003",
+        "expected": {
+            "gpaw": 48,
+            "attributes": 0,
+            "max_vcpus": 1,
+            "num_vcpus": 1,
+            "rsvd": [0,0,0]
+        },
+        "result": "None",
+        "run": false 
+    }        
+}

--- a/tests/test-td-payload/src/testtdinfo.rs
+++ b/tests/test-td-payload/src/testtdinfo.rs
@@ -1,0 +1,136 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_std]
+extern crate alloc;
+
+use crate::lib::{TestCase, TestResult};
+use alloc::string::String;
+use core::ffi::c_void;
+use tdx_tdcall::tdx;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TdInfoRetData {
+    pub gpaw: u64,
+    pub attributes: u64,
+    pub max_vcpus: u32,
+    pub num_vcpus: u32,
+    pub rsvd: [u64; 3],
+}
+
+/**
+ * Test Tdinfo
+ */
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Tdinfo {
+    pub name: String,
+    pub expected: TdInfoRetData,
+    pub result: TestResult,
+    pub run: bool,
+}
+
+/**
+ * Implement the TestCase trait for Tdinfo
+ */
+impl TestCase for Tdinfo {
+    /**
+     * set up the Test case of Tdinfo
+     */
+    fn setup(&mut self) {
+        self.result = TestResult::Pass;
+    }
+
+    /**
+     * run the test case
+     */
+    fn run(&mut self) {
+        let mut td_info = tdx::TdInfoReturnData {
+            gpaw: 0,
+            attributes: 0,
+            max_vcpus: 0,
+            num_vcpus: 0,
+            rsvd: [0; 3],
+        };
+        tdx::tdcall_get_td_info(&mut td_info);
+
+        if (self.expected.gpaw != td_info.gpaw) {
+            self.result = TestResult::Fail;
+            log::info!(
+                "Check gpaw fail - Expected {:?}: Actual {:?}\n",
+                self.expected.gpaw,
+                td_info.gpaw
+            );
+            return;
+        } else {
+            log::info!("gpaw - {:?}\n", td_info.gpaw);
+        }
+
+        if (self.expected.max_vcpus != td_info.max_vcpus) {
+            self.result = TestResult::Fail;
+            log::info!(
+                "Check max_vcpus fail - Expected {:?}: Actual {:?}\n",
+                self.expected.max_vcpus,
+                td_info.max_vcpus
+            );
+            return;
+        } else {
+            log::info!("max_vcpus - {:?}\n", td_info.max_vcpus);
+        }
+
+        if (self.expected.num_vcpus != td_info.num_vcpus) {
+            self.result = TestResult::Fail;
+            log::info!(
+                "Check num_vcpus fail - Expected {:?}: Actual {:?}\n",
+                self.expected.num_vcpus,
+                td_info.num_vcpus
+            );
+            return;
+        } else {
+            log::info!("num_vcpus - {:?}\n", td_info.num_vcpus);
+        }
+
+        if (self.expected.max_vcpus != td_info.num_vcpus) {
+            self.result = TestResult::Fail;
+            log::info!(
+                "max_vcpus should be equal num_vcpus fail - max_vcpus {:?}: num_vcpus {:?}\n",
+                self.expected.max_vcpus,
+                td_info.num_vcpus
+            );
+            return;
+        }
+
+        if (self.expected.rsvd != td_info.rsvd) {
+            self.result = TestResult::Fail;
+            log::info!(
+                "Check rsvd fail - Expected {:?}: Actual {:?}\n",
+                self.expected.rsvd,
+                td_info.rsvd
+            );
+            return;
+        } else {
+            log::info!("rsvd - {:?}\n", td_info.rsvd);
+        }
+    }
+
+    /**
+     * Tear down the test case.
+     */
+    fn teardown(&mut self) {}
+
+    /**
+     * get the name of the test case.
+     */
+    fn get_name(&mut self) -> String {
+        String::from(&self.name)
+    }
+
+    /**
+     * get the result of the test case.
+     */
+    fn get_result(&mut self) -> TestResult {
+        self.result
+    }
+}


### PR DESCRIPTION
Implement a simple test framework to run test cases with TDX dependency.

This PR depends on [PR 130](https://github.com/confidential-containers/td-shim/pull/130). It will use latest enroll tool to enroll the test json file in CFV. 

Signed-off-by: Wei Liu <wei3.liu@intel.com>