### PR TITLE
td-payload: use `target_os` to replace `not(test)`

### DIFF
--- a/td-payload/src/mm/heap.rs
+++ b/td-payload/src/mm/heap.rs
@@ -2,17 +2,12 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#[cfg(any(target_os = "none", target_os = "uefi"))]
 use core::panic::PanicInfo;
-
-#[cfg(not(test))]
 use linked_list_allocator::LockedHeap;
 
 #[global_allocator]
-#[cfg(not(test))]
 static HEAP: LockedHeap = LockedHeap::empty();
 
-#[cfg(any(target_os = "none", target_os = "uefi"))]
 #[panic_handler]
 #[allow(clippy::empty_loop)]
 fn panic(_info: &PanicInfo) -> ! {
@@ -23,7 +18,6 @@ fn panic(_info: &PanicInfo) -> ! {
     loop {}
 }
 
-#[cfg(any(target_os = "none", target_os = "uefi"))]
 #[alloc_error_handler]
 #[allow(clippy::empty_loop)]
 fn alloc_error(_info: core::alloc::Layout) -> ! {
@@ -35,12 +29,8 @@ fn alloc_error(_info: core::alloc::Layout) -> ! {
 }
 
 /// The initialization method for the global heap allocator.
-#[cfg(not(test))]
 pub fn init_heap(heap_start: u64, heap_size: usize) {
     unsafe {
         HEAP.lock().init(heap_start as *mut u8, heap_size);
     }
 }
-
-#[cfg(test)]
-pub fn init_heap(_heap_start: u64, _heap_size: usize) {}

--- a/td-payload/src/mm/mod.rs
+++ b/td-payload/src/mm/mod.rs
@@ -21,7 +21,13 @@ use crate::Error;
 
 #[cfg(feature = "tdx")]
 pub mod dma;
+#[cfg(any(target_os = "none", target_os = "uefi"))]
 pub(crate) mod heap;
+#[cfg(not(any(target_os = "none", target_os = "uefi")))]
+pub(crate) mod heap {
+    // A null implementation used by test
+    pub fn init_heap(_heap_start: u64, _heap_size: usize) {}
+}
 pub mod layout;
 pub(crate) mod page_table;
 


### PR DESCRIPTION
`cfg(not(test))` will not take effect when the crate is used as a dependency, use `target_os` instead.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>