### PR TITLE
Td shim checker

### DIFF
--- a/td-layout/Cargo.toml
+++ b/td-layout/Cargo.toml
@@ -13,6 +13,7 @@ boot-kernel = []
 [dependencies]
 scroll = { version = "0.10", default-features = false, features = ["derive"]}
 log = "0.4.13"
+td-uefi-pi =  { path = "../td-uefi-pi" }
 
 [dev-dependencies]
 memoffset = "0.6"

--- a/td-shim-tools/Cargo.toml
+++ b/td-shim-tools/Cargo.toml
@@ -19,6 +19,10 @@ required-features = ["linker"]
 name = "td-shim-sign-payload"
 required-features = ["signer"]
 
+[[bin]]
+name = "td-shim-checker"
+required-features = ["loader"]
+
 [dependencies]
 r-efi = "3.2.0"
 scroll = { version = "0.10", default-features = false, features = ["derive"]}
@@ -34,8 +38,9 @@ td-loader = { path = "../td-loader", optional = true }
 ring = { git = "https://github.com/jyao1/ring.git", branch = "uefi_support", default-features = false, features = ["alloc"], optional = true }
 
 [features]
-default = ["boot-kernel", "enroller", "linker", "signer"]
+default = ["boot-kernel", "enroller", "linker", "signer", "loader"]
 boot-kernel = ["td-layout/boot-kernel", "td-shim/boot-kernel"]
 enroller = ["clap", "der", "env_logger", "log", "ring"]
 linker = ["clap", "env_logger", "log", "td-loader"]
 signer = ["clap", "der", "env_logger", "log", "ring"]
+loader = ["clap", "env_logger", "log"]

--- a/td-shim-tools/src/bin/td-shim-checker/README.md
+++ b/td-shim-tools/src/bin/td-shim-checker/README.md
@@ -1,0 +1,19 @@
+## td-shim checker
+
+This tool accepts td-shim file as input and extracts the TdxMetadata with the format of (TdxMetadataDescriptor, Vec\<TdxMetadataSection\>) if the TdxMetadata is valid in the input td-shim file. After that the TdxMetadata is dump out.
+
+### TdxMetadata
+
+Quotation from [TD Shim Metadata](../../../../doc/tdshim_spec.md#td-shim-metadata),
+
+### td-shim checker
+
+Run the tool:
+```
+cargo run -p td-shim-tools --bin td-shim-checker --no-default-features --features="loader" -- {tdshim_file}
+```
+
+For example:
+```
+cargo run -p td-shim-tools --bin td-shim-checker -- target/x86_64-unknown-uefi/release/final.bin
+```

--- a/td-shim-tools/src/bin/td-shim-checker/main.rs
+++ b/td-shim-tools/src/bin/td-shim-checker/main.rs
@@ -1,0 +1,123 @@
+// Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2022 Alibaba Cloud
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#[macro_use]
+extern crate clap;
+use log::{error, LevelFilter};
+use std::str::FromStr;
+use std::vec::Vec;
+use std::{env, io};
+use td_layout::metadata::{TdxMetadataDescriptor, TdxMetadataSection};
+use td_shim_tools::loader::TdShimLoader;
+
+struct Config {
+    // Input file path to be read
+    pub input: String,
+    // Log level "SHA384" by default
+    pub log_level: String,
+}
+
+#[derive(Debug)]
+pub enum ConfigParseError {
+    InvalidLogLevel,
+    InvalidInputFilePath,
+}
+
+impl Config {
+    pub fn new() -> Result<Self, ConfigParseError> {
+        let matches = command!()
+            .arg(
+                arg!([tdshim] "shim binary file")
+                    .required(true)
+                    .allow_invalid_utf8(false),
+            )
+            .arg(
+                arg!(-l --"log-level" "logging level: [off, error, warn, info, debug, trace]")
+                    .required(false)
+                    .default_value("info"),
+            )
+            .get_matches();
+
+        // Safe to unwrap() because they are mandatory or have default values.
+        //
+        // rust-td binary file
+        let input = matches.value_of("tdshim").unwrap().to_string();
+
+        // Safe to unwrap() because they are mandatory or have default values.
+        let log_level = String::from_str(matches.value_of("log-level").unwrap())
+            .map_err(|_| ConfigParseError::InvalidLogLevel)?;
+
+        Ok(Self { input, log_level })
+    }
+}
+
+fn dump_tdx_metadata(
+    metadata_descriptor: &TdxMetadataDescriptor,
+    metadata_sections: &Vec<TdxMetadataSection>,
+) {
+    println!("TdxMetadata version: {}", metadata_descriptor.version);
+    println!(
+        "Number of Sections : {}",
+        metadata_descriptor.number_of_section_entry
+    );
+    println!("-----------------------------------------");
+    let mut i = 0;
+    loop {
+        let section = metadata_sections[i];
+        println!(
+            "Section {0} - {1}",
+            i,
+            TdxMetadataSection::get_type_name(section.r#type).unwrap()
+        );
+        println!("  type            : {:X}", section.r#type);
+        println!("  data_offset     : {:X}", section.data_offset);
+        println!("  raw_data_size   : {:X}", section.raw_data_size);
+        println!("  memory_address  : {:X}", section.memory_address);
+        println!("  memory_data_size: {:X}", section.memory_data_size);
+        println!("  attributes      : {:X}", section.attributes);
+
+        i += 1;
+        if i == metadata_descriptor.number_of_section_entry as usize {
+            break;
+        }
+    }
+}
+
+fn main() -> io::Result<()> {
+    use env_logger::Env;
+    let env = Env::default()
+        .filter_or("MY_LOG_LEVEL", "info")
+        .write_style_or("MY_LOG_STYLE", "always");
+    env_logger::init_from_env(env);
+    let config = Config::new().map_err(|e| {
+        error!("Parse command line error: {:?}", e);
+        io::Error::new(io::ErrorKind::Other, "Invalid command line parameter")
+    })?;
+
+    if let Ok(lvl) = LevelFilter::from_str(config.log_level.as_str()) {
+        log::set_max_level(lvl);
+    }
+
+    println!(
+        "Parse td-shim binary [{}] to get TdxMetadata ...",
+        config.input
+    );
+    let tdx_metadata = TdShimLoader::parse(&config.input);
+    if tdx_metadata.is_none() {
+        println!(
+            "Failed to parse td-shim binary [{}] to get TdxMetadata",
+            config.input
+        );
+    } else {
+        let tdx_metadata = tdx_metadata.unwrap();
+        println!(
+            "Successfully parse td-shim binary [{}] to get TdxMetadata",
+            config.input
+        );
+        dump_tdx_metadata(&tdx_metadata.0, &tdx_metadata.1);
+    }
+
+    Ok(())
+}

--- a/td-shim-tools/src/lib.rs
+++ b/td-shim-tools/src/lib.rs
@@ -22,6 +22,9 @@ pub mod linker;
 #[cfg(feature = "signer")]
 pub mod signer;
 
+#[cfg(feature = "loader")]
+pub mod loader;
+
 /// Write three bytes from an integer value into the buffer.
 pub fn write_u24(data: u32, buf: &mut [u8]) {
     assert!(data < 0xffffff);

--- a/td-shim-tools/src/loader.rs
+++ b/td-shim-tools/src/loader.rs
@@ -1,0 +1,147 @@
+use log::debug;
+use log::error;
+use scroll::Pread;
+use std::fs;
+use std::io;
+use std::io::Read;
+use std::io::Seek;
+use td_layout::metadata::{
+    TdxMetadata, TdxMetadataDescriptor, TdxMetadataGuid, TdxMetadataSection,
+    TDX_METADATA_DESCRIPTOR_LEN, TDX_METADATA_GUID_LEN, TDX_METADATA_OFFSET,
+    TDX_METADATA_SECTION_LEN,
+};
+
+pub struct TdShimLoader;
+
+fn read_from_file(file: &mut std::fs::File, pos: u64, buffer: &mut [u8]) -> io::Result<()> {
+    debug!("Read at pos={0:X}, len={1:X}", pos, buffer.len());
+    let _pos = std::io::SeekFrom::Start(pos);
+    file.seek(_pos)?;
+    file.read_exact(buffer)?;
+    debug!("{:X?}", buffer);
+    Ok(())
+}
+
+impl TdShimLoader {
+    /// generate TdxMetadata elements tupple from input file
+    ///
+    /// # Arguments
+    ///
+    /// * `filename` - The td-shim binary which contains TdxMetadata
+    pub fn parse(filename: &String) -> Option<(TdxMetadataDescriptor, Vec<TdxMetadataSection>)> {
+        // first we open the input file and get its size
+        let f = fs::File::open(filename);
+        if f.is_err() {
+            error!("Problem opening the file");
+            return None;
+        }
+
+        let mut file = f.unwrap();
+
+        let file_metadata = fs::metadata(filename);
+        if file_metadata.is_err() {
+            error!("Problem read file meatadata");
+            return None;
+        }
+
+        let file_metadata = file_metadata.unwrap();
+        let file_size = file_metadata.len();
+
+        // Then read 4 bytes at the pos of [file_len - 0x20]
+        // This is the offset of TdxMetadata
+        let mut buffer: [u8; 4] = [0; 4];
+        if read_from_file(
+            &mut file,
+            file_size - TDX_METADATA_OFFSET as u64,
+            &mut buffer,
+        )
+        .is_err()
+        {
+            error!("Failed to read metadata offset");
+            return None;
+        }
+
+        let mut metadata_offset = u32::from_le_bytes(buffer);
+        if metadata_offset > file_size as u32 - TDX_METADATA_OFFSET - TDX_METADATA_DESCRIPTOR_LEN {
+            error!("The metadata offset is invalid. {}", metadata_offset);
+            error!("{:X?}", buffer);
+            return None;
+        }
+
+        // Then read the guid
+        metadata_offset -= TDX_METADATA_GUID_LEN;
+        let mut buffer: [u8; TDX_METADATA_GUID_LEN as usize] = [0; TDX_METADATA_GUID_LEN as usize];
+        if read_from_file(&mut file, metadata_offset as u64, &mut buffer).is_err() {
+            error!("Failed to read metadata guid from file");
+            return None;
+        }
+        let metadata_guid = TdxMetadataGuid::from_bytes(&buffer);
+        if metadata_guid.is_none() {
+            error!("Invalid TdxMetadataGuid");
+            error!("{:X?}", &buffer);
+            return None;
+        }
+
+        // Then the descriptor
+        let mut buffer: [u8; TDX_METADATA_DESCRIPTOR_LEN as usize] =
+            [0; TDX_METADATA_DESCRIPTOR_LEN as usize];
+        metadata_offset += TDX_METADATA_GUID_LEN;
+        if read_from_file(&mut file, metadata_offset as u64, &mut buffer).is_err() {
+            error!("Failed to read metadata descriptor from file");
+            return None;
+        }
+        let metadata_descriptor: TdxMetadataDescriptor =
+            buffer.pread::<TdxMetadataDescriptor>(0).unwrap();
+        if !metadata_descriptor.is_valid() {
+            error!("Invalid TdxMetadata Descriptor: {:?}", metadata_descriptor);
+            return None;
+        }
+
+        // check if the metadata length exceeds the file size
+        let metadata_len = metadata_descriptor.number_of_section_entry * TDX_METADATA_SECTION_LEN
+            + TDX_METADATA_GUID_LEN
+            + TDX_METADATA_DESCRIPTOR_LEN;
+        if metadata_offset + metadata_len + TDX_METADATA_GUID_LEN + TDX_METADATA_DESCRIPTOR_LEN
+            > file_size as u32
+        {
+            error!("Invalid TdxMetadata length {}", metadata_len);
+            return None;
+        }
+
+        // after that extract the sections one by one
+        let mut metadata_sections: Vec<TdxMetadataSection> = Vec::new();
+        let mut i = 0;
+        metadata_offset += TDX_METADATA_DESCRIPTOR_LEN;
+
+        loop {
+            let mut buffer: [u8; TDX_METADATA_SECTION_LEN as usize] =
+                [0; TDX_METADATA_SECTION_LEN as usize];
+            if read_from_file(&mut file, metadata_offset as u64, &mut buffer).is_err() {
+                error!("Failed to read section[{}] from file", i);
+                return None;
+            }
+
+            let section = buffer.pread::<TdxMetadataSection>(0).unwrap();
+            metadata_sections.push(section);
+
+            i += 1;
+            if i == metadata_descriptor.number_of_section_entry {
+                break;
+            }
+            metadata_offset += TDX_METADATA_SECTION_LEN;
+        }
+
+        if i != metadata_descriptor.number_of_section_entry {
+            error!("Invalid number of sections.");
+            return None;
+        }
+
+        // check the validness of the sections
+        if !TdxMetadata::is_valid_sections(&metadata_sections) {
+            error!("Invalid metadata sections.");
+            return None;
+        }
+
+        Some((metadata_descriptor, metadata_sections))
+    }
+}

--- a/td-uefi-pi/src/pi/guid.rs
+++ b/td-uefi-pi/src/pi/guid.rs
@@ -1,12 +1,16 @@
 use core::{convert::TryInto, mem::size_of, ptr::slice_from_raw_parts, str::FromStr};
 
+use scroll::{Pread, Pwrite};
+
+// use alloc::borrow::ToOwned;
+
 const GUID_STRING_LEN: usize = 36;
 const GUID_SPLITTER: u8 = b'-';
 
 // A GUID is a 128-bit integer (16 bytes) that can be
 // used as a unique identifier.
 #[repr(C)]
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq, Eq, Pwrite, Pread)]
 pub struct Guid {
     f0: u32,
     f1: u16,
@@ -32,6 +36,16 @@ impl Guid {
                 .try_into()
                 .unwrap()
         }
+    }
+
+    pub fn from_bytes(buffer: &[u8; 16]) -> Guid {
+        let f0 = u32::from_le_bytes(buffer[0..4].try_into().unwrap());
+        let f1 = u16::from_le_bytes(buffer[4..6].try_into().unwrap());
+        let f2 = u16::from_le_bytes(buffer[6..8].try_into().unwrap());
+        let mut f3: [u8; 8] = [0; 8];
+        f3.copy_from_slice(&buffer[8..]);
+
+        Self { f0, f1, f2, f3 }
     }
 }
 


### PR DESCRIPTION
This PR corresponds to issue https://github.com/confidential-containers/td-shim/issues/81 which tries to resolve:
1. Parse td-shim binary to find out the TdxMetadata
2. Validate TdxMeatadata information and ensure it follows the td-shim spec

So we create one library and one tool.
1. Create a td-shim-loader library, that could be reused by the VMM. 
    This library exports below function:
    TdShimLoader::parse(filename: &String) -> Option<(TdxMetadataDescriptor, Vec<TdxMetadataSection>)>

2. Create a td-shim-checker tool (consuming td-shim-loader), to validate the format of the final binary.
    cargo run -p td-shim-tools --bin td-shim-checker --no-default-features --features="loader" -- target/x86_64-unknown-uefi/release/final-pe.bi

In the meantime there are some other changes in other crates. They're in td-uefi-pi and td-layout. These changes are all related to td-shim-loader and td-shim-checker. So they're in the same PR.