### PR TITLE
td-shim-tools: upgrade `clap` version to 4.0+

### DIFF
--- a/td-shim-tools/Cargo.toml
+++ b/td-shim-tools/Cargo.toml
@@ -47,7 +47,7 @@ cfg-if = "1.0"
 
 anyhow = { version = "1.0.68", optional = true }
 block-padding = { version = "0.3.2", optional = true }
-clap = { version = "3.0", features = ["cargo"], optional = true }
+clap = { version = "4.0", features = ["cargo"], optional = true }
 der = { version = "0.4.5", features = ["oid"], optional = true }
 env_logger = { version = "0.9.0", optional = true }
 log = { version = "0.4.5", optional = true }

--- a/td-shim-tools/src/bin/td-payload-reference-calculator/main.rs
+++ b/td-shim-tools/src/bin/td-payload-reference-calculator/main.rs
@@ -6,7 +6,7 @@
 //! A simple tool to calculate td-payload and parameter's reference value due to given kernel
 
 use anyhow::*;
-use clap::{arg, command};
+use clap::{arg, command, ArgAction};
 use parse_int::parse;
 use sha2::Digest;
 use std::path::Path;
@@ -49,13 +49,13 @@ fn main() {
                 .arg(
                     arg!(-k --kernel "path to vmlinuz kernel")
                         .required(true)
-                        .takes_value(true)
-                        .allow_invalid_utf8(false),
+                        .action(ArgAction::Set),
                 )
                 .arg(
                     arg!(-s --"size" "KERNEL_SIZE of the target td-shim")
                         .required(false)
-                        .default_value(KERNEL_SIZE),
+                        .default_value(KERNEL_SIZE)
+                        .action(ArgAction::Set),
                 ),
         )
         .subcommand(
@@ -63,26 +63,26 @@ fn main() {
                 .arg(
                     arg!(-p --parameter "kernel parameter string")
                         .required(true)
-                        .takes_value(true)
-                        .allow_invalid_utf8(false),
+                        .action(ArgAction::Set),
                 )
                 .arg(
                     arg!(-s --"size" "KERNEL_PARAM_SIZE of the target td-shim")
                         .required(false)
-                        .default_value(KERNEL_PARAM_SIZE),
+                        .default_value(KERNEL_PARAM_SIZE)
+                        .action(ArgAction::Set),
                 ),
         )
         .get_matches();
 
     let res = match matches.subcommand() {
         Some(("kernel", args)) => {
-            let path = args.value_of("kernel").unwrap();
-            let siz = args.value_of("size").unwrap();
+            let path = args.get_one::<String>("kernel").unwrap();
+            let siz = args.get_one::<String>("size").unwrap();
             kernel(path, siz)
         }
         Some(("param", args)) => {
-            let parameter = args.value_of("parameter").unwrap();
-            let siz = args.value_of("size").unwrap();
+            let parameter = args.get_one::<String>("parameter").unwrap();
+            let siz = args.get_one::<String>("size").unwrap();
             param(parameter, siz)
         }
         Some((_, _)) => unreachable!(),

--- a/td-shim-tools/src/bin/td-shim-checker/main.rs
+++ b/td-shim-tools/src/bin/td-shim-checker/main.rs
@@ -5,6 +5,7 @@
 
 #[macro_use]
 extern crate clap;
+use clap::ArgAction;
 use log::{error, LevelFilter};
 use std::str::FromStr;
 use std::vec::Vec;
@@ -28,26 +29,22 @@ pub enum ConfigParseError {
 impl Config {
     pub fn new() -> Result<Self, ConfigParseError> {
         let matches = command!()
-            .arg(
-                arg!([tdshim] "shim binary file")
-                    .required(true)
-                    .allow_invalid_utf8(false),
-            )
+            .arg(arg!([tdshim] "shim binary file").required(true))
             .arg(
                 arg!(-l --"log-level" "logging level: [off, error, warn, info, debug, trace]")
                     .required(false)
-                    .default_value("info"),
+                    .default_value("info")
+                    .action(ArgAction::Set),
             )
             .get_matches();
 
         // Safe to unwrap() because they are mandatory or have default values.
         //
         // rust-td binary file
-        let input = matches.value_of("tdshim").unwrap().to_string();
+        let input = matches.get_one::<String>("tdshim").unwrap().clone();
 
         // Safe to unwrap() because they are mandatory or have default values.
-        let log_level = String::from_str(matches.value_of("log-level").unwrap())
-            .map_err(|_| ConfigParseError::InvalidLogLevel)?;
+        let log_level = matches.get_one::<String>("log-level").unwrap().clone();
 
         Ok(Self { input, log_level })
     }

--- a/td-shim-tools/src/bin/td-shim-ld/main.rs
+++ b/td-shim-tools/src/bin/td-shim-ld/main.rs
@@ -9,6 +9,7 @@ extern crate clap;
 use std::io;
 use std::str::FromStr;
 
+use clap::ArgAction;
 use log::LevelFilter;
 use td_shim_tools::linker::TdShimLinker;
 
@@ -21,59 +22,53 @@ fn main() -> io::Result<()> {
 
     let matches = command!()
         .about("Link multiple shim objects into shim binary")
-        .arg(
-            arg!([reset_vector] "Reset_vector binary file")
-                .required(true)
-                .allow_invalid_utf8(false),
-        )
-        .arg(
-            arg!([ipl] "Internal payload (IPL) binary file")
-                .required(true)
-                .allow_invalid_utf8(false),
-        )
+        .arg(arg!([reset_vector] "Reset_vector binary file").required(true))
+        .arg(arg!([ipl] "Internal payload (IPL) binary file").required(true))
         .arg(
             arg!(-p --payload "Payload binary file")
                 .required(false)
-                .takes_value(true)
-                .allow_invalid_utf8(false),
+                .action(ArgAction::Set),
         )
         .arg(
             arg!(-m --metadata "Metadata sections config file")
                 .required(false)
-                .takes_value(true)
-                .allow_invalid_utf8(false),
+                .action(ArgAction::Set),
         )
         .arg(
             arg!(-l --"log-level" "Logging level: [off, error, warn, info, debug, trace]")
                 .required(false)
-                .default_value("info"),
+                .default_value("info")
+                .action(ArgAction::Set),
         )
-        .arg(arg!(-r --"relocate-payload" "Relocate shim payload content").required(false))
+        .arg(
+            arg!(-r --"relocate-payload" "Relocate shim payload content")
+                .required(false)
+                .action(ArgAction::SetTrue),
+        )
         .arg(
             arg!(-o --output "Output of the merged shim binary file")
                 .required(false)
-                .takes_value(true)
-                .allow_invalid_utf8(false),
+                .action(ArgAction::Set),
         )
         .get_matches();
 
-    if let Ok(lvl) = LevelFilter::from_str(matches.value_of("log-level").unwrap()) {
+    if let Ok(lvl) = LevelFilter::from_str(matches.get_one::<String>("log-level").unwrap()) {
         log::set_max_level(lvl);
     }
 
     let mut builder = TdShimLinker::default();
-    if let Some(output_name) = matches.value_of("output") {
-        builder.set_output_file(output_name.to_string());
+    if let Some(output_name) = matches.get_one::<String>("output") {
+        builder.set_output_file(output_name.clone());
     }
-    if matches.is_present("relocate-payload") {
+    if matches.get_flag("relocate-payload") {
         builder.set_payload_relocation(true);
     }
 
     // Safe to unwrap() because these are mandatory arguments.
-    let reset_name = matches.value_of("reset_vector").unwrap();
-    let ipl_name = matches.value_of("ipl").unwrap();
-    let payload_name = matches.value_of("payload");
-    let metadata_name = matches.value_of("metadata");
+    let reset_name = matches.get_one::<String>("reset_vector").unwrap().as_str();
+    let ipl_name = matches.get_one::<String>("ipl").unwrap().as_str();
+    let payload_name = matches.get_one::<String>("payload").map(|s| s.as_str());
+    let metadata_name = matches.get_one::<String>("metadata").map(|s| s.as_str());
 
     builder.build(reset_name, ipl_name, payload_name, metadata_name)
 }


### PR DESCRIPTION
Clap 4.0 enabled the feature showing help message for possible values which is very useful for us to add detailed description for the tools.

This will help the PR https://github.com/confidential-containers/td-shim/pull/530 to show the help message about `payload-type` options.

The new version deprecated `allow_invalid_utf8()` and `takes_value()`, we can use generic types and `ArgAction` instead.