### PR TITLE
Disable log message in release build

### DIFF
--- a/td-logger/src/lib.rs
+++ b/td-logger/src/lib.rs
@@ -35,7 +35,6 @@ impl log::Log for LoggerBackend {
 static LOGGER_BACKEND: LoggerBackend = LoggerBackend;
 
 pub fn init() -> Result<(), SetLoggerError> {
-    dbg_write_string("logger init\n");
     log::set_logger(&LOGGER_BACKEND).map(|()| log::set_max_level(LevelFilter::Info))
 }
 

--- a/td-payload/Cargo.toml
+++ b/td-payload/Cargo.toml
@@ -18,6 +18,7 @@ td-layout = { path = "../td-layout" }
 td-logger =  { path = "../td-logger" }
 td-shim = { path = "../td-shim"}
 td-uefi-pi =  { path = "../td-uefi-pi" }
+x86 = "0.47.0"
 
 td-benchmark = { path = "../devtools/td-benchmark", optional = true }
 tdx-tdcall = { path = "../tdx-tdcall", optional = true }

--- a/td-payload/src/lib.rs
+++ b/td-payload/src/lib.rs
@@ -14,18 +14,11 @@
 // limitations under the License.
 
 #![no_std]
-#![feature(alloc_error_handler)]
 
 #[macro_use]
 extern crate alloc;
 
-#[cfg(not(test))]
-#[alloc_error_handler]
-#[allow(clippy::empty_loop)]
-fn alloc_error(_info: core::alloc::Layout) -> ! {
-    log::info!("alloc_error ... {:?}\n", _info);
-    panic!("deadloop");
-}
-
 mod json;
 pub use json::json_test;
+
+pub mod serial;

--- a/td-payload/src/serial.rs
+++ b/td-payload/src/serial.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use core::fmt::Write;
+
+#[macro_export]
+macro_rules! serial_print {
+    ($($arg:tt)*) => (serial(format_args!($($arg)*)));
+}
+
+struct Serial;
+
+impl core::fmt::Write for Serial {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        serial_write_string(s);
+        Ok(())
+    }
+}
+
+/// Write a byte to the debug port, converting `\n' to '\r\n`.
+fn serial_write_byte(byte: u8) {
+    if byte == b'\n' {
+        io_write(b'\r')
+    }
+    io_write(byte)
+}
+
+/// Write a string to the debug port.
+fn serial_write_string(s: &str) {
+    for c in s.chars() {
+        serial_write_byte(c as u8);
+    }
+}
+
+const SERIAL_IO_PORT: u16 = 0x3F8;
+
+#[cfg(feature = "tdx")]
+fn io_write(byte: u8) {
+    let _ = tdx_tdcall::tdx::tdvmcall_io_write_8(SERIAL_IO_PORT, byte);
+}
+
+#[cfg(not(feature = "tdx"))]
+fn io_write(byte: u8) {
+    unsafe { x86::io::outb(SERIAL_IO_PORT, byte) };
+}
+
+/// Log the message with level and subsystem filtering.
+pub fn serial(args: core::fmt::Arguments) {
+    let mut serial = Serial {};
+    serial.write_fmt(args).expect("Failed to write serial");
+}

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -20,7 +20,7 @@ which = "4.2.4"
 
 [dependencies]
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
-log = "0.4.13"
+log = { version = "0.4.13", features = ["release_max_level_off"] }
 r-efi = "3.2.0"
 scroll = { version = "0.10", default-features = false, features = ["derive"] }
 td-layout = { path = "../td-layout" }

--- a/tests/test-td-payload/Cargo.toml
+++ b/tests/test-td-payload/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 x86 = { version = "0.47.0" }
 ring = { path = "../../library/ring", default-features = false, features = ["alloc"] }
 td-shim = { path = "../../td-shim" }
+td-payload = { path = "../../td-payload" }
 zerocopy = "0.6.0"
 
 [dependencies.lazy_static]

--- a/tests/test-td-payload/src/main.rs
+++ b/tests/test-td-payload/src/main.rs
@@ -42,6 +42,7 @@ use crate::testtrustedboot::{TdTrustedBoot, TestTdTrustedBoot};
 use r_efi::efi::Guid;
 use serde::{Deserialize, Serialize};
 use serde_json::{Result, Value};
+use td_payload::{serial::serial, serial_print};
 use td_shim::e820::{E820Entry, E820Type};
 use td_shim::{TD_ACPI_TABLE_HOB_GUID, TD_E820_TABLE_HOB_GUID};
 use td_uefi_pi::{fv, hob, pi};
@@ -251,11 +252,11 @@ extern "C" fn _start(hob: *const c_void) -> ! {
     }
 
     // run the TestSuite which contains the test cases
-    log::info!("---------------------------------------------\n");
-    log::info!("Start to run tests.\n");
-    log::info!("---------------------------------------------\n");
+    serial_print!("---------------------------------------------\n");
+    serial_print!("Start to run tests.\n");
+    serial_print!("---------------------------------------------\n");
     ts.run();
-    log::info!(
+    serial_print!(
         "Test Result: Total run {0} tests; {1} passed; {2} failed\n",
         ts.testsuite.len(),
         ts.passed_cases,


### PR DESCRIPTION
Log message is disabled in td-shim release version and reserved in the
td-payload and test-td-payload.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>