### PR TITLE
td-shim: set up page table for APs that maps all system memory

### DIFF
--- a/devtools/td-layout-config/config.json
+++ b/devtools/td-layout-config/config.json
@@ -77,7 +77,7 @@
         "payload_param_size": 0x100000,
         "payload_param_base": 0x01100000,
         "td_hob_size": 0x20000,
-        "page_table_size": 0x800000,
+        "page_table_size": 0x20000,
         "page_table_base": 0x800000,
     }
 }

--- a/td-layout/src/runtime.rs
+++ b/td-layout/src/runtime.rs
@@ -12,8 +12,8 @@
                     +--------------+ <-  0x00100000 (1M)
                     |   ........   |
                     +--------------+ <-  0x00800000
-                    |  Page Table  | <-  0x00800000
-                    +--------------+ <-  0x01000000
+                    |  Page Table  | <-  0x00020000
+                    +--------------+ <-  0x00820000
                     |    TD HOB    |
                     +--------------+ <-  0x01100000
                     | PAYLOAD PARAM|    (0x00100000)
@@ -44,8 +44,8 @@ pub const TD_PAYLOAD_SHADOW_STACK_SIZE: u32 = 0x200000;
 pub const TD_PAYLOAD_STACK_SIZE: u32 = 0x800000;
 
 pub const TD_PAYLOAD_PAGE_TABLE_BASE: u64 = 0x800000;
-pub const TD_PAYLOAD_PAGE_TABLE_SIZE: usize = 0x800000;
-pub const TD_HOB_BASE: u64 = 0x1000000;
+pub const TD_PAYLOAD_PAGE_TABLE_SIZE: usize = 0x20000;
+pub const TD_HOB_BASE: u64 = 0x820000;
 pub const TD_HOB_SIZE: u64 = 0x20000;
 pub const TD_PAYLOAD_PARAM_BASE: u64 = 0x1100000;
 pub const TD_PAYLOAD_PARAM_SIZE: u64 = 0x100000;

--- a/td-shim/ResetVector/CommonMacros.inc
+++ b/td-shim/ResetVector/CommonMacros.inc
@@ -36,6 +36,7 @@ OSArgsOffset                              equ       10h
 FirmwareArgsOffset                        equ       800h
 WakeupArgsRelocatedMailBox                equ       800h
 ApWorkingStackStart                       equ       800h
+PageTableBaseOffset                       equ       800h
 CpuArrivalOffset                          equ       900h
 CpusExitingOffset                         equ       0a00h
 TalliesOffset                             equ       0a08h
@@ -45,6 +46,7 @@ MpProtectedModeWakeupCommandWakeup        equ       1
 MpProtectedModeWakeupCommandSleep         equ       2
 MpProtectedModeWakeupCommandAssignWork    equ       3
 MpProtectedModeWakeupCommandCheck         equ       4
+MpProtectedModeWakeupCommandSetCr3        equ       5
 
 MailboxApicIdInvalid                      equ       0xffffffff
 MailboxApicidBroadcast                    equ       0xfffffffe

--- a/td-shim/ResetVector/Main.asm
+++ b/td-shim/ResetVector/Main.asm
@@ -270,11 +270,27 @@ ParkAp:
     cmp     eax, MpProtectedModeWakeupCommandAssignWork
     je      .set_ap_stack
 
+    ;
+    ; Set page table for AP
+    cmp     eax, MpProtectedModeWakeupCommandSetCr3
+    je      .set_page_table
+
     jmp    .check_apicid
 
 .check_avalible
     ;
     ; Set the ApicId to be invalid to show the AP is available
+    mov     dword[rsp + ApicidOffset], MailboxApicIdInvalid
+    jmp     .check_apicid
+
+.set_page_table
+    ;
+    ; Read out the page table address from mailbox and write it to CR3
+    mov     rax, [rsp + PageTableBaseOffset]
+    mov     cr3, rax
+
+    ;
+    ; Set the ApicId to be invalid to show the CR3 has been set
     mov     dword[rsp + ApicidOffset], MailboxApicIdInvalid
     jmp     .check_apicid
 

--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -122,6 +122,8 @@ pub extern "win64" fn _start(
     mem.accept_memory_resources(num_vcpus);
     mem.setup_paging();
 
+    // Relocate the page table that map all the physical memory
+    td::relocate_ap_page_table(TD_PAYLOAD_PAGE_TABLE_BASE);
     // Relocate Mailbox along side with the AP function
     td::relocate_mailbox(mem.layout.runtime_mailbox_base as u32);
 
@@ -217,6 +219,14 @@ fn boot_builtin_payload(
 
     let relocation_info =
         ipl::find_and_report_entry_point(mem, payload).expect("Entry point not found!");
+
+    // Set up NX (no-execute) protection for payload stack and hob
+    mem.set_nx_bit(mem.layout.runtime_stack_base, TD_PAYLOAD_STACK_SIZE as u64);
+    mem.set_nx_bit(
+        mem.layout.runtime_shadow_stack_base,
+        TD_PAYLOAD_SHADOW_STACK_SIZE as u64,
+    );
+    mem.set_nx_bit(mem.layout.runtime_hob_base, TD_PAYLOAD_HOB_SIZE as u64);
 
     // Initialize the stack to run the image
     stack_guard::stack_guard_enable(mem);

--- a/td-shim/src/bin/td-shim/memory.rs
+++ b/td-shim/src/bin/td-shim/memory.rs
@@ -126,7 +126,7 @@ impl<'a> Memory<'a> {
         // Setup page table only for system memory resources higher than 4G
         for m in &self.regions {
             let r_end = m.physical_start + m.resource_length;
-            if r_end < MEMORY_4G as u64 {
+            if r_end <= MEMORY_4G as u64 {
                 continue;
             } else {
                 td_paging::create_mapping(
@@ -140,13 +140,6 @@ impl<'a> Memory<'a> {
             }
         }
 
-        // Setup page-table level protection
-        // - Enable Non-Excutable for non-code spaces
-        self.set_nx_bit(
-            self.layout.runtime_memory_bottom,
-            self.layout.runtime_memory_top - self.layout.runtime_memory_bottom,
-        );
-
         td_paging::cr3_write();
     }
 
@@ -156,6 +149,11 @@ impl<'a> Memory<'a> {
             table.add_range(E820Type::Memory, r.physical_start, r.resource_length);
         }
 
+        table.convert_range(
+            E820Type::Reserved,
+            TD_PAYLOAD_PAGE_TABLE_BASE,
+            TD_PAYLOAD_PAGE_TABLE_SIZE as u64,
+        );
         table.convert_range(
             E820Type::Acpi,
             self.layout.runtime_acpi_base,

--- a/td-shim/src/bin/td-shim/td/tdx.rs
+++ b/td-shim/src/bin/td-shim/td/tdx.rs
@@ -26,6 +26,10 @@ pub fn relocate_mailbox(address: u32) {
     super::tdx_mailbox::relocate_mailbox(address).expect("Unable to relocate mailbox");
 }
 
+pub fn relocate_ap_page_table(page_table_base: u64) {
+    super::tdx_mailbox::relocate_page_table(get_num_vcpus(), page_table_base);
+}
+
 pub fn get_num_vcpus() -> u32 {
     let td_info = tdx::tdcall_get_td_info().expect("Fail to get TDINFO");
 


### PR DESCRIPTION
TD-Shim needs to setup page table for APs that maps all the system memory since the wakeup vector can be any memory address that is usable.

Here we use a same page table for BSP and AP. At the beginning, the page table of the AP only maps 0 to 4G. After BSP sets the page table, it wakes up all the APs and notifies them to reset CR3.

 - Reduce the size of page table to 128KB by setting the frame size of runtime memory region to 4K and the rest to 1G. The default 128KB page table can map 12TB system memory.
 - Cancel the NX protection for Linux Kernel since page table will be switched soon after transfer to Kernel, and setting the NX bit for mailbox or memory that is not reserved in E820 table will cause problem for AP wakeup.
 - Page table for AP is set before relocating the AP waiting loop.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>