### PR TITLE
remove all the `boot-kernel` features

### DIFF
--- a/sh_script/build_final.sh
+++ b/sh_script/build_final.sh
@@ -14,11 +14,11 @@ fi
 
 final_boot_kernel() {
     echo "Build final binary with boot-kernel support"
-    cargo xbuild -p td-shim --target x86_64-unknown-none --release --features=main,tdx,boot-kernel
+    cargo xbuild -p td-shim --target x86_64-unknown-none --release --features=main,tdx
 
     cargo run -p td-shim-tools --bin td-shim-strip-info -- -n td-shim --target x86_64-unknown-none
 
-    cargo run -p td-shim-tools --features=td-shim/default,td-shim/tdx,boot-kernel --bin td-shim-ld -- \
+    cargo run -p td-shim-tools --features=td-shim/default,td-shim/tdx --bin td-shim-ld -- \
         target/x86_64-unknown-none/release/ResetVector.bin \
         target/x86_64-unknown-none/release/td-shim \
         -o target/release/final-boot-kernel.bin

--- a/td-layout/Cargo.toml
+++ b/td-layout/Cargo.toml
@@ -8,7 +8,6 @@ license = "BSD-2-Clause-Patent"
 edition = "2018"
 
 [features]
-boot-kernel = []
 
 [dependencies]
 scroll = { version = "0.10", default-features = false, features = ["derive"]}

--- a/td-shim-tools/Cargo.toml
+++ b/td-shim-tools/Cargo.toml
@@ -61,8 +61,7 @@ byteorder = { version = "1.4.3", optional = true }
 parse_int = { version = "0.6.0", optional = true }
 
 [features]
-default = ["boot-kernel", "enroller", "linker", "signer", "loader", "tee"]
-boot-kernel = ["td-layout/boot-kernel", "td-shim/boot-kernel"]
+default = ["enroller", "linker", "signer", "loader", "tee"]
 enroller = ["clap", "der", "env_logger", "log", "ring", "td-shim/secure-boot"]
 linker = ["clap", "env_logger", "log", "parse_int", "serde_json", "serde", "td-loader"]
 signer = ["clap", "der", "env_logger", "log", "ring", "td-shim/secure-boot"]

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -46,8 +46,7 @@ der = {version = "0.4.5", features = ["derive", "alloc"], optional = true}
 tdx-tdcall = { path = "../tdx-tdcall", optional = true }
 
 [features]
-default = ["boot-kernel", "secure-boot"]
-boot-kernel = ["td-layout/boot-kernel"]
+default = ["secure-boot"]
 secure-boot = ["der", "ring"]
 tdx = ["tdx-tdcall", "td-exception/tdx", "td-logger/tdx", "x86"]
 lazy-accept = ["tdx"]


### PR DESCRIPTION
Fix: https://github.com/confidential-containers/td-shim/issues/523

The use of `boot-kernel` features in `td-shim`, `td-layout` and `td-shim-tools` has been removed. We can remove these features now.