### PR TITLE
td-shim: Make build script check for required commands

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,6 +2,11 @@ on: [push, pull_request]
 
 name: Format and Clippy
 
+env:
+  AR: llvm-ar
+  AS: nasm
+  CC: clang
+
 jobs:
   clippy:
     name: Clippy
@@ -9,6 +14,13 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
+      # Install first since it's needed to build NASM
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "10.0"
+          directory: ${{ runner.temp }}/llvm
 
       - name: install NASM
         uses: ilammy/setup-nasm@v1
@@ -28,6 +40,13 @@ jobs:
     name: Format
     runs-on: ubuntu-20.04
     steps:
+
+      # Install first since it's needed to build NASM
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "10.0"
+          directory: ${{ runner.temp }}/llvm
 
       - name: install NASM
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -10,6 +10,9 @@ on:
 name: Library Crates
 
 env:
+  AR: llvm-ar
+  AS: nasm
+  CC: clang
   STABLE_RUST_TOOLCHAIN: 1.58.1
   NIGHTLY_RUST_TOOLCHAIN: nightly-2021-08-20
   TOOLCHAIN_PROFILE: minimal
@@ -26,14 +29,15 @@ jobs:
           - ubuntu-20.04
           - windows-2019
     steps:
-      - name: install NASM
-        uses: ilammy/setup-nasm@v1
-
+      # Install first since it's needed to build NASM
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: "10.0"
           directory: ${{ runner.temp }}/llvm
+
+      - name: install NASM
+        uses: ilammy/setup-nasm@v1
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -69,14 +73,15 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: install NASM
-        uses: ilammy/setup-nasm@v1
-
+      # Install first since it's needed to build NASM
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: "10.0"
           directory: ${{ runner.temp }}/llvm
+
+      - name: install NASM
+        uses: ilammy/setup-nasm@v1
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
 name: RUN CODE
 
 env:
+  AR: llvm-ar
+  AS: nasm
+  CC: clang
   RUST_TOOLCHAIN: nightly-2021-08-20
   TOOLCHAIN_PROFILE: minimal
 
@@ -25,14 +28,15 @@ jobs:
           - ubuntu-20.04
           - windows-2019
     steps:
-      - name: install NASM
-        uses: ilammy/setup-nasm@v1
-
+      # Install first since it's needed to build NASM
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v1
         with:
           version: "10.0"
           directory: ${{ runner.temp }}/llvm
+
+      - name: install NASM
+        uses: ilammy/setup-nasm@v1
 
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
Although the required tooling is documented in the README, it's too easy
to end up with a failed build due to missing tooling.

Add a new function to the build script to check for all dependencies and
fail with helpful messages on error.

Fixes: #110.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>