### PR TITLE
td-shim: disable crate `log` in td-shim library

### DIFF
--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -20,7 +20,6 @@ which = "4.2.4"
 
 [dependencies]
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
-log = { version = "0.4.13", features = ["release_max_level_off"] }
 r-efi = "3.2.0"
 scroll = { version = "0.10", default-features = false, features = ["derive"] }
 td-layout = { path = "../td-layout" }
@@ -30,6 +29,7 @@ zerocopy = "0.6.0"
 
 td-loader = { path = "../td-loader", optional = true }
 linked_list_allocator = { version = "0.10", optional = true }
+log = { version = "0.4.13", features = ["release_max_level_off"], optional = true }
 ring = { path = "../library/ring", default-features = false, features = ["alloc"], optional = true }
 spin = { version = "0.9.2", optional = true }
 td-exception =  { path = "../td-exception", features = ["tdx"], optional = true }
@@ -52,6 +52,7 @@ secure-boot = ["der", "ring"]
 tdx = ["tdx-tdcall", "td-exception/tdx", "td-logger/tdx", "x86"]
 lazy-accept = ["tdx"]
 main = [
+    "log",
     "td-loader",
     "linked_list_allocator",
     "ring",

--- a/td-shim/src/acpi.rs
+++ b/td-shim/src/acpi.rs
@@ -105,17 +105,13 @@ impl Xsdt {
 
     pub fn add_table(&mut self, addr: u64) {
         if self.header.length < size_of::<GenericSdtHeader>() as u32 {
-            log::error!(
-                "Invalid header: Xsdt header length should not be less than generic header size"
-            );
+            return;
         } else {
             let table_num =
                 (self.header.length as usize - size_of::<GenericSdtHeader>()) / size_of::<u64>();
             if table_num < ACPI_TABLES_MAX_NUM {
                 self.tables[table_num] = addr as u64;
                 self.header.length += size_of::<u64>() as u32;
-            } else {
-                log::error!("too many ACPI tables, max {}", ACPI_TABLES_MAX_NUM);
             }
         }
     }


### PR DESCRIPTION
Any other crates that depend on `td-shim` will derive the feature of the `log` crate, so make it optional and enable it with `main`.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>