### PR TITLE
td-loader: get .init_array with the PT_DYNAMIC segment

### DIFF
--- a/td-loader/fuzz/fuzz_targets/fuzzlib.rs
+++ b/td-loader/fuzz/fuzz_targets/fuzzlib.rs
@@ -12,9 +12,9 @@ pub fn fuzz_elf_loader(data: &[u8]) {
     let mut loaded_buffer = vec![0u8; 0x800000];
 
     elf::relocate_elf_mem_with_per_program_header(&data[..], loaded_buffer.as_mut_slice());
-    let _ = elf::parse_pre_init_array_section(data);
-    let _ = elf::parse_init_array_section(data);
-    let _ = elf::parse_finit_array_section(data);
+    let _ = elf::parse_pre_init_array_section(&loaded_buffer);
+    let _ = elf::parse_init_array_section(&loaded_buffer);
+    let _ = elf::parse_finit_array_section(&loaded_buffer);
 
     if let Some(elf) = Elf::parse(data) {
         log::info!("{:?}\n", elf.header);

--- a/td-loader/src/elf.rs
+++ b/td-loader/src/elf.rs
@@ -5,7 +5,7 @@
 use core::ops::Range;
 use scroll::Pwrite;
 
-use crate::elf64::{self, PT_LOAD, PT_PHDR};
+use crate::elf64;
 
 const SIZE_4KB: u64 = 0x00001000u64;
 
@@ -39,13 +39,11 @@ pub fn relocate_elf_with_per_program_header(
     let mut top: u64 = 0u64;
 
     for ph in elf.program_headers().unwrap() {
-        if ph.p_type == PT_LOAD {
-            if bottom > ph.p_vaddr {
-                bottom = ph.p_vaddr;
-            }
-            if top < ph.p_vaddr.checked_add(ph.p_memsz)? {
-                top = ph.p_vaddr + ph.p_memsz;
-            }
+        if bottom > ph.p_vaddr {
+            bottom = ph.p_vaddr;
+        }
+        if top < ph.p_vaddr.checked_add(ph.p_memsz)? {
+            top = ph.p_vaddr + ph.p_memsz;
         }
     }
 
@@ -57,7 +55,7 @@ pub fn relocate_elf_with_per_program_header(
     top = align_value(top, SIZE_4KB, false);
     // load per program header
     for ph in elf.program_headers().unwrap() {
-        if (ph.p_type == PT_LOAD || ph.p_type == PT_PHDR) && ph.p_memsz != 0 {
+        if ph.p_memsz != 0 {
             if ph.p_offset.checked_add(ph.p_filesz)? > image.len() as u64
                 || ph.p_vaddr.checked_add(ph.p_filesz)? > loaded_buffer.len() as u64
             {


### PR DESCRIPTION
Section header table is not loaded into memory, runtime initialization
program can use the `PT_DYNAMIC` segment to find the `.init_array` or
`.finit_array`.

Update the implementation of the `parse_init_array_section` function
and load all the program segment into memory.