### PR TITLE
td-shim: use mailbox slice for idt/mailbox relocation

### DIFF
--- a/td-shim/src/bin/td-shim/linux/boot.rs
+++ b/td-shim/src/bin/td-shim/linux/boot.rs
@@ -60,7 +60,7 @@ pub fn boot_kernel(
     kernel: &[u8],
     rsdp_addr: u64,
     e820: &[E820Entry],
-    mailbox_base: u64,
+    mailbox: &mut [u8],
     info: &PayloadInfo,
     #[cfg(feature = "tdx")] unaccepted_bitmap: u64,
 ) -> Result<(), Error> {
@@ -110,10 +110,10 @@ pub fn boot_kernel(
     log::info!("Jump to kernel...\n");
 
     // Relocate the Interrupt Descriptor Table before jump to payload
-    switch_idt(mailbox_base);
+    switch_idt(mailbox);
 
     // Relocate Mailbox along side with the AP function
-    td::relocate_mailbox(mailbox_base as u32);
+    td::relocate_mailbox(mailbox);
 
     // Calling kernel 64bit entry follows sysv64 calling convention
     let entry64: extern "sysv64" fn(usize, usize) = unsafe { core::mem::transmute(entry64) };

--- a/td-shim/src/bin/td-shim/td/tdx.rs
+++ b/td-shim/src/bin/td-shim/td/tdx.rs
@@ -25,8 +25,8 @@ pub fn accept_memory_resource_range(address: u64, size: u64) {
     super::tdx_mailbox::accept_memory_resource_range(cpu_num, address, size)
 }
 
-pub fn relocate_mailbox(address: u32) {
-    super::tdx_mailbox::relocate_mailbox(address).expect("Unable to relocate mailbox");
+pub fn relocate_mailbox(new_mailbox: &mut [u8]) {
+    super::tdx_mailbox::relocate_mailbox(new_mailbox).expect("Unable to relocate mailbox");
 }
 
 pub fn relocate_ap_page_table(page_table_base: u64) {


### PR DESCRIPTION
The purpose of these changes is remove the using of `get_dynamic_mem_slice_mut` in helper functions.