### PR TITLE
td-shim-tools: add td-payload-reference-calculator

### DIFF
--- a/td-shim-tools/Cargo.toml
+++ b/td-shim-tools/Cargo.toml
@@ -34,6 +34,10 @@ required-features = ["tee"]
 name = "td-shim-layout-builder"
 required-features = ["layout_builder"]
 
+[[bin]]
+name = "td-payload-reference-calculator"
+required-features = ["calculator"]
+
 [dependencies]
 r-efi = "3.2.0"
 argparse = "0.2.2"
@@ -45,6 +49,8 @@ td-shim = { path = "../td-shim", default-features = false }
 td-uefi-pi =  { path = "../td-uefi-pi" }
 cfg-if = "1.0"
 
+anyhow = { version = "1.0.68", optional = true }
+block-padding = { version = "0.3.2", optional = true }
 clap = { version = "3.0", features = ["cargo"], optional = true }
 der = { version = "0.4.5", features = ["oid"], optional = true }
 env_logger = { version = "0.9.0", optional = true }
@@ -69,3 +75,4 @@ signer = ["clap", "der", "env_logger", "log", "ring", "td-shim/secure-boot"]
 loader = ["clap", "env_logger", "log"]
 tee = ["clap", "env_logger", "log", "serde_json", "serde", "hex", "sha2", "byteorder"]
 layout_builder = ["clap", "env_logger", "log", "clap/derive", "serde", "serde_json", "tera", "json5"]
+calculator = ["clap", "hex", "parse_int", "sha2", "anyhow", "block-padding"]

--- a/td-shim-tools/src/bin/td-payload-reference-calculator/README.md
+++ b/td-shim-tools/src/bin/td-payload-reference-calculator/README.md
@@ -1,0 +1,40 @@
+# TD Payload Reference Calculator
+A simple tool to calculate td-payload's reference value via bzImage, and kernel parameter
+
+## Usage
+
+### Kernel (bzImage)
+
+The test bzImage can be fetched via
+
+```bash
+wget https://github.com/Xynnn007/td-payload-reference-provider/raw/main/tests/bzImage
+```
+
+Test with the example bzImage
+```
+cargo run -- kernel -k bzImage -s 0x10000000
+```
+
+The `kernel-size` parameter here means `KERNEL_SIZE` defined in guest firmware, s.t. [TD-SHIM](https://github.com/confidential-containers/td-shim)
+
+Will get the result
+```
+5b7aa6572f649714ff00b6a2b9170516a068fd1a0ba72aa8de27574131d454e6396d3bfa1727d9baf421618a942977fa
+```
+
+which is from https://github.com/confidential-containers/attestation-service/pull/33/files#diff-1a4e5ad4c3b043c019c00bc3b3072fd6e1e5b03a5ce8c498e1c0acaf697d9d3fR265
+
+### Kernel Parameter
+
+Test
+```
+cargo run -- param -p "root=/dev/vda1 console=hvc0 rw" -s 0x1000
+```
+
+Will get the result
+```
+64ed1e5a47e8632f80faf428465bd987af3e8e4ceb10a5a9f387b6302e30f4993bded2331f0691c4a38ad34e4cbbc627
+```
+
+which is from https://github.com/confidential-containers/attestation-service/pull/33/files#diff-1a4e5ad4c3b043c019c00bc3b3072fd6e1e5b03a5ce8c498e1c0acaf697d9d3fR269

--- a/td-shim-tools/src/bin/td-payload-reference-calculator/main.rs
+++ b/td-shim-tools/src/bin/td-payload-reference-calculator/main.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2022 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! A simple tool to calculate td-payload and parameter's reference value due to given kernel
+
+use anyhow::*;
+use clap::{arg, command};
+use parse_int::parse;
+use sha2::Digest;
+use std::path::Path;
+
+pub const KERNEL_SIZE: &str = "0x2000000";
+pub const KERNEL_PARAM_SIZE: &str = "0x1000";
+
+fn kernel(path: &str, size: &str) -> Result<String> {
+    let path = Path::new(path).to_path_buf();
+    let siz = parse::<u64>(size)?;
+    let file_size = std::fs::metadata(&path)?.len();
+    if file_size > siz {
+        bail!("File size should be less than `kernel-size`");
+    }
+    let buf = std::fs::read(path)?;
+    padding_digest(buf, siz as usize)
+}
+
+fn param(param: &str, size: &str) -> Result<String> {
+    let param = Vec::try_from(param)?;
+    let siz = parse::<usize>(size)?;
+    padding_digest(param, siz)
+}
+
+fn padding_digest(mut buf: Vec<u8>, len: usize) -> Result<String> {
+    let diff = len - buf.len();
+
+    buf.extend_from_slice(&vec![0; diff as usize]);
+    let mut hasher = sha2::Sha384::new();
+    hasher.update(&buf);
+    let res = hasher.finalize();
+    Ok(hex::encode(res))
+}
+
+fn main() {
+    let matches = command!()
+        .subcommand_required(true)
+        .subcommand(
+            command!("kernel")
+                .arg(
+                    arg!(-k --kernel "path to vmlinuz kernel")
+                        .required(true)
+                        .takes_value(true)
+                        .allow_invalid_utf8(false),
+                )
+                .arg(
+                    arg!(-s --"size" "KERNEL_SIZE of the target td-shim")
+                        .required(false)
+                        .default_value(KERNEL_SIZE),
+                ),
+        )
+        .subcommand(
+            command!("param")
+                .arg(
+                    arg!(-p --parameter "kernel parameter string")
+                        .required(true)
+                        .takes_value(true)
+                        .allow_invalid_utf8(false),
+                )
+                .arg(
+                    arg!(-s --"size" "KERNEL_PARAM_SIZE of the target td-shim")
+                        .required(false)
+                        .default_value(KERNEL_PARAM_SIZE),
+                ),
+        )
+        .get_matches();
+
+    let res = match matches.subcommand() {
+        Some(("kernel", args)) => {
+            let path = args.value_of("kernel").unwrap();
+            let siz = args.value_of("size").unwrap();
+            kernel(path, siz)
+        }
+        Some(("param", args)) => {
+            let parameter = args.value_of("parameter").unwrap();
+            let siz = args.value_of("size").unwrap();
+            param(parameter, siz)
+        }
+        Some((_, _)) => unreachable!(),
+        None => unreachable!(),
+    };
+
+    match res {
+        std::result::Result::Ok(res) => println!("{res}"),
+        Err(e) => eprintln!("[ERROR]: {}", e.to_string()),
+    }
+}


### PR DESCRIPTION
td-payload-reference-calculator helps to calculate the reference value of kernel (bzImage) and kernel parameter.

Close https://github.com/confidential-containers/td-shim/issues/487

Signed-off-by: Xynnn007 <xynnn@linux.alibaba.com>