### PR TITLE
remove `bin` from `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ Cargo.lock
 target/
 *.bin
 *.obj
-bin
 # afl fuzz and cargo fuzz
 *.profraw
 corpus


### PR DESCRIPTION
Prevent source files in the `bin` folders from being ignored

Fix: https://github.com/confidential-containers/td-shim/issues/477

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>