### PR TITLE
tests: counting memory size ignores the reserved address range

### DIFF
--- a/tests/test-td-payload/config/test_config_1.json
+++ b/tests/test-td-payload/config/test_config_1.json
@@ -112,7 +112,7 @@
             "size": "1G"
         },
         "result": "None",
-        "run": false
+        "run": true
     },
     "tcs012": {
         "name": "memorymap002",

--- a/tests/test-td-payload/config/test_config_2.json
+++ b/tests/test-td-payload/config/test_config_2.json
@@ -124,7 +124,7 @@
             "size": "2G"
         },
         "result": "None",
-        "run": false
+        "run": true
     },
     "tcs013": {
         "name": "memorymap003",

--- a/tests/test-td-payload/config/test_config_3.json
+++ b/tests/test-td-payload/config/test_config_3.json
@@ -132,7 +132,7 @@
             "size": "4G"
         },
         "result": "None",
-        "run": false
+        "run": true
     },
     "tcs014": {
         "name": "memorymap004",

--- a/tests/test-td-payload/config/test_config_4.json
+++ b/tests/test-td-payload/config/test_config_4.json
@@ -140,7 +140,7 @@
             "size": "8G"
         },
         "result": "None",
-        "run": false
+        "run": true
     },
     "tcs015": {
         "name": "memorymap005",

--- a/tests/test-td-payload/config/test_config_5.json
+++ b/tests/test-td-payload/config/test_config_5.json
@@ -148,7 +148,7 @@
             "size": "16G"
         },
         "result": "None",
-        "run": false
+        "run": true
     },
     "tcs016": {
         "name": "tdtrustedboot001",


### PR DESCRIPTION
Address range from top of low memory (TOLM) to 4G is not for system memory
so we should exclude this range when calculating the system memory size.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>