### PR TITLE
td-shim: reuse mailbox memory for runtime IDT

### DIFF
--- a/devtools/td-layout-config/config.json
+++ b/devtools/td-layout-config/config.json
@@ -67,7 +67,6 @@
         */
         "event_log_size": 0x100000,
         "mailbox_size": 0x2000,
-        "idt_size": 0x2000,
         "page_table_size": 0x20000,
         "acpi_size": 0x100000,
         "unaccepted_memory_bitmap_size": 0x40000,

--- a/td-exception/src/idt.rs
+++ b/td-exception/src/idt.rs
@@ -32,8 +32,8 @@ lazy_static! {
 
 #[repr(C, packed)]
 pub struct DescriptorTablePointer {
-    limit: u16,
-    base: u64,
+    pub limit: u16,
+    pub base: u64,
 }
 
 #[no_mangle]

--- a/td-layout/src/lib.rs
+++ b/td-layout/src/lib.rs
@@ -32,7 +32,6 @@ use runtime::*;
 pub const MIN_MEMORY_SIZE: u64 = (TD_PAYLOAD_ACPI_SIZE
     + TD_PAYLOAD_UNACCEPTED_MEMORY_BITMAP_SIZE
     + TD_PAYLOAD_PAGE_TABLE_SIZE
-    + TD_PAYLOAD_IDT_SIZE
     + TD_PAYLOAD_EVENT_LOG_SIZE
     + TD_PAYLOAD_MAILBOX_SIZE) as u64;
 
@@ -40,7 +39,6 @@ pub const MIN_MEMORY_SIZE: u64 = (TD_PAYLOAD_ACPI_SIZE
 pub const MIN_MEMORY_SIZE: u64 = (TD_PAYLOAD_ACPI_SIZE
     + TD_PAYLOAD_SIZE
     + TD_PAYLOAD_PAGE_TABLE_SIZE
-    + TD_PAYLOAD_IDT_SIZE
     + TD_PAYLOAD_EVENT_LOG_SIZE
     + TD_PAYLOAD_MAILBOX_SIZE) as u64;
 
@@ -50,7 +48,6 @@ pub struct RuntimeMemoryLayout {
     pub runtime_page_table_base: u64,
     pub runtime_acpi_base: u64,
     pub runtime_mailbox_base: u64,
-    pub runtime_idt_base: u64,
     pub runtime_unaccepted_bitmap_base: u64,
     pub runtime_payload_base: u64,
     pub runtime_memory_bottom: u64,
@@ -71,9 +68,6 @@ impl RuntimeMemoryLayout {
 
         current_base -= TD_PAYLOAD_MAILBOX_SIZE as u64;
         let runtime_mailbox_base = current_base;
-
-        current_base -= TD_PAYLOAD_IDT_SIZE as u64;
-        let runtime_idt_base = current_base;
 
         current_base -= TD_PAYLOAD_PAGE_TABLE_SIZE as u64;
         let runtime_page_table_base = current_base;
@@ -97,7 +91,6 @@ impl RuntimeMemoryLayout {
         RuntimeMemoryLayout {
             runtime_event_log_base,
             runtime_mailbox_base,
-            runtime_idt_base,
             runtime_page_table_base,
             runtime_acpi_base,
             runtime_unaccepted_bitmap_base,
@@ -118,10 +111,6 @@ impl fmt::Debug for RuntimeMemoryLayout {
             .field(
                 "runtime_event_log_base",
                 &format_args!("0x{:x}", self.runtime_event_log_base),
-            )
-            .field(
-                "runtime_idt_base",
-                &format_args!("0x{:x}", self.runtime_idt_base),
             )
             .field(
                 "runtime_page_table_base",
@@ -163,7 +152,7 @@ mod tests {
     #[test]
     #[cfg(feature = "boot-kernel")]
     fn test_runtime_memory_layout_boot_kernel() {
-        assert_eq!(MIN_MEMORY_SIZE, 0x264000);
+        assert_eq!(MIN_MEMORY_SIZE, 0x262000);
 
         let layout = RuntimeMemoryLayout::new(MIN_MEMORY_SIZE + 0x1000);
 
@@ -173,7 +162,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "boot-kernel"))]
     fn test_runtime_memory_layout_boot_payload() {
-        assert_eq!(MIN_MEMORY_SIZE, 0x2224000);
+        assert_eq!(MIN_MEMORY_SIZE, 0x2222000);
 
         let layout = RuntimeMemoryLayout::new(MIN_MEMORY_SIZE + 0x1000);
 

--- a/td-layout/src/memslice.rs
+++ b/td-layout/src/memslice.rs
@@ -8,8 +8,8 @@ use crate::build_time::{
 };
 use crate::runtime::{
     KERNEL_BASE, KERNEL_PARAM_BASE, KERNEL_PARAM_SIZE, KERNEL_SIZE, TD_HOB_BASE, TD_HOB_SIZE,
-    TD_PAYLOAD_ACPI_SIZE, TD_PAYLOAD_EVENT_LOG_SIZE, TD_PAYLOAD_IDT_SIZE, TD_PAYLOAD_MAILBOX_SIZE,
-    TD_PAYLOAD_SIZE, TD_PAYLOAD_UNACCEPTED_MEMORY_BITMAP_SIZE,
+    TD_PAYLOAD_ACPI_SIZE, TD_PAYLOAD_EVENT_LOG_SIZE, TD_PAYLOAD_MAILBOX_SIZE, TD_PAYLOAD_SIZE,
+    TD_PAYLOAD_UNACCEPTED_MEMORY_BITMAP_SIZE,
 };
 
 /// Type of build time and runtime memory regions.
@@ -32,8 +32,6 @@ pub enum SliceType {
     PayloadHob,
     /// The 'Mailbox' region in runtime memory layout
     RelocatedMailbox,
-    /// The 'IDT' region in runtime memory layout
-    RelocatedIdt,
     /// The `TD_EVENT_LOG` region in runtime memory layout
     EventLog,
     /// The `ACPI` region in runtime memory layout
@@ -104,10 +102,6 @@ pub unsafe fn get_dynamic_mem_slice_mut<'a>(t: SliceType, base_address: usize) -
         SliceType::RelocatedMailbox => core::slice::from_raw_parts_mut(
             base_address as *const u8 as *mut u8,
             TD_PAYLOAD_MAILBOX_SIZE as usize,
-        ),
-        SliceType::RelocatedIdt => core::slice::from_raw_parts_mut(
-            base_address as *const u8 as *mut u8,
-            TD_PAYLOAD_IDT_SIZE as usize,
         ),
         SliceType::Acpi | SliceType::PayloadHob => core::slice::from_raw_parts_mut(
             base_address as *const u8 as *mut u8,

--- a/td-layout/src/runtime.rs
+++ b/td-layout/src/runtime.rs
@@ -19,18 +19,19 @@
                     |    KERNEL    |    (0x02000000)
                     +--------------+
                     |   ........   |
-                    +--------------+ <-  0x7DD9C000
+                    +--------------+ <-  0x7DD9E000
                     |  UNACCEPTED  |    (0x00040000)
-                    +--------------+ <-  0x7DDDC000
+                    +--------------+ <-  0x7DDDE000
                     |     ACPI     |    (0x00100000)
-                    +--------------+ <-  0x7DEDC000
+                    +--------------+ <-  0x7DEDE000
                     |    PAYLOAD   |    (0x02000000)
-                    +--------------+ <-  0x7FEDC000
+                    +--------------+ <-  0x7FEDE000
                     |  Page Table  | <-  0x00020000
-                    +--------------+ <-  0x7FEFC000
-                    |      IDT     |    (0x00002000)
                     +--------------+ <-  0x7FEFE000
-                    |    MAILBOX   |    (0x00002000)
+                    |              |    // (0 - 0x7FF, mailbox header and OS)
+                    |    MAILBOX   |    // (0x800 - 0xBFF, BSP - AP communication)
+                    | (0x00002000) |    // (0xC00 - 0xFFF, IDT and an exception hander)
+                    |              |    // (0x1000 - 0x1FFF, AP loop function)
                     +--------------+ <-  0x7FF00000
                     | TD_EVENT_LOG |    (0x00100000)
                     +--------------+ <-  0x80000000 (2G) - for example
@@ -38,7 +39,6 @@
 
 pub const TD_PAYLOAD_EVENT_LOG_SIZE: u32 = 0x100000;
 pub const TD_PAYLOAD_MAILBOX_SIZE: u32 = 0x2000;
-pub const TD_PAYLOAD_IDT_SIZE: u32 = 0x2000;
 pub const TD_PAYLOAD_PAGE_TABLE_SIZE: u32 = 0x20000;
 pub const TD_PAYLOAD_ACPI_SIZE: u32 = 0x100000;
 pub const TD_PAYLOAD_SIZE: u32 = 0x2000000;

--- a/td-shim/src/bin/td-shim/linux/boot.rs
+++ b/td-shim/src/bin/td-shim/linux/boot.rs
@@ -61,7 +61,6 @@ pub fn boot_kernel(
     rsdp_addr: u64,
     e820: &[E820Entry],
     mailbox_base: u64,
-    idt_base: u64,
     info: &PayloadInfo,
     #[cfg(feature = "tdx")] unaccepted_bitmap: u64,
 ) -> Result<(), Error> {
@@ -111,7 +110,7 @@ pub fn boot_kernel(
     log::info!("Jump to kernel...\n");
 
     // Relocate the Interrupt Descriptor Table before jump to payload
-    switch_idt(idt_base);
+    switch_idt(mailbox_base);
 
     // Relocate Mailbox along side with the AP function
     td::relocate_mailbox(mailbox_base as u32);

--- a/td-shim/src/bin/td-shim/memory.rs
+++ b/td-shim/src/bin/td-shim/memory.rs
@@ -6,8 +6,8 @@ use alloc::vec::Vec;
 use core::panic;
 use td_layout::build_time::{TD_SHIM_FIRMWARE_BASE, TD_SHIM_FIRMWARE_SIZE};
 use td_layout::runtime::{
-    self, KERNEL_BASE, KERNEL_SIZE, TD_PAYLOAD_EVENT_LOG_SIZE, TD_PAYLOAD_IDT_SIZE,
-    TD_PAYLOAD_PAGE_TABLE_SIZE, TD_PAYLOAD_SIZE,
+    self, KERNEL_BASE, KERNEL_SIZE, TD_PAYLOAD_EVENT_LOG_SIZE, TD_PAYLOAD_PAGE_TABLE_SIZE,
+    TD_PAYLOAD_SIZE,
 };
 use td_layout::{memslice, RuntimeMemoryLayout, MIN_MEMORY_SIZE};
 use td_shim::e820::{E820Entry, E820Type};
@@ -146,11 +146,6 @@ impl<'a> Memory<'a> {
             E820Type::Reserved,
             self.layout.runtime_page_table_base,
             TD_PAYLOAD_PAGE_TABLE_SIZE as u64,
-        );
-        table.convert_range(
-            E820Type::Reserved,
-            self.layout.runtime_idt_base,
-            TD_PAYLOAD_IDT_SIZE as u64,
         );
         table.convert_range(
             E820Type::Acpi,


### PR DESCRIPTION
Fix: https://github.com/confidential-containers/td-shim/issues/476