### PR TITLE
Update crate linked_list_allocator to version 0.10.4

### DIFF
--- a/td-payload/Cargo.toml
+++ b/td-payload/Cargo.toml
@@ -13,7 +13,7 @@ required-features = ["start"]
 
 [dependencies]
 bit_field = "0.10"
-linked_list_allocator = "0.10"
+linked_list_allocator = "0.10.4"
 lazy_static = "1.0"
 log = "0.4.13"
 r-efi = "3.2.0"

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -28,7 +28,7 @@ cc-measurement = { path = "../cc-measurement" }
 zerocopy = "0.6.0"
 
 td-loader = { path = "../td-loader", optional = true }
-linked_list_allocator = { version = "0.10", optional = true }
+linked_list_allocator = { version = "0.10.4", optional = true }
 log = { version = "0.4.13", features = ["release_max_level_off"], optional = true }
 ring = { path = "../library/ring", default-features = false, features = ["alloc"], optional = true }
 spin = { version = "0.9.2", optional = true }


### PR DESCRIPTION
Old crate has known security vulnerabilities

Signed-off-by: Wei Liu <wei3.liu@intel.com>