### PR TITLE
Fix: no-std code coverage collection doesn't work

### DIFF
--- a/td-payload/src/bin/example/main.rs
+++ b/td-payload/src/bin/example/main.rs
@@ -77,6 +77,7 @@ pub extern "C" fn main() -> ! {
             buffer.as_ptr() as u64,
             coverage_len
         );
+        loop {}
     }
 
     panic!("td-payload: all tests finished and enters dead loop");

--- a/td-payload/src/mm/dma.rs
+++ b/td-payload/src/mm/dma.rs
@@ -60,7 +60,7 @@ pub unsafe fn alloc_dma_pages(num: usize) -> Option<usize> {
         .map(|ptr| ptr.as_ptr() as usize)
         .ok()?;
 
-    core::slice::from_raw_parts_mut(addr as *mut u8, SIZE_4K).fill(0);
+    core::slice::from_raw_parts_mut(addr as *mut u8, size).fill(0);
 
     Some(addr)
 }


### PR DESCRIPTION
Fix #494 ,DMA needs to be in scope when using pmemsave