### PR TITLE
Add check for readlen and header.length in secure_boot.rs

### DIFF
--- a/td-shim/src/secure_boot.rs
+++ b/td-shim/src/secure_boot.rs
@@ -271,6 +271,7 @@ impl<'a> PayloadVerifier<'a> {
         let header = file.gread::<CfvPubKeyFileHeader>(&mut readlen).unwrap();
         if &header.type_guid != CFV_FILE_HEADER_PUBKEY_GUID.as_bytes()
             || header.length as usize > file.len()
+            || readlen > header.length as usize
         {
             return Err(VerifyErr::InvalidPublicKey);
         }


### PR DESCRIPTION
Fix #317

Signed-off-by: Wei Liu <wei3.liu@intel.com>