### PR TITLE
Test runtime heap and stack usage.

### DIFF
--- a/devtools/td-benchmark/Cargo.toml
+++ b/devtools/td-benchmark/Cargo.toml
@@ -13,3 +13,9 @@ log = "0.4.13"
 scroll = { version = "0.10", default-features = false, features = ["derive"]}
 td-layout = { path = "../../td-layout" }
 x86 = "0.47.0"
+
+lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
+spin = "0.9.2"
+
+[dev-dependencies]
+alloca = "0.3.3"

--- a/devtools/td-benchmark/Cargo.toml
+++ b/devtools/td-benchmark/Cargo.toml
@@ -10,12 +10,16 @@ edition = "2018"
 [dependencies]
 linked_list_allocator = "0.10.4"
 log = "0.4.13"
-scroll = { version = "0.10", default-features = false, features = ["derive"]}
-td-layout = { path = "../../td-layout" }
-x86 = "0.47.0"
+x86 = { version = "0.47.0", optional = true }
+scroll = { version = "0.10", default-features = false, features = ["derive"], optional = true }
+td-layout = { path = "../../td-layout", optional = true }
 
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 spin = "0.9.2"
 
 [dev-dependencies]
 alloca = "0.3.3"
+
+[features]
+default = ["benchmark"]
+benchmark = ["td-layout", "x86", "scroll"]

--- a/devtools/td-benchmark/src/benchmark.rs
+++ b/devtools/td-benchmark/src/benchmark.rs
@@ -1,0 +1,165 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+#![allow(unused)]
+
+use core::alloc::GlobalAlloc;
+use core::alloc::Layout;
+use core::arch::asm;
+use linked_list_allocator::LockedHeap;
+use scroll::Pread;
+use td_layout::RuntimeMemoryLayout;
+
+#[global_allocator]
+pub static ALLOCATOR: MyHeap = MyHeap::empty();
+
+// stack guard is enabled and the stack needs add guard size
+// for stack layout, please refer to td-shim/src/stack_guard.rs.
+// REVISIT: need a better way to remove the duplicated definition here.
+const STACK_GUARD_PAGE_SIZE: usize = 0x1000;
+const STACK_EXCEPTION_PAGE_SIZE: usize = 0x1000;
+
+// REVISIT: need a better way to determine how to adjust the stack, or remove it.
+const STACK_ADJUSTMENT_HACK: usize = 0x8;
+
+const STACK_FILL_PATTERN: u8 = 0x5A;
+
+// NOTE: Below code is NOT thread safe. Please don't use it in any AP.
+pub struct MyHeap {
+    max_heap: usize,
+    used_heap: usize,
+    inner: LockedHeap,
+}
+
+impl MyHeap {
+    pub const fn empty() -> Self {
+        Self {
+            max_heap: 0,
+            used_heap: 0,
+            inner: LockedHeap::empty(),
+        }
+    }
+
+    pub fn init(&self, heap_size: usize, heap_start: usize) {
+        unsafe {
+            self.inner.lock().init(heap_start as *mut u8, heap_size);
+        }
+    }
+}
+
+// the trait `GlobalAlloc` requires an `unsafe impl` declaration
+// NOTE: Below code is NOT thread safe. Please don't use it in any AP.
+#[allow(clippy::cast_ref_to_mut)]
+unsafe impl GlobalAlloc for MyHeap {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let res = self.inner.alloc(layout);
+        if !res.is_null() {
+            (*(self as *const MyHeap as *mut MyHeap)).used_heap += layout.size();
+            if self.max_heap < self.used_heap {
+                (*(self as *const MyHeap as *mut MyHeap)).max_heap = self.used_heap;
+            }
+        }
+        res
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.inner.dealloc(ptr, layout);
+        (*(self as *const MyHeap as *mut MyHeap)).used_heap -= layout.size();
+    }
+}
+
+#[derive(Default)]
+pub struct BenchmarkContext<'a> {
+    memory_layout: RuntimeMemoryLayout,
+    name: &'a str,
+    start_timestamp: u64,
+    end_timestamp: u64,
+    max_stack: usize,
+    max_heap: usize,
+}
+
+impl<'a> BenchmarkContext<'a> {
+    pub fn new(memory_layout: RuntimeMemoryLayout, name: &'a str) -> Self {
+        BenchmarkContext {
+            memory_layout,
+            name,
+            ..Default::default()
+        }
+    }
+
+    fn runtime_stack_base(&self) -> usize {
+        self.memory_layout.runtime_stack_base as usize
+            + STACK_GUARD_PAGE_SIZE
+            + STACK_EXCEPTION_PAGE_SIZE
+    }
+
+    pub fn bench_start(&mut self) {
+        let rsp: usize;
+        unsafe {
+            asm!("mov {}, rsp", out(reg) rsp);
+        }
+        log::info!("rsp_start: {:x}\n", rsp);
+        let stack_buffer = unsafe {
+            core::slice::from_raw_parts_mut(
+                self.runtime_stack_base() as *const u8 as *mut u8,
+                // REVISIT:
+                // Debug does not need to subtract stack,
+                // release needs to subtract some stack,
+                // which may be related to optimization
+                rsp - self.runtime_stack_base() - STACK_ADJUSTMENT_HACK,
+            )
+        };
+
+        for x in stack_buffer.iter_mut() {
+            *x = STACK_FILL_PATTERN;
+        }
+
+        log::info!("bench start ...\n");
+        self.start_timestamp = unsafe { x86::time::rdtsc() };
+    }
+
+    pub fn bench_end(&mut self) {
+        self.end_timestamp = unsafe { x86::time::rdtsc() };
+        log::info!("bench end ...\n");
+        let rsp: usize;
+        unsafe {
+            asm!("mov {}, rsp", out(reg) rsp);
+        }
+        log::info!("rsp_end: {:x}\n", rsp);
+        let stack_buffer = unsafe {
+            core::slice::from_raw_parts_mut(
+                self.runtime_stack_base() as *const u8 as *mut u8,
+                // REVISIT:
+                // Debug does not need to subtract stack,
+                // release needs to subtract some stack,
+                // which may be related to optimization
+                rsp - self.runtime_stack_base() - STACK_ADJUSTMENT_HACK,
+            )
+        };
+
+        let max_stack_used = detect_stack_in_buffer(stack_buffer).unwrap();
+        self.max_stack = max_stack_used;
+
+        log::info!(" delta: {}\n", self.end_timestamp - self.start_timestamp);
+        log::info!("detect max stack size is: 0x{:0x}\n", self.max_stack);
+        log::info!("detect max heap size is: 0x{:0x}\n\n", ALLOCATOR.max_heap);
+    }
+}
+
+fn detect_stack_in_buffer(buffer: &[u8]) -> Option<usize> {
+    let expected_value: u64 = STACK_FILL_PATTERN as u64
+        | (STACK_FILL_PATTERN as u64) << 8
+        | (STACK_FILL_PATTERN as u64) << 16
+        | (STACK_FILL_PATTERN as u64) << 24
+        | (STACK_FILL_PATTERN as u64) << 32
+        | (STACK_FILL_PATTERN as u64) << 40
+        | (STACK_FILL_PATTERN as u64) << 48
+        | (STACK_FILL_PATTERN as u64) << 56;
+    for i in 0..(buffer.len() / 8) {
+        let value: u64 = buffer.pread(i * 8).unwrap();
+        if value != expected_value {
+            return Some(buffer.len() - i * 8);
+        }
+    }
+    None
+}

--- a/devtools/td-benchmark/src/heap.rs
+++ b/devtools/td-benchmark/src/heap.rs
@@ -1,0 +1,124 @@
+// Copyright (c) 2022 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use core::alloc::GlobalAlloc;
+use core::alloc::Layout;
+use lazy_static::lazy_static;
+use linked_list_allocator::LockedHeap;
+use spin::Mutex;
+
+lazy_static! {
+    static ref HEAP_GLOBALS: Mutex<AllocInfo> = Mutex::new(AllocInfo::empty());
+}
+
+pub struct Alloc;
+
+/// A type provide functions for profiling heap usage.
+///
+/// Note: `HeapProfiling::init` must be called before using the heap
+///
+/// `HeapProfiling::heap_usage()` used to get the maximum heap usage.
+///
+/// # Example
+///
+/// ```no_run
+/// use td_benchmark::{Alloc, HeapProfiling};
+/// #[global_allocator]
+/// static ALLOC: td_benchmark::Alloc = td_benchmark::Alloc;
+///
+/// let heap_base;
+/// let heap_size;
+///
+/// HeapProfiling::init(heap_base, heap_size);
+///
+/// your_functions();
+///
+/// let max_heap_size = HeapProfiling::heap_usage().unwrap();
+/// ```
+//
+// The actual heap profiler state is stored in `HEAP_GLOBALS`.
+pub struct HeapProfiling;
+
+impl HeapProfiling {
+    /// Initializes an empty heap
+    ///
+    /// # Args
+    ///
+    /// * `heap_start` is automatically aligned,
+    /// * `heap_size` must be large enough to store the required metadata, otherwise this function will panic.
+    ///
+    /// # Heap allocator implementation is provided by  `linked_list_allocator` crate.
+    pub fn init(heap_start: usize, heap_size: usize) {
+        let mut heap_info = HEAP_GLOBALS.lock();
+        heap_info.init(heap_start, heap_size)
+    }
+
+    /// Returns the current maximum heap usage.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// HeapProfiling::init(heap_start, heap_size);
+    ///
+    /// {
+    ///     let _ = vec![0;1024];
+    ///     let stack_usage = HeapProfiling::heap_usage().unwrap();
+    /// }
+    /// ```
+    pub fn heap_usage() -> Option<usize> {
+        let heap_info = HEAP_GLOBALS.lock();
+        Some(heap_info.get_max_heap())
+    }
+}
+
+struct AllocInfo {
+    max_heap: usize,
+    used_heap: usize,
+    inner: LockedHeap,
+}
+
+impl AllocInfo {
+    pub const fn empty() -> Self {
+        Self {
+            max_heap: 0,
+            used_heap: 0,
+            inner: LockedHeap::empty(),
+        }
+    }
+
+    /// # Safety
+    ///
+    /// This function must be called at most once and must only be used on an
+    /// empty heap.
+    ///
+    pub fn init(&mut self, heap_start: usize, heap_size: usize) {
+        unsafe {
+            self.inner.lock().init(heap_start as *mut u8, heap_size);
+        }
+    }
+
+    pub fn get_max_heap(&self) -> usize {
+        self.max_heap
+    }
+}
+
+unsafe impl GlobalAlloc for Alloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let mut heap_info = HEAP_GLOBALS.lock();
+        let res = heap_info.inner.alloc(layout);
+        if !res.is_null() {
+            heap_info.used_heap += layout.size();
+            if heap_info.max_heap < heap_info.used_heap {
+                heap_info.max_heap = heap_info.used_heap;
+            }
+        }
+        res
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        let mut heap_info = HEAP_GLOBALS.lock();
+        heap_info.inner.dealloc(ptr, layout);
+        heap_info.used_heap -= layout.size();
+    }
+}

--- a/devtools/td-benchmark/src/lib.rs
+++ b/devtools/td-benchmark/src/lib.rs
@@ -14,6 +14,12 @@ use linked_list_allocator::LockedHeap;
 use scroll::Pread;
 use td_layout::RuntimeMemoryLayout;
 
+mod heap;
+mod stack;
+
+pub use heap::{Alloc, HeapProfiling};
+pub use stack::StackProfiling;
+
 #[global_allocator]
 pub static ALLOCATOR: MyHeap = MyHeap::empty();
 

--- a/devtools/td-benchmark/src/lib.rs
+++ b/devtools/td-benchmark/src/lib.rs
@@ -1,175 +1,66 @@
-// Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2022 Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
+//! This crate provides heap profiling and stack profiling capabilities
+//! only for TD environment.
+//!
+//! # Features
+//! - benchmark this features enabled by default.
+//!   with this feature enabled, the customer `ALLOCATOR` is
+//!   registered to `#[global_allocator]` automatic. It can
+//!   be disabled by adding `--default-features = false`.
+//!
+//! # Stack usage testing
+//!
+//! `StackProfiling` provide functions for stack usage testing
+//!
+//! # Example
+//!
+//! ```no_run
+//! use td_benchmark::StackProfiling;
+//! StackProfiling::init(0x5a5a_5a5a_5a5a_5a5a, 0x1A0000);
+//!
+//! {
+//!     let a = [0;1024];
+//!     // insert calls like this at the point of interest.
+//!     let stack_usage = StackProfiling::stack_usage().unwrap();
+//! }
+//! ```
+//!
+//! # Heap usage testing
+//!
+//! `HeapProfiling` provide functions for stack usage testing
+//!
+//! Use `HeapProfiling` need disable `benchmark` feature by adding `default-features = false`
+//! For example in Cargo.toml:
+//!
+//! td-benchmark = { path = "path_to/td-shim/devtools/td-benchmark", default-features = false, optional = true}
+//!
+//! ```no_std
+//! // adding global allocator `Alloc`
+//! #[global_allocator]
+//! static ALLOC: td_benchmark::Alloc = td_benchmark::Alloc;
+//!
+//! // Then add the following code to your code to initialize alloc before allocation.
+//! // heap start heap end is the location where the heap is created.
+//! HeapProfiling::init(heap_start, heap_size);
+//!
+//!
+//! // call `heap_usage` at the point your interest.
+//! let stack_usage = HeapProfiling::heap_usage().unwrap();
+//! ```
+//!
 #![no_std]
-#![allow(unused)]
 
-#[macro_use]
 extern crate alloc;
-use core::alloc::GlobalAlloc;
-use core::alloc::Layout;
-use core::arch::asm;
-use linked_list_allocator::LockedHeap;
-use scroll::Pread;
-use td_layout::RuntimeMemoryLayout;
 
 mod heap;
 mod stack;
 
 pub use heap::{Alloc, HeapProfiling};
 pub use stack::StackProfiling;
-
-#[global_allocator]
-pub static ALLOCATOR: MyHeap = MyHeap::empty();
-
-// stack guard is enabled and the stack needs add guard size
-// for stack layout, please refer to td-shim/src/stack_guard.rs.
-// REVISIT: need a better way to remove the duplicated definition here.
-const STACK_GUARD_PAGE_SIZE: usize = 0x1000;
-const STACK_EXCEPTION_PAGE_SIZE: usize = 0x1000;
-
-// REVISIT: need a better way to determine how to adjust the stack, or remove it.
-const STACK_ADJUSTMENT_HACK: usize = 0x8;
-
-const STACK_FILL_PATTERN: u8 = 0x5A;
-
-// NOTE: Below code is NOT thread safe. Please don't use it in any AP.
-pub struct MyHeap {
-    max_heap: usize,
-    used_heap: usize,
-    inner: LockedHeap,
-}
-
-impl MyHeap {
-    pub const fn empty() -> Self {
-        Self {
-            max_heap: 0,
-            used_heap: 0,
-            inner: LockedHeap::empty(),
-        }
-    }
-
-    pub fn init(&self, heap_size: usize, heap_start: usize) {
-        unsafe {
-            self.inner.lock().init(heap_start as *mut u8, heap_size);
-        }
-    }
-}
-
-// the trait `GlobalAlloc` requires an `unsafe impl` declaration
-// NOTE: Below code is NOT thread safe. Please don't use it in any AP.
-#[allow(clippy::cast_ref_to_mut)]
-unsafe impl GlobalAlloc for MyHeap {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let res = self.inner.alloc(layout);
-        if !res.is_null() {
-            (*(self as *const MyHeap as *mut MyHeap)).used_heap += layout.size();
-            if self.max_heap < self.used_heap {
-                (*(self as *const MyHeap as *mut MyHeap)).max_heap = self.used_heap;
-            }
-        }
-        res
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        self.inner.dealloc(ptr, layout);
-        (*(self as *const MyHeap as *mut MyHeap)).used_heap -= layout.size();
-    }
-}
-
-#[derive(Default)]
-pub struct BenchmarkContext<'a> {
-    memory_layout: RuntimeMemoryLayout,
-    name: &'a str,
-    start_timestamp: u64,
-    end_timestamp: u64,
-    max_stack: usize,
-    max_heap: usize,
-}
-
-impl<'a> BenchmarkContext<'a> {
-    pub fn new(memory_layout: RuntimeMemoryLayout, name: &'a str) -> Self {
-        BenchmarkContext {
-            memory_layout,
-            name,
-            ..Default::default()
-        }
-    }
-
-    fn runtime_stack_base(&self) -> usize {
-        self.memory_layout.runtime_stack_base as usize
-            + STACK_GUARD_PAGE_SIZE
-            + STACK_EXCEPTION_PAGE_SIZE
-    }
-
-    pub fn bench_start(&mut self) {
-        let rsp: usize;
-        unsafe {
-            asm!("mov {}, rsp", out(reg) rsp);
-        }
-        log::info!("rsp_start: {:x}\n", rsp);
-        let stack_buffer = unsafe {
-            core::slice::from_raw_parts_mut(
-                self.runtime_stack_base() as *const u8 as *mut u8,
-                // REVISIT:
-                // Debug does not need to subtract stack,
-                // release needs to subtract some stack,
-                // which may be related to optimization
-                rsp - self.runtime_stack_base() - STACK_ADJUSTMENT_HACK,
-            )
-        };
-
-        for x in stack_buffer.iter_mut() {
-            *x = STACK_FILL_PATTERN;
-        }
-
-        log::info!("bench start ...\n");
-        self.start_timestamp = unsafe { x86::time::rdtsc() };
-    }
-
-    pub fn bench_end(&mut self) {
-        self.end_timestamp = unsafe { x86::time::rdtsc() };
-        log::info!("bench end ...\n");
-        let rsp: usize;
-        unsafe {
-            asm!("mov {}, rsp", out(reg) rsp);
-        }
-        log::info!("rsp_end: {:x}\n", rsp);
-        let stack_buffer = unsafe {
-            core::slice::from_raw_parts_mut(
-                self.runtime_stack_base() as *const u8 as *mut u8,
-                // REVISIT:
-                // Debug does not need to subtract stack,
-                // release needs to subtract some stack,
-                // which may be related to optimization
-                rsp - self.runtime_stack_base() - STACK_ADJUSTMENT_HACK,
-            )
-        };
-
-        let max_stack_used = detect_stack_in_buffer(stack_buffer).unwrap();
-        self.max_stack = max_stack_used;
-
-        log::info!(" delta: {}\n", self.end_timestamp - self.start_timestamp);
-        log::info!("detect max stack size is: 0x{:0x}\n", self.max_stack);
-        log::info!("detect max heap size is: 0x{:0x}\n\n", ALLOCATOR.max_heap);
-    }
-}
-
-fn detect_stack_in_buffer(buffer: &[u8]) -> Option<usize> {
-    let expected_value: u64 = STACK_FILL_PATTERN as u64
-        | (STACK_FILL_PATTERN as u64) << 8
-        | (STACK_FILL_PATTERN as u64) << 16
-        | (STACK_FILL_PATTERN as u64) << 24
-        | (STACK_FILL_PATTERN as u64) << 32
-        | (STACK_FILL_PATTERN as u64) << 40
-        | (STACK_FILL_PATTERN as u64) << 48
-        | (STACK_FILL_PATTERN as u64) << 56;
-    for i in 0..(buffer.len() / 8) {
-        let value: u64 = buffer.pread(i * 8).unwrap();
-        if value != expected_value {
-            return Some(buffer.len() - i * 8);
-        }
-    }
-    None
-}
+#[cfg(feature = "benchmark")]
+mod benchmark;
+#[cfg(feature = "benchmark")]
+pub use benchmark::{BenchmarkContext, MyHeap, ALLOCATOR};

--- a/devtools/td-benchmark/src/stack.rs
+++ b/devtools/td-benchmark/src/stack.rs
@@ -1,0 +1,139 @@
+// Copyright (c) 2022 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use core::arch::asm;
+use lazy_static::lazy_static;
+use spin::Mutex;
+
+lazy_static! {
+    static ref STACK_GLOBALS: Mutex<StackInfo> = Mutex::new(StackInfo::default());
+}
+
+#[derive(Debug, Default)]
+struct StackInfo {
+    pub base: usize,
+    pub mark: u64,
+    pub mark_stack_size: usize,
+}
+
+/// A type provide functions for profiling stack usage.
+///
+/// Profiling starts after init is called.
+/// `StackProfiling::stack_usage()` should be call after `StackProfiling::init()`
+//
+// The actual stack profiler state is stored in `STACK_GLOBALS`.
+pub struct StackProfiling;
+
+impl StackProfiling {
+    /// Initialize `StackProfiling`.
+    ///
+    /// # Arguments
+    ///
+    /// * `mark` - a magic value to fill the stack memory.
+    /// * `mark_stack_size` - size of stack memory filled with mark value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use td_benchmark::StackProfiling;
+    /// StackProfiling::init(0x5a5a_5a5a_5a5a_5a5a, 0x1A0000);
+    /// ```
+    pub fn init(mark: u64, mark_stack_size: usize) {
+        let base = mark_stack(mark, mark_stack_size);
+        let mut stack_info = STACK_GLOBALS.lock();
+        stack_info.base = base;
+        stack_info.mark = mark;
+        stack_info.mark_stack_size = mark_stack_size;
+    }
+
+    /// Returns the current maximum stack usage.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use td_benchmark::StackProfiling;
+    /// StackProfiling::init(0x5a5a_5a5a_5a5a_5a5a, 0x1A0000);
+    ///
+    /// {
+    ///     let a = [0;1024];
+    ///     let stack_usage = StackProfiling::stack_usage().unwrap();
+    /// }
+    /// ```
+    pub fn stack_usage() -> Option<usize> {
+        let stack_info = STACK_GLOBALS.lock();
+        calculate_stack_usage(stack_info.base, stack_info.mark, stack_info.mark_stack_size)
+    }
+}
+
+fn mark_stack(mark: u64, mark_stack_size: usize) -> usize {
+    let rsp: usize;
+    unsafe {
+        asm!("mov {}, rsp", out(reg) rsp);
+    }
+    let base = rsp - mark_stack_size;
+    let len = mark_stack_size / 8;
+    let buffer = unsafe { core::slice::from_raw_parts_mut(base as *mut u64, len) };
+    for v in buffer.iter_mut() {
+        *v = mark;
+    }
+    base
+}
+
+fn calculate_stack_usage(base: usize, mark: u64, mark_stack_size: usize) -> Option<usize> {
+    let len = mark_stack_size / 8;
+    let buffer = unsafe { core::slice::from_raw_parts(base as *mut u64, len) };
+    let mut max_stack_size = mark_stack_size;
+    for (i, v) in buffer.iter().enumerate().take(len) {
+        if *v != mark {
+            max_stack_size = mark_stack_size - i * 8;
+            break;
+        }
+    }
+    if max_stack_size == mark_stack_size {
+        None
+    } else {
+        Some(max_stack_size)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn stack_use() {
+        let max_stack_size = 0x12_0000;
+        let mark = 0x5a5a5a5a5a5a5a5a;
+        let base_stack_address = mark_stack(mark, max_stack_size);
+        function_use_stack();
+        let stack_use = calculate_stack_usage(base_stack_address, mark, max_stack_size).unwrap();
+        assert!(stack_use > 0x5000 && stack_use < 0x6000)
+    }
+
+    #[test]
+    fn stack_use_profiling() {
+        let max_stack_size = 0x12_0000;
+        let mark = 0x5a5a5a5a5a5a5a5a;
+        StackProfiling::init(mark, max_stack_size);
+        function_use_stack();
+        let stack_use = StackProfiling::stack_usage().unwrap();
+        assert!(stack_use > 0x5000 && stack_use < 0x6000)
+    }
+
+    #[test]
+    fn stack_use_invalid() {
+        StackProfiling::init(0, 0);
+        StackProfiling::stack_usage();
+    }
+
+    fn function_use_stack() {
+        alloca::with_alloca(
+            0x5000, /* how much bytes we want to allocate on stack*/
+            |memory: &mut [core::mem::MaybeUninit<u8>]| {
+                for m in memory.iter_mut() {
+                    m.write(0x1);
+                }
+            },
+        );
+    }
+}


### PR DESCRIPTION
REF #456 

1.  Add heap stack profiling implementations - heap.rs and stack.rs
2.  Refactor `td-benchmark` library.
    - make library structure more clearer.
    - split lib.rs and make benchmark functions to a separate file benchmark.rs
    - add a default feature `benchmark` for benchmark.rs. So heap.rs and stack.rs can be used without `td-layout`, `x86`, `scroll` dependencies.


Limitation: 
- this approach need change source code(less than 10 lines)
- limited by execution coverage. if program never reaches a particular function, the library collects no data.
   