### PR TITLE
reproducible-tool: bug fix for the absence of binary write back.

### DIFF
--- a/td-shim-tools/src/bin/td-shim-strip-info/main.rs
+++ b/td-shim-tools/src/bin/td-shim-strip-info/main.rs
@@ -140,6 +140,7 @@ fn main() -> std::io::Result<()> {
         println!(
             "INFO: -s or --strip_path is not specified, Skipping strip related rust file path."
         );
+        fs::write(binary_path, buf).expect("Failed to open the compiled binary!\n");
         return Ok(());
     }
 


### PR DESCRIPTION
fix #288 
Signed-off-by: Longlong Yang <longlong.yang@intel.com>