### PR TITLE
actions: Add an action for automatically doing releases and publishing the needed binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,91 @@
+name: Release TD-shim (staging)
+on: create
+
+env:
+  RUST_TOOLCHAIN: nightly-2022-04-07
+  TOOLCHAIN_PROFILE: minimal
+
+jobs:
+  release:
+    if: github.event_name == 'create' && github.event.ref_type== 'tag'
+    name: Release
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+
+    steps:
+      - name: install NASM
+        uses: ilammy/setup-nasm@v1
+
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "10.0"
+          directory: ${{ runner.temp }}/llvm
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: ${{ env.TOOLCHAIN_PROFILE }}
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: rust-src
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Run cargo install cargo-xbuild
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-xbuild
+
+      - name: Generate artifacts
+        run: |
+          bash sh_script/build_final.sh
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: true
+
+      - name: Upload final-pe.bin
+        id: upload_release_final_pe_bin
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: target/x86_64-unknown-uefi/release/final-pe.bin
+          asset_name: final-pe.bin
+          asset_content_type: application/octet-stream
+
+      - name: Upload final-pe-boot-kernel.bin
+        id: upload_release_final_pe_boot_kernel_bin
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: target/x86_64-unknown-uefi/release/final-pe-boot-kernel.bin
+          asset_name: final-pe-boot-kernel.bin
+          asset_content_type: application/octet-stream
+
+      - name: Upload final-elf.bin
+        id: upload_release_final_elf_bin
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: target/x86_64-unknown-uefi/release/final-elf.bin
+          asset_name: final-elf.bin
+          asset_content_type: application/octet-stream

--- a/sh_script/build_final.sh
+++ b/sh_script/build_final.sh
@@ -2,6 +2,7 @@
 
 export CC=clang
 export AR=llvm-ar
+export AS=nasm
 
 if [[ ! $PWD =~ td-shim$ ]];then
     pushd ..

--- a/sh_script/build_final.sh
+++ b/sh_script/build_final.sh
@@ -7,10 +7,9 @@ if [[ ! $PWD =~ td-shim$ ]];then
     pushd ..
 fi
 
-cargo xbuild -p td-shim --target x86_64-unknown-uefi --release --features=main,tdx --no-default-features
-
 final_pe() {
     echo final-pe
+    cargo xbuild -p td-shim --target x86_64-unknown-uefi --release --features=main,tdx --no-default-features
     cargo xbuild -p td-payload --target x86_64-unknown-uefi --release --features=main,tdx --no-default-features
     cargo run -p td-shim-tools --features="linker" --no-default-features --bin td-shim-ld -- \
         target/x86_64-unknown-uefi/release/ResetVector.bin \
@@ -21,6 +20,7 @@ final_pe() {
 
 final_elf() {
     echo final-elf
+    cargo xbuild -p td-shim --target x86_64-unknown-uefi --release --features=main,tdx --no-default-features
     cargo xbuild -p td-payload --target devtools/rustc-targets/x86_64-unknown-none.json --release --features=main,tdx
     cargo run -p td-shim-tools --features="linker" --no-default-features --bin td-shim-ld -- \
     target/x86_64-unknown-uefi/release/ResetVector.bin \

--- a/sh_script/build_final.sh
+++ b/sh_script/build_final.sh
@@ -24,7 +24,7 @@ final_elf() {
     cargo xbuild -p td-shim --target x86_64-unknown-uefi --release --features=main,tdx --no-default-features
     cargo xbuild -p td-payload --target devtools/rustc-targets/x86_64-unknown-none.json --release --features=main,tdx
     cargo run -p td-shim-tools --features="linker" --no-default-features --bin td-shim-ld -- \
-    target/x86_64-unknown-uefi/release/ResetVector.bin \
+        target/x86_64-unknown-uefi/release/ResetVector.bin \
         target/x86_64-unknown-uefi/release/td-shim.efi \
         target/x86_64-unknown-none/release/td-payload \
         -o target/x86_64-unknown-uefi/release/final-elf.bin 

--- a/sh_script/build_final.sh
+++ b/sh_script/build_final.sh
@@ -19,6 +19,17 @@ final_pe() {
         -o target/x86_64-unknown-uefi/release/final-pe.bin
 }
 
+final_pe_boot_kernel() {
+    echo "final-pe with boot-kernel support"
+    cargo xbuild -p td-shim --target x86_64-unknown-uefi --release --features=main,tdx,boot-kernel
+    cargo xbuild -p td-payload --target x86_64-unknown-uefi --release --features=main,tdx
+    cargo run -p td-shim-tools --features=td-shim/default,td-shim/tdx,boot-kernel --bin td-shim-ld -- \
+        target/x86_64-unknown-uefi/release/ResetVector.bin \
+        target/x86_64-unknown-uefi/release/td-shim.efi \
+        target/x86_64-unknown-uefi/release/td-payload.efi \
+        -o target/x86_64-unknown-uefi/release/final-pe-boot-kernel.bin
+}
+
 final_elf() {
     echo final-elf
     cargo xbuild -p td-shim --target x86_64-unknown-uefi --release --features=main,tdx --no-default-features
@@ -33,5 +44,6 @@ final_elf() {
 case "${1:-}" in
     elf) final_elf ;;
     pe) final_pe ;;
-    *) final_pe && final_elf ;;
+    pe_boot_kernel) final_pe_boot_kernel ;;
+    *) final_pe && final_pe_boot_kernel && final_elf ;;
 esac


### PR DESCRIPTION
This series is a pre-req for being able to release the  TD-shim binaries as part of a tagged release.

This groundwork leverages the `build_final.sh` script, which currently builds the `final-pe.bin` and the `final-elf.bin` binaries, to also build a `final-pe-boot-kernel.bin` binary.

The new binary is basically the good and well known `final-pe.bin`, but built with the `boot-kernel` feature enabled, which is essential for using td-shim with Cloud Hypervisor.

Once this series is merged, we'll use this script as part of a GitHub action that will run once a release is tagged, generating then those binaries and attaching those as artefacts of the release.  The action will come on a different PR as it'll hit the `main` branch directly, while this series here targets the staging branch.

@jyao1, please, take a look at those simple changes and let me know if you have any concern about them.