### PR TITLE
workflows,release: Rename action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release TD-shim (staging)
+name: Release TD-shim
 on: create
 
 env:


### PR DESCRIPTION
Now that everything from the staging branch got merged into main,
there's no reason to keep the "staging" reference to the release
workflow.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>