### PR TITLE
td-paging: make page table base and size as variable

### DIFF
--- a/devtools/td-layout-config/src/main.rs
+++ b/devtools/td-layout-config/src/main.rs
@@ -102,7 +102,7 @@ macro_rules! RUNTIME_TEMPLATE {
                     +--------------+ <-  0x00100000 (1M)
                     |   ........   |
                     +--------------+ <-  {pt_base:#010X}
-                    |  Page Table  |
+                    |  Page Table  | <-  {pt_size:#010x}
                     +--------------+ <-  {td_hob_base:#010X}
                     |    TD HOB    |
                     +--------------+ <-  {payload_param_base:#010X}
@@ -134,6 +134,7 @@ pub const TD_PAYLOAD_SHADOW_STACK_SIZE: u32 = {shadow_stack_size:#X};
 pub const TD_PAYLOAD_STACK_SIZE: u32 = {stack_size:#X};
 
 pub const TD_PAYLOAD_PAGE_TABLE_BASE: u64 = {pt_base:#X};
+pub const TD_PAYLOAD_PAGE_TABLE_SIZE: usize = {pt_size:#X};
 pub const TD_HOB_BASE: u64 = {td_hob_base:#X};
 pub const TD_HOB_SIZE: u64 = {td_hob_size:#X};
 pub const TD_PAYLOAD_PARAM_BASE: u64 = {payload_param_base:#X};
@@ -252,6 +253,7 @@ impl TdLayout {
             &mut to_generate,
             RUNTIME_TEMPLATE!(),
             pt_base = self.runtime.pt_base,
+            pt_size = self.runtime.pt_size,
             td_hob_base = self.runtime.td_hob_base,
             td_hob_size = self.runtime.td_hob_size,
             payload_base = self.runtime.payload_base,
@@ -388,6 +390,7 @@ impl TdLayoutImageLoaded {
 #[derive(Debug, Default, PartialEq)]
 struct TdLayoutRuntime {
     pt_base: u32,
+    pt_size: u32,
     td_hob_base: u32,
     td_hob_size: u32,
     payload_base: u32,
@@ -423,6 +426,7 @@ impl TdLayoutRuntime {
 
         TdLayoutRuntime {
             pt_base: config.runtime_layout.page_table_base,
+            pt_size: config.runtime_layout.page_table_size,
             td_hob_base,
             td_hob_size: config.runtime_layout.td_hob_size,
             payload_param_base: config.runtime_layout.payload_param_base,

--- a/td-layout/src/runtime.rs
+++ b/td-layout/src/runtime.rs
@@ -12,7 +12,7 @@
                     +--------------+ <-  0x00100000 (1M)
                     |   ........   |
                     +--------------+ <-  0x00800000
-                    |  Page Table  |
+                    |  Page Table  | <-  0x00800000
                     +--------------+ <-  0x01000000
                     |    TD HOB    |
                     +--------------+ <-  0x01100000
@@ -44,6 +44,7 @@ pub const TD_PAYLOAD_SHADOW_STACK_SIZE: u32 = 0x200000;
 pub const TD_PAYLOAD_STACK_SIZE: u32 = 0x800000;
 
 pub const TD_PAYLOAD_PAGE_TABLE_BASE: u64 = 0x800000;
+pub const TD_PAYLOAD_PAGE_TABLE_SIZE: usize = 0x800000;
 pub const TD_HOB_BASE: u64 = 0x1000000;
 pub const TD_HOB_SIZE: u64 = 0x20000;
 pub const TD_PAYLOAD_PARAM_BASE: u64 = 0x1100000;

--- a/td-paging/src/consts.rs
+++ b/td-paging/src/consts.rs
@@ -6,25 +6,8 @@
 pub const PHYS_VIRT_OFFSET: usize = 0;
 /// Page size.
 pub const PAGE_SIZE: usize = 0x1000;
-/// The memory size reserved for page table pages.
-pub const PAGE_TABLE_SIZE: usize = 0x800000;
 
 /// Default PTE(page table entry) size.
 pub const PAGE_SIZE_DEFAULT: usize = 0x4000_0000;
 /// Minimal PTE(page table entry) size.
 pub const PAGE_SIZE_4K: usize = 0x1000;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use td_layout::runtime;
-
-    #[test]
-    fn test_constants() {
-        // Ensure the runtime layout has reserved enough space for page table pages.
-        assert!(
-            PAGE_TABLE_SIZE as u64
-                <= runtime::TD_PAYLOAD_PARAM_BASE - runtime::TD_PAYLOAD_PAGE_TABLE_BASE
-        );
-    }
-}

--- a/td-paging/src/lib.rs
+++ b/td-paging/src/lib.rs
@@ -4,6 +4,8 @@
 
 #![no_std]
 
+extern crate alloc;
+
 mod consts;
 mod frame;
 mod page_table;
@@ -11,9 +13,22 @@ mod page_table;
 pub use consts::*;
 pub use page_table::{cr3_write, create_mapping, create_mapping_with_flags, set_page_flags};
 
+#[derive(Debug)]
+pub enum Error {
+    InvalidArguments,
+    MappingError(u64, u64), // physical address, frame size
+}
+
+type Result<T> = core::result::Result<T, Error>;
+
 /// Initialize the page table management subsystem.
-pub fn init() {
-    frame::init();
+pub fn init(base: u64, size: usize) -> Result<()> {
+    if base as usize % PAGE_SIZE != 0 || size % PAGE_SIZE != 0 {
+        return Err(Error::InvalidArguments);
+    }
+
+    frame::init(base, size);
+    Ok(())
 }
 
 /// Reserve page table page at physical address `addr`.

--- a/td-shim/src/bin/td-shim/memory.rs
+++ b/td-shim/src/bin/td-shim/memory.rs
@@ -5,7 +5,8 @@
 use alloc::vec::Vec;
 use td_layout::build_time::{TD_SHIM_FIRMWARE_BASE, TD_SHIM_FIRMWARE_SIZE};
 use td_layout::runtime::{
-    self, TD_PAYLOAD_BASE, TD_PAYLOAD_EVENT_LOG_SIZE, TD_PAYLOAD_PAGE_TABLE_BASE, TD_PAYLOAD_SIZE,
+    self, TD_PAYLOAD_BASE, TD_PAYLOAD_EVENT_LOG_SIZE, TD_PAYLOAD_PAGE_TABLE_BASE,
+    TD_PAYLOAD_PAGE_TABLE_SIZE, TD_PAYLOAD_SIZE,
 };
 use td_layout::{RuntimeMemoryLayout, MIN_MEMORY_SIZE};
 use td_shim::e820::E820Type;
@@ -87,7 +88,7 @@ impl<'a> Memory<'a> {
 
     pub fn setup_paging(&mut self) {
         // Init frame allocator
-        td_paging::init();
+        td_paging::init(TD_PAYLOAD_PAGE_TABLE_BASE, TD_PAYLOAD_PAGE_TABLE_SIZE);
         // Create mapping for firmware image space
         td_paging::create_mapping(
             &mut self.pt,
@@ -214,4 +215,19 @@ pub fn cpu_get_memory_space_size() -> u8 {
     );
 
     size_of_mem_space
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use td_layout::runtime;
+
+    #[test]
+    fn test_constants() {
+        // Ensure the runtime layout has reserved enough space for page table pages.
+        assert!(
+            PAGE_TABLE_SIZE as u64
+                <= runtime::TD_PAYLOAD_PARAM_BASE - runtime::TD_PAYLOAD_PAGE_TABLE_BASE
+        );
+    }
 }

--- a/td-shim/src/bin/td-shim/payload_hob.rs
+++ b/td-shim/src/bin/td-shim/payload_hob.rs
@@ -192,7 +192,7 @@ pub fn build_payload_hob(acpi_tables: &Vec<&[u8]>, memory: &Memory) -> Option<Pa
     e820.convert_range(
         E820Type::Reserved,
         TD_PAYLOAD_PAGE_TABLE_BASE,
-        td_paging::PAGE_TABLE_SIZE as u64,
+        TD_PAYLOAD_PAGE_TABLE_SIZE as u64,
     );
     e820.convert_range(E820Type::Reserved, TD_PAYLOAD_BASE, TD_PAYLOAD_SIZE as u64);
     e820.convert_range(

--- a/tests/test-td-paging/src/lib.rs
+++ b/tests/test-td-paging/src/lib.rs
@@ -51,12 +51,10 @@ fn kernel_main(boot_info: &'static mut BootInfo) -> ! {
 #[cfg(test)]
 mod tests {
     use td_layout::runtime;
-    use td_paging::{
-        create_mapping, reserve_page, PAGE_SIZE_DEFAULT, PAGE_TABLE_SIZE, PHYS_VIRT_OFFSET,
-    };
+    use td_paging::{reserve_page, PHYS_VIRT_OFFSET};
     use x86_64::{
         structures::paging::{OffsetPageTable, PageTable},
-        PhysAddr, VirtAddr,
+        VirtAddr,
     };
 
     /// Build page table to map guest physical addres range [0, system_memory_size), the top page table
@@ -71,8 +69,10 @@ mod tests {
 
         if page_table_memory_base > system_memory_size
             || page_table_memory_base < runtime::TD_PAYLOAD_PAGE_TABLE_BASE
-            || page_table_memory_base > runtime::TD_PAYLOAD_PAGE_TABLE_BASE + PAGE_TABLE_SIZE as u64
-            || runtime::TD_PAYLOAD_PAGE_TABLE_BASE + PAGE_TABLE_SIZE as u64 > system_memory_size
+            || page_table_memory_base
+                > runtime::TD_PAYLOAD_PAGE_TABLE_BASE + runtime::TD_PAYLOAD_PAGE_TABLE_SIZE as u64
+            || runtime::TD_PAYLOAD_PAGE_TABLE_BASE + runtime::TD_PAYLOAD_PAGE_TABLE_SIZE as u64
+                > system_memory_size
         {
             panic!(
                 "invalid parameters (0x{:x}, 0x{:x} to setup_paging()",
@@ -98,10 +98,13 @@ mod tests {
 
     #[test_case]
     fn test_create_paging() {
-        td_paging::init();
+        td_paging::init(
+            runtime::TD_PAYLOAD_PAGE_TABLE_BASE,
+            runtime::TD_PAYLOAD_PAGE_TABLE_SIZE,
+        );
         setup_paging(
             runtime::TD_PAYLOAD_PAGE_TABLE_BASE + 0x1000,
-            runtime::TD_PAYLOAD_PAGE_TABLE_BASE + PAGE_TABLE_SIZE as u64,
+            runtime::TD_PAYLOAD_PAGE_TABLE_BASE + runtime::TD_PAYLOAD_PAGE_TABLE_SIZE as u64,
         );
 
         // TODO: add test cases for create_mapping_with_flags(), set_page_flags()


### PR DESCRIPTION
Caller may decide where to put the page table and how much memory should page table occupy. This makes the td-paging crate more reusable.        
     - init() API will accept two arguments of base and size.
     - FrameAlloc use vector to hold the bitmap. Heap is ready when setting up page table.