### PR TITLE
Add setting env steps for Elf format payload build in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Set env:
 ```
 set CC_x86_64_unknown_uefi=clang
 set AR_x86_64_unknown_uefi=llvm-ar
+
+For Elf format payload build:
+set CC_x86_64_unknown_none=clang
+set AR_x86_64_unknown_none=llvm-ar
 ```
 
 ### Secure boot support


### PR DESCRIPTION
Add setting env steps in README.md to support
Elf format payload build.

Fix #259 

Signed-off-by: Wei Liu <wei3.liu@intel.com>