### PR TITLE
doc: update td-shim spec to add a reserved field in payload info

### DIFF
--- a/doc/tdshim_spec.md
+++ b/doc/tdshim_spec.md
@@ -345,6 +345,9 @@ typedef struct {
   // TD_PAYLOAD_IMAGE_TYPE
   UINT32                 ImageType;
 
+  // Reserved field
+  UINT32                 Reserved;
+
   // Guest physical address of the payload entrypoint.
   UINT64                 Entrypoint;
 } HOB_PAYLOAD_INFO_TABLE;


### PR DESCRIPTION
To make the HOB_PAYLOAD_INFO_TABLE naturally aligned without padding, add
a u32 type reserved field in this struct.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>