### PR TITLE
tdx-tdcall: use shared GPA for `GetQuote`

### DIFF
--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -379,7 +379,7 @@ pub fn tdvmcall_setup_event_notify(vector: u64) -> Result<(), TdVmcallError> {
 ///
 /// * buffer: a piece of 4KB-aligned shared memory
 pub fn tdvmcall_get_quote(buffer: &mut [u8]) -> Result<(), TdVmcallError> {
-    let addr = buffer.as_mut_ptr() as u64;
+    let addr = buffer.as_mut_ptr() as u64 | *SHARED_MASK;
 
     let mut args = TdVmcallArgs {
         r11: TDVMCALL_GETQUOTE,


### PR DESCRIPTION
GHCI takes shared GPA as input for TDG.VP.VMCALL<GetQuote> leaf function.

To be compatible with different versions of qemu, add an option to choose whether to use shared GPA.