### PR TITLE
td-shim: clear 'command' when AP is waked up

### DIFF
--- a/td-shim/src/bin/td-shim/asm/ap_loop.asm
+++ b/td-shim/src/bin/td-shim/asm/ap_loop.asm
@@ -81,6 +81,10 @@ ap_relocated_func:
     # BSP sets these variables before unblocking APs
     mov     rax, 0
     mov     eax, dword ptr[rbx + WakeupVectorOffset]
+
+    #
+    # Clear the command as the acknowledgement that the wake up command is received
+    mov     qword ptr[rbx + CommandOffset], MpProtectedModeWakeupCommandNoop
     nop
     jmp     rax
 


### PR DESCRIPTION
Fix issue https://github.com/confidential-containers/td-shim/issues/321

According to ACPI specification section '5.2.12.19. Multiprocessor Wakeup
Structure', the application processor need clear the command to Noop(0) as
the acknowledgement that the command is received.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>