### PR TITLE
td-shim: refactor ACPI related code

### DIFF
--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -19,6 +19,7 @@ tdx-tdcall = { path = "../tdx-tdcall" }
 which = "4.2.4"
 
 [dependencies]
+anyhow = { version = "1.0", default-features = false, optional = true }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 r-efi = "3.2.0"
 scroll = { version = "0.10", default-features = false, features = ["derive"] }
@@ -54,6 +55,7 @@ lazy-accept = ["tdx"]
 ring-hash = ["cc-measurement/ring"]
 sha2-hash = ["cc-measurement/sha2"]
 main = [
+    "anyhow",
     "log",
     "td-loader",
     "linked_list_allocator",

--- a/td-shim/src/bin/td-shim/acpi.rs
+++ b/td-shim/src/bin/td-shim/acpi.rs
@@ -2,144 +2,209 @@
 // Copyright (c) 2022 Alibaba Cloud
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
-extern crate alloc;
 
-use alloc::vec::Vec;
-use td_shim::acpi::{calculate_checksum, Rsdp, Xsdt};
+use alloc::collections::BTreeMap;
+use anyhow::*;
+use core::ops::Range;
+use td_shim::acpi::{calculate_checksum, GenericSdtHeader, Rsdp};
 
 use super::*;
+
+pub type AcpiSignature = [u8; 4];
+
+const DSDT_SIGNATURE: &AcpiSignature = b"DSDT";
+const XSDT_SIGNATURE: &AcpiSignature = b"XSDT";
+const FADT_SIGNATURE: &AcpiSignature = b"FACP";
+
+const MIN_FADT_LENGTH: u32 = 44;
 
 #[derive(Default)]
 pub struct AcpiTables<'a> {
     acpi_memory: &'a mut [u8],
-    pa: u64,
     size: usize,
-    fadt: Option<(usize, usize)>, // FADT offset in acpi memory
-    dsdt: Option<usize>,          // DSDT offset in acpi memory
-    table_offset: Vec<usize>,
+    tables: BTreeMap<AcpiSignature, Range<usize>>,
 }
 
 impl<'a> AcpiTables<'a> {
-    pub fn new(td_acpi_mem: &'a mut [u8], pa: u64) -> Self {
+    pub fn new(acpi_memory: &'a mut [u8]) -> Self {
         AcpiTables {
-            acpi_memory: td_acpi_mem,
-            pa,
+            acpi_memory,
             ..Default::default()
         }
     }
 
-    pub fn finish(&mut self) -> u64 {
-        let mut xsdt = Xsdt::new();
-
-        // The Fixed ACPI Description Table (FADT) should always be the first table in XSDT.
-        if let Some((fadt_off, fadt_len)) = self.fadt {
+    pub fn finish(&mut self) -> Result<u64> {
+        let fadt_addr = self.tables.remove(FADT_SIGNATURE).map(|r| {
             // Safe because DSDT is loaded in acpi_memory which is below 4G
             let dsdt = self
-                .dsdt
-                .as_ref()
-                .map(|v| self.offset_to_address(*v))
+                .tables
+                .remove(DSDT_SIGNATURE)
+                .map(|v| self.offset_to_address(v.start))
                 .unwrap_or_default() as u32;
-            let fadt = &mut self.acpi_memory[fadt_off..fadt_off + fadt_len];
+
+            let fadt = &mut self.acpi_memory[r.clone()];
             // The Differentiated System Description Table (DSDT) is referred by the FADT table.
             if dsdt != 0 {
                 // The DSDT field of FADT [40..44]
-                dsdt.write_to(&mut fadt[40..44]);
+                fadt[40..44].copy_from_slice(&u32::to_le_bytes(dsdt));
+
+                // Update FADT checksum
+                fadt[9] = 0;
+                fadt[9] = calculate_checksum(fadt);
             }
 
-            // Update FADT checksum
-            fadt[9] = 0;
-            fadt[9] = calculate_checksum(fadt);
-            xsdt.add_table(self.offset_to_address(fadt_off));
-        }
+            fadt.as_ptr() as u64
+        });
 
-        for offset in &self.table_offset {
-            xsdt.add_table(self.offset_to_address(*offset));
-        }
-
-        let xsdt_addr = self.offset_to_address(self.size);
-        xsdt.checksum();
-        xsdt.write_to(&mut self.acpi_memory[self.size..self.size + size_of::<Xsdt>()]);
-        self.size += size_of::<Xsdt>();
-
-        let rsdp_addr = self.offset_to_address(self.size);
-        let rsdp = Rsdp::new(xsdt_addr);
-        rsdp.write_to(&mut self.acpi_memory[self.size..self.size + size_of::<Rsdp>()]);
-        self.size += size_of::<Rsdp>();
-
-        rsdp_addr as u64
+        let xsdt_addr = self
+            .create_xsdt(fadt_addr)
+            .ok_or(anyhow!("Failed to create XSDT"))?;
+        self.create_rsdp(xsdt_addr)
+            .ok_or(anyhow!("Failed to create RSDP"))
     }
 
-    pub fn install(&mut self, table: &[u8]) {
-        // Also reserve space for Xsdt and Rsdp
-        let total_size = self.size + table.len() + size_of::<Xsdt>() + size_of::<Rsdp>();
-        if self.acpi_memory.len() < total_size {
-            log::error!(
-                "ACPI content size exceeds limit 0x{:X}",
-                self.acpi_memory.len(),
-            );
-            return;
-        } else if table.len() < size_of::<GenericSdtHeader>() {
-            log::error!("ACPI table with length 0x{:X} is invalid", table.len());
-            return;
+    pub fn install(&mut self, table: &[u8]) -> Result<()> {
+        // Reserve space for Xsdt and Rsdp
+        let reserved_space = size_of::<Rsdp>()
+            + size_of::<GenericSdtHeader>()
+            + self.tables.len() * size_of::<u64>();
+
+        if self.size.checked_add(table.len()).is_none()
+            || table.len() < size_of::<GenericSdtHeader>()
+        {
+            return Err(anyhow!("Invalid ACPI table"));
+        } else if self.acpi_memory.len() - reserved_space < self.size + table.len() {
+            return Err(anyhow!("No enough memory to install ACPI tables"));
         }
 
         // Safe because we have checked buffer size.
         let header = GenericSdtHeader::read_from(&table[..size_of::<GenericSdtHeader>()]).unwrap();
-        if header.length as usize > table.len() {
-            log::error!(
-                "invalid ACPI table, header length {} is bigger than data length {}",
-                header.length as usize,
-                table.len()
-            );
-            return;
+        let length = header.length as usize;
+        if length > table.len() || length < size_of::<GenericSdtHeader>() {
+            return Err(anyhow!("Invalid ACPI table"));
         }
 
-        if &header.signature == b"FACP" {
-            // We will write to the `dsdt` fields at [40-44)
-            if header.length < 44 {
-                log::error!("invalid ACPI FADT table");
-                return;
-            }
-            self.fadt = Some((self.size, header.length as usize));
-        } else if &header.signature == b"DSDT" {
-            self.dsdt = Some(self.size);
-        } else {
-            for offset in &self.table_offset {
-                // Safe because it's reading data from our own buffer.
-                let table_header = GenericSdtHeader::read_from(
-                    &self.acpi_memory[*offset..*offset + size_of::<GenericSdtHeader>()],
-                )
-                .unwrap();
-                if table_header.signature == header.signature {
-                    log::info!(
-                        "ACPI: {} has been installed, use first\n",
-                        core::str::from_utf8(&header.signature).unwrap_or_default()
-                    );
-                    return;
-                }
-            }
-            self.table_offset.push(self.size);
+        // Check whether we have already installed the ACPI table with the same signature
+        if self.tables.get(&header.signature).is_some() {
+            log::warn!(
+                "ACPI table: {} has been installed, use the first installed one\n",
+                core::str::from_utf8(&header.signature).unwrap_or_default()
+            );
+            return Ok(());
         }
+
+        // We will write to the `dsdt` fields at [40-44)
+        if &header.signature == FADT_SIGNATURE {
+            if header.length < MIN_FADT_LENGTH {
+                return Err(anyhow!("Invalid ACPI table"));
+            }
+        }
+
+        let offset = self
+            .write_table(table)
+            .ok_or(anyhow!("Failed to write ACPI table into ACPI memory"))?;
+        self.tables
+            .insert(header.signature, offset..offset + table.len());
+
+        Ok(())
+    }
+
+    fn write_table(&mut self, table: &[u8]) -> Option<usize> {
+        if self.size.checked_add(table.len())? > self.acpi_memory.len() {
+            return None;
+        }
+
+        let offset = self.size;
 
         self.acpi_memory[self.size..self.size + table.len()].copy_from_slice(table);
         self.size += table.len();
+
+        Some(offset)
+    }
+
+    fn create_xsdt(&mut self, fadt_addr: Option<u64>) -> Option<u64> {
+        let mut xsdt = Sdt::new(XSDT_SIGNATURE, 1);
+
+        // The Fixed ACPI Description Table (FADT) should always be the first table in XSDT.
+        if let Some(fadt_addr) = fadt_addr {
+            xsdt.extend(&u64::to_le_bytes(fadt_addr))
+        }
+
+        for (signature, table) in &self.tables {
+            if signature != FADT_SIGNATURE && signature != DSDT_SIGNATURE {
+                xsdt.extend(&u64::to_le_bytes(self.offset_to_address(table.start)));
+            }
+        }
+
+        self.write_table(xsdt.as_bytes())
+            .and_then(|offset| Some(self.offset_to_address(offset)))
+    }
+
+    fn create_rsdp(&mut self, xsdt_addr: u64) -> Option<u64> {
+        let rsdp = Rsdp::new(xsdt_addr);
+        self.write_table(rsdp.as_bytes())
+            .and_then(|offset| Some(self.offset_to_address(offset)))
     }
 
     fn offset_to_address(&self, offset: usize) -> u64 {
-        self.pa + offset as u64
+        self.acpi_memory.as_ptr() as u64 + offset as u64
+    }
+}
+
+pub struct Sdt {
+    table: Vec<u8>,
+}
+
+impl Sdt {
+    pub fn new(signature: &[u8; 4], revision: u8) -> Self {
+        let header =
+            GenericSdtHeader::new(signature, size_of::<GenericSdtHeader>() as u32, revision);
+
+        let mut table = Vec::new();
+        table.extend_from_slice(header.as_bytes());
+        table[9] = calculate_checksum(&table);
+
+        Self { table }
+    }
+
+    pub fn new_from_bytes(sdt: &[u8]) -> Self {
+        let mut table = Vec::new();
+        table.extend_from_slice(sdt);
+
+        Self { table }
+    }
+
+    pub fn extend(&mut self, data: &[u8]) {
+        self.table.extend_from_slice(data);
+
+        let length = self.table.len() as u32;
+        self.table[4..8].copy_from_slice(&u32::to_le_bytes(length));
+        self.checksum();
+    }
+
+    pub fn checksum(&mut self) {
+        self.table[9] = 0;
+        self.table[9] = calculate_checksum(&self.table);
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.table.as_slice()
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use core::convert::TryInto;
+
     use super::*;
 
     #[test]
     fn test_acpi_tables() {
         let mut buff = [0u8; 500];
-        let mut tables = AcpiTables::new(&mut buff, 0x100000);
+        let buff_addr = buff.as_ptr() as u64;
+        let mut tables = AcpiTables::new(&mut buff);
 
-        assert_eq!(tables.offset_to_address(0x1000), 0x101000);
+        assert_eq!(tables.offset_to_address(0x1000), buff_addr + 0x1000);
         assert_eq!(tables.size, 0);
 
         tables.install(&[]);
@@ -149,14 +214,17 @@ mod tests {
         tables.install(&[0u8; 269]);
         assert_eq!(tables.size, 0);
 
-        let hdr = GenericSdtHeader::new(b"FACP", 44, 2);
+        let hdr = GenericSdtHeader::new(FADT_SIGNATURE, 44, 2);
         let mut buf = [0u8; 44];
         buf[0..size_of::<GenericSdtHeader>()].copy_from_slice(hdr.as_bytes());
         tables.install(&buf);
-        assert_eq!(tables.fadt, Some((0, 44)));
+        assert_eq!(
+            tables.tables.get(FADT_SIGNATURE),
+            Some(&core::ops::Range { start: 0, end: 44 })
+        );
         assert_eq!(tables.size, 44);
 
-        let hdr = GenericSdtHeader::new(b"DSDT", size_of::<GenericSdtHeader>() as u32, 2);
+        let hdr = GenericSdtHeader::new(DSDT_SIGNATURE, size_of::<GenericSdtHeader>() as u32, 2);
         tables.install(hdr.as_bytes());
         assert_eq!(tables.size, 44 + size_of::<GenericSdtHeader>());
 
@@ -168,10 +236,34 @@ mod tests {
         tables.install(hdr.as_bytes());
         assert_eq!(tables.size, 44 + 2 * size_of::<GenericSdtHeader>());
 
-        let addr = tables.finish();
+        let addr = tables.finish().unwrap();
+        // RSDP is intalled after `FADT`, `DSDT`, `TEST` and `XSDT`
+        // XSDT contains two pointer point to `FADT` and `TEST`
+        // DSDT is pointed by `FADT`
         assert_eq!(
             addr,
-            0x100000 + 240 + 2 * size_of::<GenericSdtHeader>() as u64
+            buff_addr
+                + MIN_FADT_LENGTH as u64
+                + 3 * size_of::<GenericSdtHeader>() as u64
+                + size_of::<u64>() as u64 * 2,
         );
+    }
+
+    #[test]
+    fn test_sdt() {
+        const CHECK_SUM: u8 = 26;
+
+        let mut sdt = Sdt::new(b"TEST", 1);
+        assert_eq!(sdt.as_bytes().len(), size_of::<GenericSdtHeader>());
+
+        sdt.extend(&[0x2; 0x100]);
+        assert_eq!(sdt.as_bytes().len(), size_of::<GenericSdtHeader>() + 0x100);
+        assert_eq!(
+            sdt.as_bytes().len(),
+            u32::from_le_bytes(sdt.as_bytes()[4..8].try_into().unwrap()) as usize
+        );
+
+        sdt.checksum();
+        assert_eq!(sdt.as_bytes()[9], CHECK_SUM);
     }
 }

--- a/td-shim/src/bin/td-shim/mp.rs
+++ b/td-shim/src/bin/td-shim/mp.rs
@@ -6,80 +6,34 @@ use core::convert::TryInto;
 use core::mem::size_of;
 use zerocopy::{AsBytes, FromBytes};
 
-use td_shim::acpi::{self, GenericSdtHeader};
+use td_shim::acpi::{
+    self,
+    madt::{LocalApic, MadtMpwkStruct},
+    GenericSdtHeader,
+};
 
-// 255 vCPUs needs 2278 bytes, refer to create_madt().
-const MADT_MAX_SIZE: usize = 0xc00;
+use crate::acpi::{AcpiSignature, Sdt};
+
 const NUM_8259_IRQS: usize = 16;
 
 const ACPI_1_0_PROCESSOR_LOCAL_APIC: u8 = 0x00;
 const ACPI_MADT_MPWK_STRUCT_TYPE: u8 = 0x10;
 
-pub struct Madt {
-    pub data: [u8; MADT_MAX_SIZE],
-    pub size: usize,
-}
-
-impl Madt {
-    fn default() -> Self {
-        Madt {
-            data: [0; MADT_MAX_SIZE],
-            size: 0,
-        }
-    }
-
-    fn write(&mut self, data: &[u8]) {
-        self.data[self.size..self.size + data.len()].copy_from_slice(data);
-        self.size += data.len();
-
-        // Update the length field in header
-        self.data[4..8].copy_from_slice(&u32::to_le_bytes(self.size as u32));
-        self.update_checksum()
-    }
-
-    fn update_checksum(&mut self) {
-        self.data[9] = 0;
-        self.data[9] = acpi::calculate_checksum(&self.data[0..self.size]);
-    }
-
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.data[..self.size]
-    }
-}
-
-#[repr(packed)]
-#[derive(Default, AsBytes, FromBytes)]
-struct LocalApic {
-    pub r#type: u8,
-    pub length: u8,
-    pub processor_id: u8,
-    pub apic_id: u8,
-    pub flags: u32,
-}
-
-#[repr(packed)]
-#[derive(Default, AsBytes, FromBytes)]
-struct MadtMpwkStruct {
-    r#type: u8,
-    length: u8,
-    mail_box_version: u16,
-    reserved: u32,
-    mail_box_address: u64,
-}
+const MADT_SIGNATURE: &AcpiSignature = b"APIC";
+const MADT_REVISION: u8 = 1;
 
 // Create ACPI MADT table based on the one from VMM
 // APIC / IRQ information should be provided by VMM
 // TD-Shim appends the MP wakeup structure to the table
-pub fn create_madt(vmm_madt: &[u8], mailbox_base: u64) -> Option<Madt> {
-    if &vmm_madt[0..4] != b"APIC" || vmm_madt.len() < size_of::<GenericSdtHeader>() {
+pub fn create_madt(vmm_madt: &[u8], mailbox_base: u64) -> Option<Sdt> {
+    if &vmm_madt[0..4] != MADT_SIGNATURE || vmm_madt.len() < size_of::<GenericSdtHeader>() {
         return None;
     }
 
     // Safe since we have checked the length
     let len = u32::from_le_bytes(vmm_madt[4..8].try_into().unwrap());
 
-    let mut madt = Madt::default();
-    madt.write(&vmm_madt[..len as usize]);
+    let mut madt = Sdt::new_from_bytes(&vmm_madt[..len as usize]);
 
     let mpwk = MadtMpwkStruct {
         r#type: ACPI_MADT_MPWK_STRUCT_TYPE,
@@ -88,7 +42,7 @@ pub fn create_madt(vmm_madt: &[u8], mailbox_base: u64) -> Option<Madt> {
         reserved: 0,
         mail_box_address: mailbox_base,
     };
-    madt.write(mpwk.as_bytes());
+    madt.extend(mpwk.as_bytes());
 
     Some(madt)
 }
@@ -96,26 +50,18 @@ pub fn create_madt(vmm_madt: &[u8], mailbox_base: u64) -> Option<Madt> {
 // If there is no MADT passed from VMM, construct the default
 // one which contains the APIC base / version, local APIC and
 // MP wakeup structure
-pub fn create_madt_default(cpu_num: u32, mailbox_base: u64) -> Option<Madt> {
+pub fn create_madt_default(cpu_num: u32, mailbox_base: u64) -> Option<Sdt> {
     log::info!("create_madt(): cpu_num: {:x}\n", cpu_num);
 
-    let table_length = size_of::<GenericSdtHeader>()
-        + 8
-        + cpu_num as usize * size_of::<LocalApic>()
-        + size_of::<MadtMpwkStruct>();
-    if cpu_num == 0 || table_length > MADT_MAX_SIZE {
+    if cpu_num == 0 || cpu_num > u8::MAX as u32 {
         return None;
     }
 
-    let mut madt = Madt::default();
-    let header = GenericSdtHeader::new(b"APIC", table_length as u32, 1);
-
-    // Write generic header
-    madt.write(header.as_bytes());
+    let mut madt = Sdt::new(MADT_SIGNATURE, MADT_REVISION);
 
     // Write APIC base and version
-    madt.write(&0xfee00000u32.to_le_bytes());
-    madt.write(&1u32.to_le_bytes());
+    madt.extend(&0xfee00000u32.to_le_bytes());
+    madt.extend(&1u32.to_le_bytes());
 
     for cpu in 0..cpu_num {
         let lapic = LocalApic {
@@ -125,7 +71,7 @@ pub fn create_madt_default(cpu_num: u32, mailbox_base: u64) -> Option<Madt> {
             apic_id: cpu as u8,
             flags: 1,
         };
-        madt.write(lapic.as_bytes());
+        madt.extend(lapic.as_bytes());
     }
 
     let mpwk = MadtMpwkStruct {
@@ -135,10 +81,7 @@ pub fn create_madt_default(cpu_num: u32, mailbox_base: u64) -> Option<Madt> {
         reserved: 0,
         mail_box_address: mailbox_base,
     };
-    madt.write(mpwk.as_bytes());
-
-    assert_eq!(madt.size, table_length);
-    madt.update_checksum();
+    madt.extend(mpwk.as_bytes());
 
     Some(madt)
 }
@@ -147,17 +90,43 @@ pub fn create_madt_default(cpu_num: u32, mailbox_base: u64) -> Option<Madt> {
 mod tests {
     use super::*;
 
+    const MAILBOX: u64 = 0x100000;
+
+    #[test]
+    fn test_create_mdat_default() {
+        assert!(create_madt_default(0, MAILBOX).is_none());
+        let madt = create_madt_default(255, MAILBOX).unwrap();
+        assert_eq!(
+            madt.as_bytes().len(),
+            size_of::<GenericSdtHeader>()
+                + size_of::<u32>() * 2
+                + size_of::<LocalApic>() * 255
+                + size_of::<MadtMpwkStruct>()
+        );
+    }
+
     #[test]
     fn test_create_mdat() {
-        assert!(create_madt_default(0, 0x1000).is_none());
-        let madt = create_madt_default(255, 0x1000).unwrap();
-        assert!(madt.size < MADT_MAX_SIZE);
-
-        let mut vmm_madt = [0u8; size_of::<SdtHeader>()];
-        assert!(create_madt(&vmm_madt, 0x1000).is_none());
+        let mut vmm_madt = [0u8; size_of::<GenericSdtHeader>()];
+        assert!(create_madt(&vmm_madt, MAILBOX).is_none());
 
         vmm_madt[0..4].copy_from_slice(b"APIC");
-        let madt = create_madt(&vmm_madt, mailbox).unwrap();
-        assert_eq!(madt.size, vmm_madt.len() + size_of::<MadtMpwkStruct>());
+        vmm_madt[4..8].copy_from_slice(&u32::to_le_bytes(size_of::<GenericSdtHeader>() as u32));
+
+        let madt = create_madt(&vmm_madt, MAILBOX).unwrap();
+        assert_eq!(
+            madt.as_bytes().len(),
+            vmm_madt.len() + size_of::<MadtMpwkStruct>()
+        );
+
+        let mut vmm_madt = [0u8; 0x100];
+        vmm_madt[0..4].copy_from_slice(b"APIC");
+        vmm_madt[4..8].copy_from_slice(&u32::to_le_bytes(size_of::<GenericSdtHeader>() as u32));
+
+        let madt = create_madt(&vmm_madt, MAILBOX).unwrap();
+        assert_eq!(
+            madt.as_bytes().len(),
+            size_of::<GenericSdtHeader>() + size_of::<MadtMpwkStruct>()
+        );
     }
 }


### PR DESCRIPTION
 - Define `Sdt` structure which uses vector for variable length System Description Tables. Then we can use it for XSDT and MADT

 - Move MADT definitions into library crate.

 - Refactor implementation of `AcpiTables`. Use `anyhow` to handle errors.

Also fix: https://github.com/confidential-containers/td-shim/issues/454