### PR TITLE
td-shim: get private memory information with metadata

### DIFF
--- a/td-shim/src/bin/td-shim/e820.rs
+++ b/td-shim/src/bin/td-shim/e820.rs
@@ -10,7 +10,7 @@ use td_shim::e820::{E820Entry, E820Type};
 // Linux BootParam supports 128 e820 entries, so...
 const MAX_E820_ENTRY: usize = 128;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct E820Table {
     entries: Vec<E820Entry>,
 }

--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -116,9 +116,6 @@ pub extern "win64" fn _start(
     // Initialize memory subsystem.
     let mut mem = memory::Memory::new(&td_hob_info.memory)
         .expect("Unable to find a piece of suitable memory for runtime");
-    let num_vcpus = td::get_num_vcpus();
-    #[cfg(feature = "tdx")]
-    mem.accept_memory_resources(num_vcpus);
     mem.setup_paging();
 
     // Relocate Mailbox along side with the AP function
@@ -135,6 +132,7 @@ pub extern "win64" fn _start(
     let mut td_event_log = tcg::TdEventLog::new(event_log_buf);
     log_hob_list(hob_list, &mut td_event_log);
 
+    let num_vcpus = td::get_num_vcpus();
     //Create MADT and TDEL
     let (madt, tdel) = prepare_acpi_tables(
         &mut td_hob_info.acpi_tables,
@@ -200,7 +198,6 @@ fn boot_linux_kernel(
 
     let rsdp = install_acpi_tables(acpi_tables, &mem.layout);
     let e820_table = mem.create_e820();
-    log::info!("e820 table: {:x?}\n", e820_table.as_slice());
     // Safe because we are handle off this buffer to linux kernel.
     let payload = unsafe { memslice::get_mem_slice_mut(memslice::SliceType::Payload) };
 

--- a/td-shim/src/bin/td-shim/payload_hob.rs
+++ b/td-shim/src/bin/td-shim/payload_hob.rs
@@ -176,10 +176,6 @@ pub fn build_payload_hob(acpi_tables: &Vec<&[u8]>, memory: &Memory) -> Option<Pa
     payload_hob.add_cpu(memory::cpu_get_memory_space_size(), 16);
     payload_hob.add_fv(TD_SHIM_PAYLOAD_BASE as u64, TD_SHIM_PAYLOAD_SIZE as u64);
 
-    for resource in &memory.regions {
-        payload_hob.add_resource(&resource).ok()?;
-    }
-
     for &table in acpi_tables {
         payload_hob
             .add_guided_data(&TD_ACPI_TABLE_HOB_GUID, table)

--- a/td-shim/src/bin/td-shim/td/tdx.rs
+++ b/td-shim/src/bin/td-shim/td/tdx.rs
@@ -18,7 +18,8 @@ pub fn get_shared_page_mask() -> u64 {
     tdx::td_shared_mask().expect("Unable to get GPAW")
 }
 
-pub fn accept_memory_resource_range(mut cpu_num: u32, address: u64, size: u64) {
+pub fn accept_memory_resource_range(address: u64, size: u64) {
+    let cpu_num = get_num_vcpus();
     super::tdx_mailbox::accept_memory_resource_range(cpu_num, address, size)
 }
 

--- a/tests/test-td-payload/config/test_config_1.json
+++ b/tests/test-td-payload/config/test_config_1.json
@@ -112,7 +112,7 @@
             "size": "1G"
         },
         "result": "None",
-        "run": false
+        "run": true
     },
     "tcs012": {
         "name": "memorymap002",

--- a/tests/test-td-payload/config/test_config_2.json
+++ b/tests/test-td-payload/config/test_config_2.json
@@ -124,7 +124,7 @@
             "size": "2G"
         },
         "result": "None",
-        "run": false
+        "run": true
     },
     "tcs013": {
         "name": "memorymap003",

--- a/tests/test-td-payload/config/test_config_3.json
+++ b/tests/test-td-payload/config/test_config_3.json
@@ -132,7 +132,7 @@
             "size": "4G"
         },
         "result": "None",
-        "run": false
+        "run": true
     },
     "tcs014": {
         "name": "memorymap004",

--- a/tests/test-td-payload/config/test_config_4.json
+++ b/tests/test-td-payload/config/test_config_4.json
@@ -140,7 +140,7 @@
             "size": "8G"
         },
         "result": "None",
-        "run": false
+        "run": true
     },
     "tcs015": {
         "name": "memorymap005",

--- a/tests/test-td-payload/config/test_config_5.json
+++ b/tests/test-td-payload/config/test_config_5.json
@@ -148,7 +148,7 @@
             "size": "16G"
         },
         "result": "None",
-        "run": false
+        "run": true
     },
     "tcs016": {
         "name": "tdtrustedboot001",

--- a/tests/test-td-payload/src/testmemmap.rs
+++ b/tests/test-td-payload/src/testmemmap.rs
@@ -70,7 +70,7 @@ impl TestMemoryMap {
             let table = hob::get_guid_data(hob).expect("Failed to get data from ACPI GUID HOB");
 
             let mut offset = 0;
-            while offset < table.len() {
+            while offset < table.len() && offset + size_of::<E820Entry>() <= table.len() {
                 let entry = E820Entry::read_from(&table[offset..offset + size_of::<E820Entry>()])?;
                 // save it to tables
                 e820.push(entry);


### PR DESCRIPTION
Fix issue: https://github.com/confidential-containers/td-shim/issues/261

VMM reports the private memory resources as reserved memory type, and they
may be confused with other reserved memory information reported by VMM.

As declared in td-shim spec that the private memory information is
optional because the TD Shim can get the information from metadata
directly, we can ignore the private memory regions reported by VMM and use
the metadata instead.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>