### PR TITLE
Refactor memory implementation

### DIFF
--- a/td-paging/src/consts.rs
+++ b/td-paging/src/consts.rs
@@ -7,7 +7,7 @@ pub const PHYS_VIRT_OFFSET: usize = 0;
 /// Page size.
 pub const PAGE_SIZE: usize = 0x1000;
 /// The memory size reserved for page table pages.
-pub const PAGE_TABLE_SIZE: usize = 0x100000;
+pub const PAGE_TABLE_SIZE: usize = 0x800000;
 
 /// Default PTE(page table entry) size.
 pub const PAGE_SIZE_DEFAULT: usize = 0x4000_0000;

--- a/td-shim/src/bin/td-shim/e820.rs
+++ b/td-shim/src/bin/td-shim/e820.rs
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
+use alloc::vec::Vec;
 use td_layout::{build_time, runtime, RuntimeMemoryLayout};
 
 // Linux BootParam supports 128 e820 entries, so...
 const MAX_E820_ENTRY: usize = 128;
 
 #[derive(Clone, Copy)]
+#[repr(u32)]
 pub enum E820Type {
     Memory = 1,
     Reserved = 2,
@@ -16,6 +18,22 @@ pub enum E820Type {
     Unusable = 5,
     Disabled = 6,
     Pmem = 7,
+    Unknown = 0xff,
+}
+
+impl From<u32> for E820Type {
+    fn from(i: u32) -> Self {
+        match i {
+            1 => E820Type::Memory,
+            2 => E820Type::Reserved,
+            3 => E820Type::Acpi,
+            4 => E820Type::Nvs,
+            5 => E820Type::Unusable,
+            6 => E820Type::Disabled,
+            7 => E820Type::Pmem,
+            _ => E820Type::Unknown,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -36,18 +54,22 @@ impl E820Entry {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-#[repr(C, packed)]
+#[derive(Debug)]
 pub struct E820Table {
-    entries: [E820Entry; MAX_E820_ENTRY],
-    size: usize,
+    entries: Vec<E820Entry>,
+}
+
+#[derive(Debug)]
+pub enum E820Error {
+    RangeAlreadyExists,
+    RangeNotExists,
+    TooManyEntries,
 }
 
 impl Default for E820Table {
     fn default() -> Self {
         Self {
-            entries: [E820Entry::default(); MAX_E820_ENTRY],
-            size: 0,
+            entries: Vec::new(),
         }
     }
 }
@@ -57,49 +79,142 @@ impl E820Table {
         Self::default()
     }
 
-    pub fn add_range(&mut self, r#type: E820Type, start: u64, length: u64) {
-        if self.size == MAX_E820_ENTRY {
-            return;
-        }
-        if self.size > 0 {
-            let end_entry = &mut self.entries[self.size - 1];
-            let exist_end = end_entry.addr + end_entry.size;
-            if start == exist_end && r#type as u32 == end_entry.r#type {
-                end_entry.size += length;
-                return;
+    // Add a new range to the table
+    pub fn add_range(
+        &mut self,
+        r#type: E820Type,
+        start: u64,
+        length: u64,
+    ) -> Result<(), E820Error> {
+        let mut pos = self.entries.len();
+        for (i, e) in self.entries.iter().enumerate() {
+            if start >= e.addr && start < e.addr + e.size {
+                return Err(E820Error::RangeAlreadyExists);
+            }
+            if start + length <= e.addr {
+                pos = i;
+                break;
             }
         }
-        self.entries[self.size] = E820Entry::new(start, length, r#type);
-        self.size += 1;
+        if self.entries.len() == MAX_E820_ENTRY && !self.able_to_merge(pos, r#type, start, length) {
+            return Err(E820Error::TooManyEntries);
+        }
+        self.entries
+            .insert(pos, E820Entry::new(start, length, r#type));
+        self.merge();
+        Ok(())
+    }
+
+    // Convert an existing range to another type
+    pub fn convert_range(
+        &mut self,
+        r#type: E820Type,
+        start: u64,
+        length: u64,
+    ) -> Result<(), E820Error> {
+        let entry_num = self.entries.len();
+        let mut idx = 0;
+        loop {
+            if idx == entry_num {
+                break;
+            }
+            let entry_end = self.entries[idx].addr + self.entries[idx].size;
+            if start >= self.entries[idx].addr && start < entry_end {
+                // Return error if the length exceeds the range of current entry
+                if length > entry_end - start {
+                    return Err(E820Error::RangeNotExists);
+                }
+                // If range covers the whole entry, update the type,
+                // otherwise insert a new entry.
+                if self.entries[idx].size == length {
+                    self.entries[idx].r#type = r#type as u32;
+                    self.merge();
+                    return Ok(());
+                }
+
+                if self.entries[idx].addr == start {
+                    // if the entry num of e820 table has reached the maximum, and
+                    // the new entry cannot be merged with an exits one, then return
+                    // an error.
+                    if entry_num == MAX_E820_ENTRY
+                        && !self.able_to_merge(idx, r#type, start, length)
+                    {
+                        return Err(E820Error::TooManyEntries);
+                    }
+                    self.entries[idx].size -= length;
+                    self.entries[idx].addr = start + length;
+                    self.entries
+                        .insert(idx, E820Entry::new(start, length, r#type))
+                } else if self.entries[idx].addr + self.entries[idx].size == start + length {
+                    // check if the new entry can be merged with the right one
+                    if entry_num == MAX_E820_ENTRY
+                        && !self.able_to_merge(idx, r#type, start, length)
+                    {
+                        return Err(E820Error::TooManyEntries);
+                    }
+                    self.entries[idx].size -= length;
+                    self.entries
+                        .insert(idx + 1, E820Entry::new(start, length, r#type))
+                } else {
+                    self.entries[idx].size = start - self.entries[idx].addr;
+                    self.entries
+                        .insert(idx + 1, E820Entry::new(start, length, r#type));
+                    self.entries.insert(
+                        idx + 2,
+                        E820Entry::new(
+                            start + length,
+                            entry_end - (start + length),
+                            self.entries[idx].r#type.into(),
+                        ),
+                    );
+                }
+                self.merge();
+                return Ok(());
+            }
+            idx += 1;
+        }
+        return Err(E820Error::RangeNotExists);
+    }
+
+    // Check if the new entry can be merged with the its neighbour
+    // if exists
+    fn able_to_merge(&self, pos: usize, r#type: E820Type, start: u64, length: u64) -> bool {
+        if (pos > 0
+            && self.entries[pos - 1].r#type == r#type as u32
+            && self.entries[pos - 1].addr + self.entries[pos - 1].size == start)
+            || (pos + 1 < self.entries.len()
+                && self.entries[pos + 1].r#type == r#type as u32
+                && self.entries[pos + 1].addr == start + length)
+        {
+            true
+        } else {
+            false
+        }
+    }
+
+    fn merge(&mut self) {
+        let mut entry_num = self.entries.len();
+        let mut idx = 0;
+        loop {
+            if idx == entry_num - 1 {
+                break;
+            }
+            let entry_end = self.entries[idx].addr + self.entries[idx].size;
+            if entry_end == self.entries[idx + 1].addr
+                && self.entries[idx].r#type == self.entries[idx + 1].r#type
+            {
+                self.entries[idx].size += self.entries[idx + 1].size;
+                self.entries.remove(idx + 1);
+                entry_num -= 1;
+                continue;
+            }
+            idx += 1;
+        }
     }
 
     pub fn as_slice(&self) -> &[E820Entry] {
         &self.entries
     }
-}
-
-pub fn create_e820_entries(runtime_memory: &RuntimeMemoryLayout) -> E820Table {
-    let mut table = E820Table::new();
-
-    table.add_range(E820Type::Memory, 0, runtime_memory.runtime_acpi_base as u64);
-    table.add_range(
-        E820Type::Acpi,
-        runtime_memory.runtime_acpi_base,
-        runtime::TD_PAYLOAD_ACPI_SIZE as u64,
-    );
-    table.add_range(
-        E820Type::Nvs,
-        runtime_memory.runtime_event_log_base,
-        runtime::TD_PAYLOAD_EVENT_LOG_SIZE as u64,
-    );
-    table.add_range(
-        E820Type::Nvs,
-        runtime_memory.runtime_mailbox_base,
-        runtime::TD_PAYLOAD_MAILBOX_SIZE as u64,
-    );
-    // TODO: above memory above 4G? Should those memory be reported as `Memory`?
-
-    table
 }
 
 #[cfg(test)]
@@ -117,20 +232,46 @@ mod tests {
     }
 
     #[test]
-    fn test_e820_table() {
+    fn test_e820_table_add_range() {
         let mut table = E820Table::new();
-        assert_eq!(table.size as usize, 0);
-        table.add_range(E820Type::Memory, 0x0, 0x1000);
-        assert_eq!(table.size as usize, 1);
-        table.add_range(E820Type::Memory, 0x1000, 0x1000);
-        assert_eq!(table.size as usize, 1);
-        assert_eq!(table.entries[0].size as u64, 0x2000);
-        table.add_range(E820Type::Acpi, 0x2000, 0x1000);
-        assert_eq!(table.size as usize, 2);
+        table.add_range(E820Type::Memory, 0x0, 0x1000).unwrap();
+        table.add_range(E820Type::Memory, 0x2000, 0x1000).unwrap();
+        assert_eq!(table.as_slice().len(), 2);
+        table.add_range(E820Type::Memory, 0x1000, 0x1000).unwrap();
+        assert_eq!(table.as_slice().len(), 1);
+    }
 
-        for idx in 0..MAX_E820_ENTRY {
-            table.add_range(E820Type::Memory, idx as u64 * 0x2000, 0x1000);
-        }
-        assert_eq!(table.size as usize, MAX_E820_ENTRY);
+    #[test]
+    fn test_e820_table_convert_range() {
+        let mut table = E820Table::new();
+        table.add_range(E820Type::Memory, 0x0, 0x1000).unwrap();
+        table.add_range(E820Type::Memory, 0x2000, 0x1000).unwrap();
+        table.add_range(E820Type::Acpi, 0x1000, 0x1000).unwrap();
+        assert_eq!(table.as_slice().len(), 3);
+        table
+            .convert_range(E820Type::Memory, 0x1400, 0x800)
+            .unwrap();
+        assert_eq!(table.as_slice().len(), 5);
+
+        table.convert_range(E820Type::Acpi, 0x1400, 0x800).unwrap();
+        table
+            .convert_range(E820Type::Memory, 0x1000, 0x800)
+            .unwrap();
+        assert_eq!(table.as_slice().len(), 3);
+
+        table.convert_range(E820Type::Acpi, 0x1000, 0x800).unwrap();
+        table
+            .convert_range(E820Type::Memory, 0x1800, 0x800)
+            .unwrap();
+        assert_eq!(table.as_slice().len(), 3);
+
+        let mut table = E820Table::new();
+        let result = table.convert_range(E820Type::Memory, 0x0, 0x1000);
+        assert!(result.is_err());
+        table.add_range(E820Type::Memory, 0x2000, 0x1000).unwrap();
+        table.add_range(E820Type::Memory, 0x0, 0x1000).unwrap();
+        assert_eq!(table.as_slice().len(), 2);
+        let result = table.convert_range(E820Type::Memory, 0x800, 0x2000);
+        assert!(result.is_err());
     }
 }

--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -199,7 +199,7 @@ pub extern "win64" fn _start(
         boot_linux_kernel(
             &payload_info,
             &td_hob_info.acpi_tables,
-            &mem.layout,
+            &mem,
             &mut td_event_log,
             num_vcpus,
         );
@@ -271,7 +271,7 @@ fn log_hob_list(hob_list: &[u8], td_event_log: &mut tcg::TdEventLog) {
 fn boot_linux_kernel(
     kernel_info: &PayloadInfo,
     acpi_tables: &Vec<&[u8]>,
-    layout: &RuntimeMemoryLayout,
+    mem: &memory::Memory,
     td_event_log: &mut TdEventLog,
     vcpus: u32,
 ) {
@@ -282,8 +282,9 @@ fn boot_linux_kernel(
         _ => panic!("Unknown kernel image type {}!!!", kernel_info.image_type),
     };
 
-    let rsdp = prepare_acpi_tables(acpi_tables, layout, td_event_log, vcpus);
-    let e820_table = e820::create_e820_entries(layout);
+    let rsdp = prepare_acpi_tables(acpi_tables, &mem.layout, td_event_log, vcpus);
+    let e820_table = mem.create_e820();
+    log::info!("e820 table: {:x?}\n", e820_table.as_slice());
     // Safe because we are handle off this buffer to linux kernel.
     let payload = unsafe { memslice::get_mem_slice_mut(memslice::SliceType::Payload) };
 

--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -173,25 +173,22 @@ pub extern "win64" fn _start(
         TdHobInfo::read_from_hob(hob_list).expect("Error occurs reading from VMM HOB");
 
     // Initialize memory subsystem.
+    let mut mem = memory::Memory::new(&td_hob_info.memory)
+        .expect("Unable to find a piece of suitable memory for runtime");
     let num_vcpus = td::get_num_vcpus();
-    accept_memory_resources(&td_hob_info.memory, num_vcpus);
-    td_paging::init();
-    let memory_top_below_4gb = hob::get_system_memory_size_below_4gb(hob_list)
-        .expect("failed to figure out memory below 4G from hob list");
-    let runtime_memory_layout = RuntimeMemoryLayout::new(memory_top_below_4gb);
-    let memory_all = memory::get_memory_size(hob_list);
-    let mut mem = memory::Memory::new(&runtime_memory_layout, memory_all);
+    #[cfg(feature = "tdx")]
+    mem.accept_memory_resources(num_vcpus);
     mem.setup_paging();
 
     // Relocate Mailbox along side with the AP function
-    td::relocate_mailbox(runtime_memory_layout.runtime_mailbox_base as u32);
+    td::relocate_mailbox(mem.layout.runtime_mailbox_base as u32);
 
     // Set up the TD event log buffer.
     // Safe because it's used to initialize the EventLog subsystem which ensures safety.
     let event_log_buf = unsafe {
         memslice::get_dynamic_mem_slice_mut(
             memslice::SliceType::EventLog,
-            runtime_memory_layout.runtime_event_log_base as usize,
+            mem.layout.runtime_event_log_base as usize,
         )
     };
     let mut td_event_log = tcg::TdEventLog::new(event_log_buf);
@@ -202,7 +199,7 @@ pub extern "win64" fn _start(
         boot_linux_kernel(
             &payload_info,
             &td_hob_info.acpi_tables,
-            &runtime_memory_layout,
+            &mem.layout,
             &mut td_event_log,
             num_vcpus,
         );
@@ -230,20 +227,13 @@ pub extern "win64" fn _start(
     stack_guard::stack_guard_enable(&mut mem);
     #[cfg(feature = "cet-ss")]
     cet_ss::enable_cet_ss(
-        runtime_memory_layout.runtime_shadow_stack_base,
-        runtime_memory_layout.runtime_shadow_stack_top,
+        mem.layout.runtime_shadow_stack_base,
+        mem.layout.runtime_shadow_stack_top,
     );
-    let stack_top =
-        (runtime_memory_layout.runtime_stack_base + TD_PAYLOAD_STACK_SIZE as u64) as usize;
+    let stack_top = (mem.layout.runtime_stack_base + TD_PAYLOAD_STACK_SIZE as u64) as usize;
 
     // Prepare the HOB list to run the image
-    let hob_base = prepare_hob_list(
-        hob_list,
-        &runtime_memory_layout,
-        basefw,
-        basefwsize,
-        memory_top_below_4gb,
-    );
+    let hob_base = prepare_hob_list(hob_list, &mem.layout, basefw, basefwsize);
 
     // Finally let's switch stack and jump to the image entry point...
     log::info!(
@@ -276,14 +266,6 @@ fn log_hob_list(hob_list: &[u8], td_event_log: &mut tcg::TdEventLog) {
         &tdx_handofftable_pointers_buffer,
         hob_list,
     );
-}
-
-fn accept_memory_resources(resources: &[ResourceDescription], num_vcpus: u32) {
-    for r in resources {
-        if r.resource_type == pi::hob::RESOURCE_SYSTEM_MEMORY {
-            td::accept_memory_resource_range(num_vcpus, r.physical_start, r.resource_length);
-        }
-    }
 }
 
 fn boot_linux_kernel(
@@ -358,7 +340,6 @@ fn prepare_hob_list(
     layout: &RuntimeMemoryLayout,
     basefw: u64,
     basefwsize: u64,
-    memory_top_below_4gb: u64,
 ) -> u64 {
     let hob_base = layout.runtime_hob_base;
     let memory_bottom = layout.runtime_memory_bottom;
@@ -371,9 +352,9 @@ fn prepare_hob_list(
         },
         version: 9u32,
         boot_mode: pi::boot_mode::BOOT_WITH_FULL_CONFIGURATION,
-        efi_memory_top: memory_top_below_4gb,
+        efi_memory_top: layout.runtime_memory_top,
         efi_memory_bottom: memory_bottom,
-        efi_free_memory_top: memory_top_below_4gb,
+        efi_free_memory_top: layout.runtime_memory_top,
         efi_free_memory_bottom: memory_bottom
             + ipl::efi_page_to_size(ipl::efi_size_to_page(size_of::<HobTemplate>() as u64)),
         efi_end_of_hob_list: hob_base + size_of::<HobTemplate>() as u64,

--- a/td-shim/src/bin/td-shim/td/tdx_mailbox.rs
+++ b/td-shim/src/bin/td-shim/td/tdx_mailbox.rs
@@ -149,13 +149,13 @@ fn wait_for_ap_arrive(ap_num: u32) {
     }
 }
 
-pub fn ap_assign_work(cpu_index: u32, stack: u64, entry: u32) {
+pub fn ap_assign_work(cpu_index: u32, stack_top: u64, entry: u32) {
     // Safety:
     // BSP is the owner of the mailbox area, and APs cooperate with BSP to access the mailbox area.
     let mut mail_box = unsafe { MailBox::new(get_mem_slice_mut(SliceType::MailBox)) };
 
     mail_box.set_wakeup_vector(entry);
-    mail_box.set_fw_arg(0, stack);
+    mail_box.set_fw_arg(0, stack_top);
     mail_box.set_command(spec::MP_WAKEUP_COMMAND_ACCEPT_PAGES);
     x86::fence::mfence();
     mail_box.set_apic_id(cpu_index);
@@ -254,8 +254,9 @@ pub fn accept_memory_resource_range(mut cpu_num: u32, address: u64, size: u64) {
     if major_part > 0 {
         // 0 is the bootstrap processor running this code
         for i in make_apic_range(active_ap_cnt) {
-            let ap_stack = stacks.as_ptr() as u64 + (i - 1) as u64 * 0x800;
-            ap_assign_work(i, ap_stack, parallel_accept_memory as *const () as u32);
+            // rsp should be at the top of the memory allocated for each ap
+            let stack_top = stacks.as_ptr() as u64 + i as u64 * AP_TEMP_STACK_SIZE as u64;
+            ap_assign_work(i, stack_top, parallel_accept_memory as *const () as u32);
         }
     }
 


### PR DESCRIPTION
This pull request makes some refactoring on HOB and memory:
- Memory: make create_e820_table() and accept_memory_resources() as methods of struct Memory. 
   Report all of the system memory to OS through E820 table.
- E820: enhance its implementation and add some interfaces to simplify E820 construction.
- Paging: Map all the memory reported by VMM.
- TD-Hob: parse TD-Hob into a struct instance to avoid parsing multiple times to get ACPI tables and 
   Payload information etc.

And fix below issues:
- https://github.com/confidential-containers/td-shim/issues/131
- https://github.com/confidential-containers/td-shim/issues/121