### PR TITLE
td-loader: Fix build issue of fuzzing test case

### DIFF
--- a/td-loader/fuzz/fuzz_targets/fuzzlib.rs
+++ b/td-loader/fuzz/fuzz_targets/fuzzlib.rs
@@ -11,7 +11,7 @@ pub fn fuzz_elf_loader(data: &[u8]) {
     }
     let mut loaded_buffer = vec![0u8; 0x800000];
 
-    elf::relocate_elf_with_per_program_header(&data[..], loaded_buffer.as_mut_slice(), |_| ());
+    elf::relocate_elf_with_per_program_header(&data[..], loaded_buffer.as_mut_slice());
     let _ = elf::parse_init_array_section(data);
     let _ = elf::parse_finit_array_section(data);
 
@@ -127,7 +127,7 @@ pub fn fuzz_pe_loader(data: &[u8]) {
 
             relocate(data, loaded_buffer.as_mut_slice(), 0x100000);
 
-            relocate_pe_mem_with_per_sections(data, loaded_buffer.as_mut_slice(), |_| ());
+            relocate_pe_mem_with_per_sections(data, loaded_buffer.as_mut_slice());
         }
     }
 }


### PR DESCRIPTION
Remove the third parameter in relocate_elf_with_per_program_header()

Signed-off-by: Wei Liu <wei3.liu@intel.com>