### PR TITLE
td-exception: remove attribute of enabling feature `asm_sym`

### DIFF
--- a/td-exception/src/lib.rs
+++ b/td-exception/src/lib.rs
@@ -4,7 +4,6 @@
 
 #![no_std]
 #![feature(naked_functions)]
-#![feature(asm_sym)]
 
 pub mod asm;
 pub mod idt;


### PR DESCRIPTION
`asm_sym` is stable in the toolchain we use.

Signed-off-by: Jiaqi Gao <jiaqi.gao@intel.com>