### PR TITLE
Makefile: update STABLE_TOOLCHAIN to fix `scoped_threads`

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -13,7 +13,7 @@ env:
   AS: nasm
   AR_x86_64_unknown_uefi: llvm-ar
   CC_x86_64_unknown_uefi: clang
-  STABLE_RUST_TOOLCHAIN: 1.60.0
+  STABLE_RUST_TOOLCHAIN: 1.66.0
   NIGHTLY_RUST_TOOLCHAIN: nightly-2022-11-15
   TOOLCHAIN_PROFILE: minimal
 

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -13,7 +13,7 @@ env:
   AS: nasm
   AR_x86_64_unknown_uefi: llvm-ar
   CC_x86_64_unknown_uefi: clang
-  STABLE_RUST_TOOLCHAIN: 1.60.0
+  STABLE_RUST_TOOLCHAIN: 1.66.0
   NIGHTLY_RUST_TOOLCHAIN: nightly-2022-11-15
   TOOLCHAIN_PROFILE: minimal
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 export CARGO=cargo
-export STABLE_TOOLCHAIN:=1.60.0
+export STABLE_TOOLCHAIN:=1.66.0
 export NIGHTLY_TOOLCHAIN:=nightly-2022-11-15
 export BUILD_TYPE:=release
 export PREFIX:=/usr/local

--- a/devtools/dev_container/Dockerfile
+++ b/devtools/dev_container/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 
 # Install rustup and a fixed version of Rust.
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2022-11-15
-RUN rustup toolchain install 1.60.0
+RUN rustup toolchain install 1.66.0
 RUN rustup component add rust-src
 RUN rustup component add llvm-tools-preview
 COPY cargo_config /root/.cargo/config


### PR DESCRIPTION
Unstable toolchain was updated to nightly-2022-11-15 by PR (https://github.com/confidential-containers/td-shim/pull/491). We should also update stable toolchain.