### PR TITLE
td-loader: Use checked_add to avoid arithmetic overflow

### DIFF
--- a/td-loader/src/elf64.rs
+++ b/td-loader/src/elf64.rs
@@ -904,4 +904,13 @@ mod test_elf_loader {
             println!("{:?}", &str);
         }
     }
+
+    #[test]
+    #[should_panic(expected = "Add with overflow")]
+    fn test_vm_range() {
+        let mut hdr = SectionHeader::default();
+        hdr.sh_addr = u64::MAX;
+        hdr.sh_size = 0x1;
+        hdr.vm_range();
+    }
 }

--- a/td-loader/src/elf64.rs
+++ b/td-loader/src/elf64.rs
@@ -525,7 +525,11 @@ pub struct SectionHeader {
 
 impl SectionHeader {
     pub fn vm_range(&self) -> Range<usize> {
-        self.sh_addr as usize..(self.sh_addr + self.sh_size) as usize
+        self.sh_addr as usize
+            ..self
+                .sh_addr
+                .checked_add(self.sh_size)
+                .expect("Add with overflow") as usize
     }
 }
 


### PR DESCRIPTION
Fix: #362
Signed-off-by: Wei Liu <wei3.liu@intel.com>