### PR TITLE
reproducible-tool: Roll back temporarily due to bug introduced by strip option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,3 @@ panic = "abort" # disable stack unwinding on panic
 [profile.release]
 panic = "abort"    # disable stack unwinding on panic
 lto = true         # Link-time optimization
-strip = "symbols"  # remove debug related symbols/sections

--- a/td-reproducible-tool/readme.md
+++ b/td-reproducible-tool/readme.md
@@ -23,6 +23,8 @@ Solution: <br>
 ```
 NOTE: 3 and 4 may be resolved directly after rust-lang RFC 3127. This tool provide a temp solution to solve 3 and 4 before RFC is implemented.
 
+NOTE: 1 and 2 are not applied because this strip feature has potential stability issue. For example, [bug](https://github.com/confidential-containers/td-shim/issues/272). It can be enabled after the strip becomes more robust.
+
 ## tool usage
 
 ```


### PR DESCRIPTION
Signed-off-by: Longlong Yang <longlong.yang@intel.com>