### PR TITLE
td-paging: Use checked_sub() to avoid overflow in page_table.rs

### DIFF
--- a/td-paging/src/page_table.rs
+++ b/td-paging/src/page_table.rs
@@ -108,7 +108,7 @@ pub fn create_mapping_with_flags(
             Size4KiB::SIZE
         };
 
-        sz -= mapped_size;
+        sz = sz.checked_sub(mapped_size).ok_or(Error::InvalidArguments)?;
         pa += mapped_size;
         va += mapped_size;
     }


### PR DESCRIPTION
Fix: #383
Signed-off-by: Wei Liu <wei3.liu@intel.com>