### PR TITLE
tests: Enable code coverage for test-td-payload

### DIFF
--- a/tests/test-td-payload/Cargo.toml
+++ b/tests/test-td-payload/Cargo.toml
@@ -17,6 +17,7 @@ td-uefi-pi =  { path = "../../td-uefi-pi" }
 tdx-tdcall = { path = "../../tdx-tdcall" , optional = true }
 td-logger =  { path = "../../td-logger" }
 td-layout = { path = "../../td-layout" }
+td-paging = { path = "../../td-paging" }
 scroll = { version = "0.10.0", default-features = false, features = ["derive"]}
 serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
@@ -25,6 +26,8 @@ ring = { path = "../../library/ring", default-features = false, features = ["all
 td-shim = { path = "../../td-shim" }
 td-payload = { path = "../../td-payload", features = ["tdx","cet-shstk","stack-guard"] }
 zerocopy = "0.6.0"
+
+minicov = { version = "0.2", default-features = false, optional = true }
 
 [dependencies.lazy_static]
 version = "1.0"
@@ -36,3 +39,4 @@ map-physical-memory = true
 [features]
 tdx = ["tdx-tdcall", "td-logger/tdx"]
 main = []
+coverage = ["minicov"]

--- a/tests/test-td-payload/src/main.rs
+++ b/tests/test-td-payload/src/main.rs
@@ -252,5 +252,31 @@ extern "C" fn main() -> ! {
         ts.failed_cases
     );
 
+    // Need to set DEFAULT_DMA_SIZE to 0x200000 before build
+    #[cfg(all(feature = "coverage", feature = "tdx"))]
+    {
+        const MAX_COVERAGE_DATA_PAGE_COUNT: usize = 0x200;
+        let mut dma = td_payload::mm::dma::DmaMemory::new(MAX_COVERAGE_DATA_PAGE_COUNT)
+            .expect("New dma fail.");
+        let buffer = dma.as_mut_bytes();
+        let coverage_len = minicov::get_coverage_data_size();
+        assert!(coverage_len < MAX_COVERAGE_DATA_PAGE_COUNT * td_paging::PAGE_SIZE);
+        minicov::capture_coverage_to_buffer(&mut buffer[0..coverage_len]);
+        print!(
+            "coverage addr: {:x}, coverage len: {}",
+            buffer.as_ptr() as u64,
+            coverage_len
+        );
+
+        loop {}
+    }
+
     panic!("deadloop");
 }
+
+#[cfg(test)]
+fn main() {}
+// FIXME: remove when https://github.com/Amanieu/minicov/issues/12 is fixed.
+#[cfg(all(feature = "coverage", feature = "tdx", target_os = "none"))]
+#[no_mangle]
+static __llvm_profile_runtime: u32 = 0;


### PR DESCRIPTION
Note: Need to set DEFAULT_DMA_SIZE to 0x200000 before build
Signed-off-by: Liu Wei <wei3.liu@intel.com>