### PR TITLE
 td-shim: follow System V ABI when payload is ELF

### DIFF
--- a/td-loader/src/elf.rs
+++ b/td-loader/src/elf.rs
@@ -4,7 +4,7 @@
 
 use scroll::Pwrite;
 
-use crate::elf64::{ProgramHeader, PT_LOAD, PT_PHDR};
+use crate::elf64::{PT_LOAD, PT_PHDR};
 
 use core::ops::Range;
 

--- a/td-loader/src/elf.rs
+++ b/td-loader/src/elf.rs
@@ -24,7 +24,6 @@ pub fn is_elf(image: &[u8]) -> bool {
 pub fn relocate_elf_with_per_program_header(
     image: &[u8],
     loaded_buffer: &mut [u8],
-    mut program_header_closures: impl FnMut(ProgramHeader),
 ) -> Option<(u64, u64, u64)> {
     let new_image_base = loaded_buffer as *const [u8] as *const u8 as usize;
     // parser file and get entry point
@@ -76,10 +75,6 @@ pub fn relocate_elf_with_per_program_header(
                 )
                 .ok()?;
         }
-    }
-
-    for ph in elf.program_headers() {
-        program_header_closures(ph);
     }
 
     Some((
@@ -153,6 +148,6 @@ mod test_elf_loader {
 
         let mut loaded_buffer = vec![0u8; 0x800000];
 
-        super::relocate_elf_with_per_program_header(pe_image, loaded_buffer.as_mut_slice(), |_| ());
+        super::relocate_elf_with_per_program_header(pe_image, loaded_buffer.as_mut_slice());
     }
 }

--- a/td-payload/src/main.rs
+++ b/td-payload/src/main.rs
@@ -86,7 +86,7 @@ mod payload_impl {
 
     #[no_mangle]
     #[cfg_attr(target_os = "uefi", export_name = "efi_main")]
-    pub extern "win64" fn _start(hob: *const c_void) -> ! {
+    pub extern "C" fn _start(hob: *const c_void) -> ! {
         #[cfg(feature = "tdx")]
         {
             td_logger::init().expect("td-payload: failed to initialize tdx logger");

--- a/td-shim/src/bin/td-shim/asm/switch_stack.asm
+++ b/td-shim/src/bin/td-shim/asm/switch_stack.asm
@@ -3,14 +3,14 @@
 
 .section .text
 
-#  switch_stack_call(
+#  switch_stack_call_win64(
 #       entry_point: usize, // rcx
 #       stack_top: usize,   // rdx
 #       P1: usize,          // r8
 #       P2: usize           // r9
 #       );
-.global switch_stack_call
-switch_stack_call:
+.global switch_stack_call_win64
+switch_stack_call_win64:
         sub    rdx,0x20
         mov    rsp,rdx
         mov    rax,rcx
@@ -18,5 +18,23 @@ switch_stack_call:
         mov    rdx,r9
         call   rax
         int3
-        jmp    switch_stack_call
+        jmp    switch_stack_call_win64
+        ret
+
+#  switch_stack_call_sysv(
+#       entry_point: usize, // rcx
+#       stack_top: usize,   // rdx
+#       P1: usize,          // r8
+#       P2: usize           // r9
+#       );
+.global switch_stack_call_sysv
+switch_stack_call_sysv:
+        sub    rdx,0x20
+        mov    rsp,rdx
+        mov    rax,rcx
+        mov    rdi,r8
+        mov    rsi,r9
+        call   rax
+        int3
+        jmp    switch_stack_call_sysv
         ret

--- a/tests/test-td-payload/src/main.rs
+++ b/tests/test-td-payload/src/main.rs
@@ -126,7 +126,7 @@ fn build_testcases() -> TestCases {
 #[cfg(not(test))]
 #[no_mangle]
 #[cfg_attr(target_os = "uefi", export_name = "efi_main")]
-extern "win64" fn _start(hob: *const c_void) -> ! {
+extern "C" fn _start(hob: *const c_void) -> ! {
     use td_layout::runtime::*;
     use testmemmap::TestMemoryMap;
 


### PR DESCRIPTION
As declared in td-shim spec that for ELF image, System-V ABI AMD64 calling
convention must be used. RDI must hold the payload HOB address, RSI must
hold the address where payload is loaded.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>