### PR TITLE
test/test-td-paging: add feature default_alloc_error_handler

### DIFF
--- a/tests/test-td-paging/src/lib.rs
+++ b/tests/test-td-paging/src/lib.rs
@@ -8,6 +8,7 @@
 // Any function, const, or static can be annotated with `#[test_case]` causing it to be aggregated
 // (like #[test]) and be passed to the test runner determined by the `#![test_runner]` crate
 // attribute.
+#![feature(default_alloc_error_handler)]
 #![feature(custom_test_frameworks)]
 #![test_runner(test_runner)]
 // Reexport the test harness main function under a different symbol.


### PR DESCRIPTION
test/test-td-paging: add feature default_alloc_error_handler to solver the error alloc_error_handler function required, but not found.

```
error: `#[alloc_error_handler]` function required, but not found.
Error: `#[alloc_error_handler]` function required, but not found.
note: Use `#![feature(default_alloc_error_handler)]` for a default error handler.
```

Signed-off-by: haowei <WeiX.Hao@intel.com>