### PR TITLE
Modify environment variables so that CI can pass

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ on:
 name: RUN CODE
 
 env:
-  AR: llvm-ar
   AS: nasm
-  CC: clang
+  AR_x86_64_unknown_uefi: llvm-ar
+  CC_x86_64_unknown_uefi: clang
   RUST_TOOLCHAIN: nightly-2021-08-20
   TOOLCHAIN_PROFILE: minimal
 


### PR DESCRIPTION
Fix: #134 

Add and modify CC and AR environment variables in .github/workflows/main.yml .

Modify the required_compiler variable value in build.rs to make it pass the check .

Signed-off-by: haowx <weix.hao.intel.com>