### PR TITLE
test-td-payload: Add #VE test case

### DIFF
--- a/tests/test-td-payload/Cargo.toml
+++ b/tests/test-td-payload/Cargo.toml
@@ -20,6 +20,7 @@ td-layout = { path = "../../td-layout" }
 scroll = { version = "0.10.0", default-features = false, features = ["derive"]}
 serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+x86 = { version = "0.44.0" }
 
 [dependencies.lazy_static]
 version = "1.0"

--- a/tests/test-td-payload/src/main.rs
+++ b/tests/test-td-payload/src/main.rs
@@ -13,6 +13,7 @@ mod testiorw32;
 mod testiorw8;
 mod testtdinfo;
 mod testtdreport;
+mod testtdve;
 
 extern crate alloc;
 use alloc::boxed::Box;
@@ -29,6 +30,7 @@ use crate::testiorw32::Tdiorw32;
 use crate::testiorw8::Tdiorw8;
 use crate::testtdinfo::Tdinfo;
 use crate::testtdreport::Tdreport;
+use crate::testtdve::TdVE;
 
 use r_efi::efi::Guid;
 use serde::{Deserialize, Serialize};
@@ -44,6 +46,7 @@ pub struct TestCases {
     pub tcs004: Tdreport,
     pub tcs005: Tdiorw8,
     pub tcs006: Tdiorw32,
+    pub tcs007: TdVE,
 }
 
 pub const CFV_FFS_HEADER_TEST_CONFIG_GUID: Guid = Guid::from_fields(
@@ -159,6 +162,10 @@ extern "win64" fn _start(hob: *const c_void) -> ! {
 
     if tcs.tcs006.run {
         ts.testsuite.push(Box::new(tcs.tcs006));
+    }
+
+    if tcs.tcs007.run {
+        ts.testsuite.push(Box::new(tcs.tcs007));
     }
 
     // run the TestSuite which contains the test cases

--- a/tests/test-td-payload/src/test.json
+++ b/tests/test-td-payload/src/test.json
@@ -58,5 +58,10 @@
         "name": "testiorw32",     
         "result": "None",
         "run": true 
+    },
+    "tcs007": {
+        "name": "testve",     
+        "result": "None",
+        "run": true
     }
 }

--- a/tests/test-td-payload/src/testtdve.rs
+++ b/tests/test-td-payload/src/testtdve.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_std]
+extern crate alloc;
+
+use crate::lib::{TestCase, TestResult};
+use alloc::string::String;
+
+use serde::{Deserialize, Serialize};
+
+/**
+ * Test #VE
+ */
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TdVE {
+    pub name: String,
+    pub result: TestResult,
+    pub run: bool,
+}
+
+/**
+ * Implement the TestCase trait for TdVE
+ */
+impl TestCase for TdVE {
+    /**
+     * set up the Test case of TdVE
+     */
+    fn setup(&mut self) {
+        self.result = TestResult::Fail;
+    }
+
+    /**
+     * run the test case
+     * io read Century of RTC
+     */
+    fn run(&mut self) {
+        unsafe { x86::io::outb(0x70, 0x32) };
+
+        let century = unsafe { x86::io::inb(0x71) };
+        log::info!("Current century is {}\n", century);
+
+        self.result = TestResult::Pass;
+    }
+
+    /**
+     * Tear down the test case.
+     */
+    fn teardown(&mut self) {}
+
+    /**
+     * get the name of the test case.
+     */
+    fn get_name(&mut self) -> String {
+        String::from(&self.name)
+    }
+
+    /**
+     * get the result of the test case.
+     */
+    fn get_result(&mut self) -> TestResult {
+        self.result
+    }
+}


### PR DESCRIPTION
Use x86::io to write/read RTC and trigger #VE handler.

Signed-off-by: Wei Liu <wei3.liu@intel.com>
