### PR TITLE
td-shim-tools: use argument to determine the type of payload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ name: Build
 
 env:
   AS: nasm
+  AR_x86_64_unknown_linux_gnu: llvm-ar
+  CC_x86_64_unknown_linux_gnu: clang
   AR_x86_64_unknown_none: llvm-ar
   CC_x86_64_unknown_none: clang
   RUST_TOOLCHAIN: nightly-2022-11-15
@@ -80,7 +82,7 @@ jobs:
 
       - name: Build image without payload
         run: |
-          cargo run -p td-shim-tools --bin td-shim-ld --no-default-features --features=linker -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -o target/release/final.bin
+          cargo run -p td-shim-tools --bin td-shim-ld -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -o target/release/final.bin
       
       - name: Meta data check
         run: |
@@ -89,9 +91,9 @@ jobs:
       - name: Build Release Elf format payload
         run: |
           cargo xbuild -p td-payload --target x86_64-unknown-none --release --bin example --features=tdx,start,cet-shstk,stack-guard
-          cargo run -p td-shim-tools --no-default-features --features=linker --bin td-shim-ld -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -p target/x86_64-unknown-none/release/example -o target/release/final-elf.bin
+          cargo run -p td-shim-tools --bin td-shim-ld -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -t executable -p target/x86_64-unknown-none/release/example -o target/release/final-elf.bin
 
       - name: Build Debug Elf format payload
         run: |
           cargo xbuild -p td-payload --bin example --target x86_64-unknown-none --bin example --features=tdx,start,cet-shstk,stack-guard
-          cargo run -p td-shim-tools --no-default-features --features=linker --bin td-shim-ld -- target/x86_64-unknown-none/debug/ResetVector.bin target/x86_64-unknown-none/debug/td-shim -p target/x86_64-unknown-none/debug/example -o target/debug/final-elf.bin
+          cargo run -p td-shim-tools --bin td-shim-ld -- target/x86_64-unknown-none/debug/ResetVector.bin target/x86_64-unknown-none/debug/td-shim -t executable -p target/x86_64-unknown-none/debug/example -o target/debug/final-elf.bin

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ cargo xbuild -p td-shim --target x86_64-unknown-none --release --features=main,t
 ### Build Elf format payload
 ```
 cargo xbuild -p td-payload --target x86_64-unknown-none --release --bin example --features=tdx,start,cet-shstk,stack-guard
-cargo run -p td-shim-tools --bin td-shim-ld --no-default-features --features=linker -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -p target/x86_64-unknown-none/release/example -o target/release/final-elf.bin
+cargo run -p td-shim-tools --bin td-shim-ld -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -t executable -p target/x86_64-unknown-none/release/example -o target/release/final-elf.bin
 ```
 
 ## Run

--- a/doc/test_with_td_payload.md
+++ b/doc/test_with_td_payload.md
@@ -34,7 +34,7 @@ $ cd ..
 ### Generate final.bin
 ```
 $ cargo xbuild -p td-shim --target x86_64-unknown-none --release --features=main,tdx --no-default-features
-$ cargo run -p td-shim-tools --bin td-shim-ld --no-default-features --features=linker -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -p target/x86_64-unknown-uefi/release/test-td-payload.efi -o target/release/final-pe.bin
+$ cargo run -p td-shim-tools --bin td-shim-ld -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -t executable -p target/x86_64-unknown-uefi/release/test-td-payload.efi -o target/release/final-pe.bin
 ```
 
 ### Enroll json file in CFV

--- a/sh_script/build_final.sh
+++ b/sh_script/build_final.sh
@@ -32,9 +32,10 @@ final_elf() {
     cargo run -p td-shim-tools --bin td-shim-strip-info -- -n td-shim --target x86_64-unknown-none
     cargo run -p td-shim-tools --bin td-shim-strip-info -- -n example --target x86_64-unknown-none
 
-    cargo run -p td-shim-tools --features="linker" --no-default-features --bin td-shim-ld -- \
+    cargo run -p td-shim-tools --bin td-shim-ld -- \
         target/x86_64-unknown-none/release/ResetVector.bin \
         target/x86_64-unknown-none/release/td-shim \
+        -t executable \
         -p target/x86_64-unknown-none/release/example \
         -o target/release/final-elf.bin 
 }
@@ -50,9 +51,10 @@ final_elf_test() {
     cargo run -p td-shim-tools --bin td-shim-strip-info -- -n td-shim --target x86_64-unknown-none
     cargo run -p td-shim-tools --bin td-shim-strip-info -- -n test-td-payload --target x86_64-unknown-none
 
-    cargo run -p td-shim-tools --features="linker" --no-default-features --bin td-shim-ld -- \
+    cargo run -p td-shim-tools --bin td-shim-ld -- \
         target/x86_64-unknown-none/release/ResetVector.bin \
         target/x86_64-unknown-none/release/td-shim \
+        -t executable \
         -p target/x86_64-unknown-none/release/test-td-payload \
         -o target/release/final-elf-test.bin
 
@@ -76,9 +78,10 @@ final_elf_sb_test() {
     cargo run -p td-shim-tools --bin td-shim-sign-payload -- -A ECDSA_NIST_P384_SHA384 data/sample-keys/ecdsa-p384-private.pk8 target/x86_64-unknown-none/release/example 1 1 
 
     echo "Build final binary with unsigned td payload"
-    cargo run -p td-shim-tools --features="linker" --no-default-features --bin td-shim-ld -- \
+    cargo run -p td-shim-tools --bin td-shim-ld -- \
         target/x86_64-unknown-none/release/ResetVector.bin \
         target/x86_64-unknown-none/release/td-shim \
+        -t executable \
         -p target/x86_64-unknown-none/release/example \
         -o target/release/final-elf-unsigned.bin
     
@@ -89,9 +92,10 @@ final_elf_sb_test() {
         -o target/release/final-elf-sb-unsigned.bin
 
     echo "Build final binary with signed td payload and enroll uncorrect public key in CFV"
-    cargo run -p td-shim-tools --features="linker" --no-default-features --bin td-shim-ld -- \
+    cargo run -p td-shim-tools --bin td-shim-ld -- \
         target/x86_64-unknown-none/release/ResetVector.bin \
         target/x86_64-unknown-none/release/td-shim \
+        -t executable \
         -p target/x86_64-unknown-none/release/td-payload-signed \
         -o target/release/final-elf-signed.bin
     


### PR DESCRIPTION
Fix: https://github.com/confidential-containers/td-shim/issues/523

td-shim-tool needs the type of payload to generate metadta for the image.

Previously, we used feature to distinguish types of payload, its disadvantage
is that we need to compile different executable files for different types.