### PR TITLE
github: Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,15 +73,15 @@ jobs:
           asset_name: final-pe.bin
           asset_content_type: application/octet-stream
 
-      - name: Upload final-pe-boot-kernel.bin
-        id: upload_release_final_pe_boot_kernel_bin
+      - name: Upload final-boot-kernel.bin
+        id: upload_release_final_boot_kernel_bin
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: target/release/final-pe-boot-kernel.bin
-          asset_name: final-pe-boot-kernel.bin
+          asset_path: target/release/final-boot-kernel.bin
+          asset_name: final-boot-kernel.bin
           asset_content_type: application/octet-stream
 
       - name: Upload final-elf.bin


### PR DESCRIPTION
While the release workflow looks for the 'final-pe-boot-kernel.bin' binary, the binary name should actually be 'final-boot-kernel.bin'

Fixes: #446

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>