### PR TITLE
Fix licenses info

### DIFF
--- a/devtools/test-runner-client/Cargo.toml
+++ b/devtools/test-runner-client/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Client cooperating with test-runner-server to execute unit test cases in virtual machines"
 repository = "https://github.com/confidential-containers/td-shim"
 homepage = "https://github.com/confidential-containers"
-license = "Apache 2.0"
+license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/devtools/test-runner-server/Cargo.toml
+++ b/devtools/test-runner-server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Server to run test cases inside a qemu virtual machine"
 repository = "https://github.com/confidential-containers/td-shim"
 homepage = "https://github.com/confidential-containers"
-license = "Apache 2.0"
+license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/td-exception/Cargo.toml
+++ b/td-exception/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Setup Interrupt Descriptor Table for td-shim"
 repository = "https://github.com/confidential-containers/td-shim"
 homepage = "https://github.com/confidential-containers"
-license = "Apache 2.0"
+license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/td-loader/Cargo.toml
+++ b/td-loader/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 description = "Parser and loader for 64 bit Portable Executable (PE+) or 32/64 bit Executable and Linkable Format(ELF) binary objects"
 repository = "https://github.com/confidential-containers/td-shim"
 homepage = "https://github.com/confidential-containers"
-license = "Apache 2.0"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "td-shim"
 version = "0.1.0"
+license = "BSD-2-Clause-Patent"
 edition = "2018"
 
 # add build process


### PR DESCRIPTION
1. Correct Apache license name form "Apache 2.0" to "Apache-2.0"
2. Add license for package td-shim

Signed-off-by: Wei Liu <wei3.liu@intel.com>