### PR TITLE
td-uefi-pi: Use wrapping_add to avoid overflow

### DIFF
--- a/td-uefi-pi/src/pi/fv.rs
+++ b/td-uefi-pi/src/pi/fv.rs
@@ -91,7 +91,7 @@ impl FirmwareVolumeHeader {
     pub fn update_checksum(&mut self) {
         // Clear the existing one before we calculate the chesum
         self.checksum = 0;
-        self.checksum = u16::MAX - sum16(self.as_bytes()) + 1;
+        self.checksum = (u16::MAX - sum16(self.as_bytes())).wrapping_add(1);
     }
 
     // Validate the checksum of the FirmwareVolumeHeader

--- a/td-uefi-pi/src/pi/fv.rs
+++ b/td-uefi-pi/src/pi/fv.rs
@@ -259,7 +259,7 @@ impl FfsFileHeader {
         self.integrity_check.header = 0;
         self.integrity_check.file = 0;
         self.state = 0;
-        self.integrity_check.header = u8::MAX - sum8(self.as_bytes()) + 1;
+        self.integrity_check.header = (u8::MAX - sum8(self.as_bytes())).wrapping_add(1);
 
         self.integrity_check.file = FFS_FIXED_CHECKSUM;
         self.state = EFI_FILE_HEADER_CONSTRUCTION | EFI_FILE_HEADER_VALID | EFI_FILE_DATA_VALID;

--- a/td-uefi-pi/src/pi/fv.rs
+++ b/td-uefi-pi/src/pi/fv.rs
@@ -401,4 +401,13 @@ mod tests {
         assert_eq!(header.integrity_check.header, 0xC);
         assert!(header.validate_checksum());
     }
+
+    #[test]
+    fn test_update_checksum() {
+        let mut header = FfsFileHeader::default();
+        header.update_checksum();
+
+        let mut header = FirmwareVolumeHeader::default();
+        header.update_checksum();
+    }
 }


### PR DESCRIPTION
Fix: #370
Fix: #375 
Signed-off-by: Wei Liu <wei3.liu@intel.com>