### PR TITLE
cc-measurement: replace `ring` with `sha2`

### DIFF
--- a/cc-measurement/Cargo.toml
+++ b/cc-measurement/Cargo.toml
@@ -6,5 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ring = { path = "../library/ring", default-features = false, features = ["alloc"] }
+sha2 = { version = "0.10.6", default-features = false, features = ["force-soft"], optional = true }
+ring = { path = "../library/ring", default-features = false, features = ["alloc"], optional = true }
 zerocopy = "0.6.0"
+
+[features]
+default = ["sha2"]

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -51,10 +51,11 @@ boot-kernel = ["td-layout/boot-kernel"]
 secure-boot = ["der", "ring"]
 tdx = ["tdx-tdcall", "td-exception/tdx", "td-logger/tdx", "x86"]
 lazy-accept = ["tdx"]
+ring-hash = ["cc-measurement/ring"]
+sha2-hash = ["cc-measurement/sha2"]
 main = [
     "td-loader",
     "linked_list_allocator",
-    "ring",
     "spin",
     "td-exception",
     "td-logger",


### PR DESCRIPTION
For https://github.com/confidential-containers/td-shim/issues/294, use crate sha2 to calculate the hash digest.