### PR TITLE
td-shim-tools: fix build error in `td-payload-reference-calculator`

### DIFF
--- a/td-shim-tools/src/bin/td-payload-reference-calculator/main.rs
+++ b/td-shim-tools/src/bin/td-payload-reference-calculator/main.rs
@@ -9,7 +9,7 @@ use anyhow::*;
 use clap::{arg, command};
 use parse_int::parse;
 use sha2::Digest;
-use std::path::Path;
+use std::{convert::TryFrom, path::Path};
 
 pub const KERNEL_SIZE: &str = "0x2000000";
 pub const KERNEL_PARAM_SIZE: &str = "0x1000";


### PR DESCRIPTION
Add a `use` for `std::convert::TryFrom`.