### PR TITLE
fix protection fault after exception handler returns

### DIFF
--- a/td-exception/src/interrupt.rs
+++ b/td-exception/src/interrupt.rs
@@ -199,7 +199,7 @@ macro_rules! interrupt_no_error {
             InterruptNoErrorStack,
             $func,
             "
-            iret
+            iretq
             "
         );
     };
@@ -215,7 +215,7 @@ macro_rules! interrupt_error {
             $func,
             "
             add rsp, 8
-            iret
+            iretq
             "
         );
     };


### PR DESCRIPTION
Fix: https://github.com/confidential-containers/td-shim/issues/172

From the assembly of the interrupt handler we can find the 'iret' is
compiled into 'iretw':
   ...
   c9c11:	5e                   	pop    %rsi
   c9c12:	5f                   	pop    %rdi
   c9c13:	5a                   	pop    %rdx
   c9c14:	59                   	pop    %rcx
   c9c15:	58                   	pop    %rax
   c9c16:	66 cf                	iretw

'iretw' pops IP, CS and the flags as 2 bytes each. But in 64-bits mode,
IRET executes with an 8-byte operand size, so it is incorrect here. We can
change it to 'iretq' to avoid the issue.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>