### PR TITLE
[Move] td-layout: add mailbox region to runtime layout

### DIFF
--- a/td-layout/src/lib.rs
+++ b/td-layout/src/lib.rs
@@ -37,6 +37,7 @@ pub struct RuntimeMemoryLayout {
 
     pub runtime_event_log_base: u64,
     pub runtime_acpi_base: u64,
+    pub runtime_mailbox_base: u64,
     pub runtime_hob_base: u64,
     pub runtime_shadow_stack_base: u64,
     pub runtime_stack_base: u64,
@@ -60,6 +61,9 @@ impl RuntimeMemoryLayout {
 
         let current_base = current_base - TD_PAYLOAD_EVENT_LOG_SIZE as u64;
         let runtime_event_log_base = current_base;
+
+        let current_base = current_base - TD_PAYLOAD_MAILBOX_SIZE as u64;
+        let runtime_mailbox_base = current_base;
 
         let current_base = current_base - TD_PAYLOAD_ACPI_SIZE as u64;
         let runtime_acpi_base = current_base;
@@ -92,6 +96,7 @@ impl RuntimeMemoryLayout {
             runtime_payload_param_base,
             runtime_payload_base,
             runtime_event_log_base,
+            runtime_mailbox_base,
             runtime_hob_base,
             runtime_acpi_base,
             runtime_shadow_stack_base,

--- a/td-layout/src/memslice.rs
+++ b/td-layout/src/memslice.rs
@@ -8,7 +8,7 @@ use crate::build_time::{
 };
 use crate::runtime::{
     TD_PAYLOAD_ACPI_SIZE, TD_PAYLOAD_BASE, TD_PAYLOAD_EVENT_LOG_SIZE, TD_PAYLOAD_HOB_SIZE,
-    TD_PAYLOAD_SIZE,
+    TD_PAYLOAD_MAILBOX_SIZE, TD_PAYLOAD_SIZE,
 };
 
 /// Type of build time and runtime memory regions.
@@ -25,6 +25,8 @@ pub enum SliceType {
     Payload,
     /// The `TD_HOB` region in runtime memory layout
     PayloadHob,
+    /// The 'Mailbox' region in runtime memory layout
+    RelocatedMailbox,
     /// The `TD_EVENT_LOG` region in runtime memory layout
     EventLog,
     /// The `ACPI` region in runtime memory layout
@@ -95,10 +97,15 @@ pub unsafe fn get_dynamic_mem_slice_mut<'a>(t: SliceType, base_address: usize) -
             base_address as *const u8 as *mut u8,
             TD_PAYLOAD_EVENT_LOG_SIZE as usize,
         ),
+        SliceType::RelocatedMailbox => core::slice::from_raw_parts_mut(
+            base_address as *const u8 as *mut u8,
+            TD_PAYLOAD_MAILBOX_SIZE as usize,
+        ),
         SliceType::Acpi => core::slice::from_raw_parts_mut(
             base_address as *const u8 as *mut u8,
             TD_PAYLOAD_ACPI_SIZE as usize,
         ),
+
         _ => panic!("get_dynamic_mem_slice_mut: not support"),
     }
 }

--- a/td-layout/src/metadata.rs
+++ b/td-layout/src/metadata.rs
@@ -129,7 +129,7 @@ impl Default for TdxMetadata {
             descriptor: Default::default(),
             sections: [Default::default(); 6],
             #[cfg(feature = "boot-kernel")]
-            payload_sections: [Default::default(), 2],
+            payload_sections: [Default::default(); 2],
         };
 
         if cfg!(feature = "boot-kernel") {

--- a/td-layout/src/runtime.rs
+++ b/td-layout/src/runtime.rs
@@ -19,18 +19,20 @@
                     |    PAYLOAD   |    (0x02000000)
                     +--------------+
                     |   ........   |
-                    +--------------+ <-  0x7D000000
+                    +--------------+ <-  0x7CFFE000
                     |     DMA      |    (0x01000000)
-                    +--------------+ <-  0x7E000000
+                    +--------------+ <-  0x7DFFE000
                     |     HEAP     |    (0x01000000)
-                    +--------------+ <-  0x7F000000
+                    +--------------+ <-  0x7EFFE000
                     |     STACK    |    (0x00800000)
-                    +--------------+ <-  0x7F800000
+                    +--------------+ <-  0x7F7FE000
                     |      SS      |    (0x00200000)
-                    +--------------+ <-  0x7FA00000
+                    +--------------+ <-  0x7F9FE000
                     |    TD_HOB    |    (0x00400000)
-                    +--------------+ <-  0x7FE00000
+                    +--------------+ <-  0x7FDFE000
                     |     ACPI     |    (0x00100000)
+                    +--------------+ <-  0x7FEFE000
+                    |    MAILBOX   |    (0x00002000)
                     +--------------+ <-  0x7FF00000
                     | TD_EVENT_LOG |    (0x00100000)
                     +--------------+ <-  0x80000000 (2G) - for example
@@ -38,6 +40,7 @@
 
 pub const TD_PAYLOAD_EVENT_LOG_SIZE: u32 = 0x100000;
 pub const TD_PAYLOAD_ACPI_SIZE: u32 = 0x100000;
+pub const TD_PAYLOAD_MAILBOX_SIZE: u32 = 0x2000;
 pub const TD_PAYLOAD_HOB_SIZE: u32 = 0x400000;
 pub const TD_PAYLOAD_SHADOW_STACK_SIZE: u32 = 0x200000;
 pub const TD_PAYLOAD_STACK_SIZE: u32 = 0x800000;


### PR DESCRIPTION
td-layout: add mailbox region to runtime layout.

Signed-off-by: haowx <weix.hao.intel.com>