### PR TITLE
Refactor #VE handler

### DIFF
--- a/td-exception/src/interrupt.rs
+++ b/td-exception/src/interrupt.rs
@@ -489,19 +489,6 @@ fn handle_tdx_ioexit(ve_info: &tdx::TdVeInfoReturnData, stack: &mut InterruptNoE
     true
 }
 
-#[cfg(feature = "tdx")]
-fn deadloop() {
-    // TBD: empty `loop {}` wastes CPU cycles
-    #[allow(clippy::empty_loop)]
-    loop {
-        // TDX does not allow HLT instruction.
-        // TDVMCALL<HLT> may be used here. TBD later.
-        // x86_64::instructions::interrupts::enable();
-        // x86_64::instructions::hlt();
-    }
-}
-
-#[cfg(not(feature = "tdx"))]
 fn deadloop() {
     #[allow(clippy::empty_loop)]
     loop {

--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -30,8 +30,8 @@ const TDCALL_TDACCEPTPAGE: u64 = 6;
 // const TDVMCALL_CPUID: u64 = 0x0000a;
 const TDVMCALL_HALT: u64 = 0x0000c;
 const TDVMCALL_IO: u64 = 0x0001e;
-// const TDVMCALL_RDMSR: u64 = 0x0001f;
-// const TDVMCALL_WRMSR: u64 = 0x00020;
+const TDVMCALL_RDMSR: u64 = 0x0001f;
+const TDVMCALL_WRMSR: u64 = 0x00020;
 const TDVMCALL_MMIO: u64 = 0x00030;
 const TDVMCALL_MAPGPA: u64 = 0x10001;
 
@@ -272,6 +272,40 @@ pub fn tdvmcall_mapgpa(paddress: u64, length: usize) {
         paddr,
         length
     );
+}
+
+pub fn tdvmcall_rdmsr(index: u32) -> u64 {
+    let mut val = 0u64;
+    let ret = unsafe {
+        td_vm_call(
+            TDVMCALL_RDMSR,
+            index as u64,
+            0,
+            0,
+            0,
+            &mut val as *mut u64 as *mut core::ffi::c_void,
+        )
+    };
+    if ret != TDVMCALL_STATUS_SUCCESS {
+        tdvmcall_halt();
+    }
+    val
+}
+
+pub fn tdvmcall_wrmsr(index: u32, value: u64) {
+    let ret = unsafe {
+        td_vm_call(
+            TDVMCALL_WRMSR,
+            index as u64,
+            value,
+            0,
+            0,
+            core::ptr::null_mut(),
+        )
+    };
+    if ret != TDVMCALL_STATUS_SUCCESS {
+        tdvmcall_halt();
+    }
 }
 
 pub fn tdcall_get_td_info(td_info: &mut TdInfoReturnData) {

--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -294,13 +294,16 @@ pub fn tdcall_extend_rtmr(digest: &TdxDigest, mr_index: u32) {
     }
 }
 
-pub fn tdcall_get_ve_info(ve_info: &mut TdVeInfoReturnData) {
-    let buffer: u64 = ve_info as *mut TdVeInfoReturnData as *mut core::ffi::c_void as usize as u64;
+pub fn tdcall_get_ve_info() -> TdVeInfoReturnData {
+    let mut ve_info = TdVeInfoReturnData::default();
+    let buffer: u64 =
+        &mut ve_info as *mut TdVeInfoReturnData as *mut core::ffi::c_void as usize as u64;
 
     let ret = unsafe { td_call(TDCALL_TDGETVEINFO, 0, 0, 0, buffer) };
     if ret != TDX_EXIT_REASON_SUCCESS {
         tdvmcall_halt();
     }
+    ve_info
 }
 
 pub fn tdcall_accept_page(address: u64) -> Result<(), TdCallError> {

--- a/tests/test-td-payload/config/test_config_1.json
+++ b/tests/test-td-payload/config/test_config_1.json
@@ -86,7 +86,7 @@
     "tcs009": {
         "name": "testve",     
         "result": "None",
-        "run": false
+        "run": true
     },
     "tcs010": {
         "name": "testacpi",


### PR DESCRIPTION
Guest TD needs to retrieve the information when a #VE is injected by TDX
Module, otherwise TDX Module will inject a #DF next time it attempting to
inject a #VE.