### PR TITLE
[Move] Update CI  and add members

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -10,6 +10,9 @@ on:
 name: Devtools
 
 env:
+  AS: nasm
+  AR_x86_64_unknown_uefi: llvm-ar
+  CC_x86_64_unknown_uefi: clang
   STABLE_RUST_TOOLCHAIN: 1.58.1
   NIGHTLY_RUST_TOOLCHAIN: nightly-2022-04-07
   TOOLCHAIN_PROFILE: minimal
@@ -32,21 +35,24 @@ jobs:
           version: "10.0"
           directory: ${{ runner.temp }}/llvm
 
+      - name: install NASM
+        uses: ilammy/setup-nasm@v1
+
       - name: Checkout sources
         uses: actions/checkout@v2
-
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
-          toolchain: ${{ env.NIGHTLY_RUST_TOOLCHAIN }}
-          override: true
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.STABLE_RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: ${{ env.TOOLCHAIN_PROFILE }}
+          toolchain: ${{ env.NIGHTLY_RUST_TOOLCHAIN }}
           override: true
 
       - name: Cache

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,9 +3,9 @@ on: [push, pull_request]
 name: Format and Clippy
 
 env:
-  AR: llvm-ar
   AS: nasm
-  CC: clang
+  AR_x86_64_unknown_uefi: llvm-ar
+  CC_x86_64_unknown_uefi: clang
 
 jobs:
   clippy:
@@ -29,7 +29,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.58.1
+          toolchain: nightly-2022-04-07
           override: true
           components: clippy
 
@@ -58,7 +58,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.58.1
+          toolchain: nightly-2022-04-07
           override: true
           components: rustfmt
 

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -10,9 +10,9 @@ on:
 name: Library Crates
 
 env:
-  AR: llvm-ar
   AS: nasm
-  CC: clang
+  AR_x86_64_unknown_uefi: llvm-ar
+  CC_x86_64_unknown_uefi: clang
   STABLE_RUST_TOOLCHAIN: 1.58.1
   NIGHTLY_RUST_TOOLCHAIN: nightly-2022-04-07
   TOOLCHAIN_PROFILE: minimal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,22 @@ jobs:
           command: install
           args: cargo-xbuild
 
+      - name: Build TdShim
+        uses: actions-rs/cargo@v1
+        with:
+          command: xbuild
+          args: -p td-shim --target x86_64-unknown-uefi --release --features=main,tdx
+
+      - name: Build PE format payload
+        run: |
+          cargo xbuild -p td-payload --target x86_64-unknown-uefi --release --features=main,tdx
+          cargo run -p td-shim-tools --features=td-shim/default --bin td-shim-ld -- target/x86_64-unknown-uefi/release/ResetVector.bin target/x86_64-unknown-uefi/release/td-shim.efi target/x86_64-unknown-uefi/release/td-payload.efi -o target/x86_64-unknown-uefi/release/final-pe.bin
+
+      - name: Build Elf format payload
+        run: |
+          cargo xbuild -p td-payload --target devtools/rustc-targets/x86_64-unknown-none.json --release --features=main,tdx
+          cargo run -p td-shim-tools --features=td-shim/default --bin td-shim-ld -- target/x86_64-unknown-uefi/release/ResetVector.bin target/x86_64-unknown-uefi/release/td-shim.efi target/x86_64-unknown-none/release/td-payload -o target/x86_64-unknown-uefi/release/final-elf.bin
+
   test:
     name: Test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,22 @@
 [workspace]
 resolver = "2"
-default-members = ["fake"]
+default-members = ["td-shim", "td-payload"]
 members = [
-	"fake",
-	"devtools/td-layout-config",
-	"devtools/test-runner-client",
-	"devtools/test-runner-server",
-	"td-exception",
-	"td-layout",
-	"td-logger",
-	"td-paging",
-	"td-uefi-pi",
-	"tdx-tdcall",
+    "devtools/td-layout-config",
+    "devtools/td-benchmark",
+    "devtools/test-runner-server",
+    "devtools/test-runner-client",
+    "td-exception",
+    "td-layout",
+    "td-logger",
+    "td-paging",
+    "td-payload",
+    "td-shim",
+    "td-shim-tools",
+    "tdx-tdcall",
+    "tests/test-td-exception",
+    "tests/test-td-paging",
+    "tests/test-td-payload",
 ]
 
 # the profile used for `cargo build`

--- a/td-payload/Cargo.toml
+++ b/td-payload/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 td-layout = { path = "../td-layout" }
 td-logger =  { path = "../td-logger" }
-uefi-pi =  { path = "../uefi-pi" }
+td-uefi-pi =  { path = "../td-uefi-pi" }
 
 td-benchmark = { path = "../devtools/td-benchmark", optional = true }
 tdx-tdcall = { path = "../tdx-tdcall", optional = true }

--- a/td-payload/src/main.rs
+++ b/td-payload/src/main.rs
@@ -39,7 +39,7 @@ mod payload_impl {
     use core::panic::PanicInfo;
     use td_layout::memslice;
     use td_layout::runtime::*;
-    use uefi_pi::hob;
+    use td_uefi_pi::hob;
 
     #[cfg(feature = "benches")]
     use benchmark::ALLOCATOR;


### PR DESCRIPTION
- Sync stagin branch CI
  The rust version in format.yaml temporarily use nightly
```
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> /home/haowx/.cargo/registry/src/github.com-1ecc6299db9ec823/linked_list_allocator-0.9.1/src/lib.rs:1:41
  |
1 | #![cfg_attr(feature = "const_mut_refs", feature(const_mut_refs))]
```
- Add members
  Add members to let CI pass
-  td-payload
  Update the dependent td-uefi-pi name in td-payload, which I forgot to update before