### PR TITLE
Fixed uart_16550 version to 0.2.14

### DIFF
--- a/devtools/test-runner-client/Cargo.toml
+++ b/devtools/test-runner-client/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2018"
 [dependencies]
 linked_list_allocator = "0.9.0"
 spin = { version = "0.9.2", features = ["lazy"]}
-uart_16550 = "0.2.14"
+uart_16550 = "=0.2.14"
 x86_64 = "=0.14.6"


### PR DESCRIPTION
Problem statement:

An error will be reported after the uart version is updated:

error: `ptr::mut_ptr::<impl *mut T>::add` is not yet stable as a const fn
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/uart_16550-0.2.17/src/mmio.rs:28:36
   |
28 |             int_en: AtomicPtr::new(base_pointer.add(1)),
   |                                    ^^^^^^^^^^^^^^^^^^^
   |
   = help: add `#![feature(const_ptr_offset)]` to the crate attributes to enable

error: `ptr::mut_ptr::<impl *mut T>::add` is not yet stable as a const fn
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/uart_16550-0.2.17/src/mmio.rs:29:39
   |
29 |             fifo_ctrl: AtomicPtr::new(base_pointer.add(2)),
   |                                       ^^^^^^^^^^^^^^^^^^^
   |
   = help: add `#![feature(const_ptr_offset)]` to the crate attributes to enable

error: `ptr::mut_ptr::<impl *mut T>::add` is not yet stable as a const fn
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/uart_16550-0.2.17/src/mmio.rs:30:39
   |
30 |             line_ctrl: AtomicPtr::new(base_pointer.add(3)),
   |                                       ^^^^^^^^^^^^^^^^^^^
   |
   = help: add `#![feature(const_ptr_offset)]` to the crate attributes to enable

error: `ptr::mut_ptr::<impl *mut T>::add` is not yet stable as a const fn
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/uart_16550-0.2.17/src/mmio.rs:31:40
   |
31 |             modem_ctrl: AtomicPtr::new(base_pointer.add(4)),
   |                                        ^^^^^^^^^^^^^^^^^^^
   |
   = help: add `#![feature(const_ptr_offset)]` to the crate attributes to enable

error: `ptr::mut_ptr::<impl *mut T>::add` is not yet stable as a const fn
  --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/uart_16550-0.2.17/src/mmio.rs:32:38
   |
32 |             line_sts: AtomicPtr::new(base_pointer.add(5)),
   |                                      ^^^^^^^^^^^^^^^^^^^
   |
   = help: add `#![feature(const_ptr_offset)]` to the crate attributes to enable

error: could not compile `uart_16550` due to 5 previous errors

Investigation:

uart_16550 update

- Remove stabilized nightly feature 'const_ptr_offset' ([https://github.com/confidential-containers/td-shim/pull/22](https://github.com/rust-osdev/uart_16550/pull/22))

Solution:

fixed uart_16550 version to 0.2.14

Signed-off-by: haowei <WeiX.Hao@intel.com>