### PR TITLE
td-shim: measure TD HOB using its real size

### DIFF
--- a/td-shim/src/bin/td-shim/shim_info.rs
+++ b/td-shim/src/bin/td-shim/shim_info.rs
@@ -203,7 +203,7 @@ impl<'a> BootTimeDynamic<'a> {
         }
 
         Some(Self {
-            td_hob: Some(td_hob),
+            td_hob: Some(hob_list),
             memory,
             payload_info,
             payload_param,


### PR DESCRIPTION
Fix: https://github.com/confidential-containers/td-shim/issues/458