### PR TITLE
td-shim: use `payload_parameter` slice for `boot_kernel()`

### DIFF
--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -191,6 +191,7 @@ fn boot_linux_kernel(
 
     linux::boot::boot_kernel(
         payload,
+        payload_parameter,
         rsdp,
         e820_table.as_slice(),
         mailbox,


### PR DESCRIPTION
The address of payload paramter may be different in different configurations so use slice instead.