### PR TITLE
tests: add cet shstk/ibt and stack guard cases

### DIFF
--- a/tests/test-td-payload/src/main.rs
+++ b/tests/test-td-payload/src/main.rs
@@ -10,9 +10,12 @@
 
 mod lib;
 mod testacpi;
+mod testcetibt;
+mod testcetshstk;
 mod testiorw32;
 mod testiorw8;
 mod testmemmap;
+mod teststackguard;
 mod testtdinfo;
 mod testtdreport;
 mod testtdve;
@@ -31,9 +34,12 @@ use td_layout::memslice;
 
 use crate::lib::{TestResult, TestSuite};
 use crate::testacpi::{TdAcpi, TestTdAcpi};
+use crate::testcetibt::TestCetIbt;
+use crate::testcetshstk::TestCetShstk;
 use crate::testiorw32::Tdiorw32;
 use crate::testiorw8::Tdiorw8;
 use crate::testmemmap::MemoryMap;
+use crate::teststackguard::TestStackGuard;
 use crate::testtdinfo::Tdinfo;
 use crate::testtdreport::Tdreport;
 use crate::testtdve::TdVE;
@@ -71,6 +77,9 @@ pub struct TestCases {
     pub tcs014: MemoryMap,
     pub tcs015: MemoryMap,
     pub tcs016: TdTrustedBoot,
+    pub tcs017: Option<TestStackGuard>,
+    pub tcs018: Option<TestCetShstk>,
+    pub tcs019: Option<TestCetIbt>,
 }
 
 pub const CFV_FFS_HEADER_TEST_CONFIG_GUID: Guid = Guid::from_fields(
@@ -134,6 +143,7 @@ extern "C" fn main() -> ! {
     use td_payload::hob::get_hob;
     use testmemmap::TestMemoryMap;
 
+    let _ = td_logger::init();
     let hob = get_hob().expect("Failed to get payload HOB").as_ptr() as u64;
 
     // create TestSuite to hold the test cases
@@ -237,6 +247,24 @@ extern "C" fn main() -> ! {
             case: tcs.tcs016,
         };
         ts.testsuite.push(Box::new(test_tboot));
+    }
+
+    if let Some(tcs017) = tcs.tcs017 {
+        if tcs017.run {
+            ts.testsuite.push(Box::new(tcs017));
+        }
+    }
+
+    if let Some(tcs018) = tcs.tcs018 {
+        if tcs018.run {
+            ts.testsuite.push(Box::new(tcs018));
+        }
+    }
+
+    if let Some(tcs019) = tcs.tcs019 {
+        if tcs019.run {
+            ts.testsuite.push(Box::new(tcs019));
+        }
     }
 
     // run the TestSuite which contains the test cases

--- a/tests/test-td-payload/src/testcetibt.rs
+++ b/tests/test-td-payload/src/testcetibt.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_std]
+extern crate alloc;
+
+use crate::lib::{TestCase, TestResult};
+use alloc::string::String;
+
+use serde::{Deserialize, Serialize};
+
+/**
+ * Test functionality of CET indirect branch tracking of `td-payload`
+ */
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TestCetIbt {
+    pub name: String,
+    pub result: TestResult,
+    pub run: bool,
+}
+
+/**
+ * Implement the TestCase trait for TestCetIbt
+ */
+impl TestCase for TestCetIbt {
+    /**
+     * set up the Test case of TestCetIbt
+     */
+    fn setup(&mut self) {
+        self.result = TestResult::Fail;
+    }
+
+    /**
+     * run the test case
+     * unable to resume execution after triggering control flow exception
+     * this function will never return
+     */
+    fn run(&mut self) {
+        unsafe { test_without_endbr() }
+    }
+
+    /**
+     * Tear down the test case.
+     */
+    fn teardown(&mut self) {}
+
+    /**
+     * get the name of the test case.
+     */
+    fn get_name(&mut self) -> String {
+        String::from(&self.name)
+    }
+
+    /**
+     * get the result of the test case.
+     */
+    fn get_result(&mut self) -> TestResult {
+        self.result
+    }
+}
+
+extern "sysv64" {
+    fn test_without_endbr();
+}
+
+core::arch::global_asm!(
+    "
+    .global test_without_endbr
+    test_without_endbr:
+    ret",
+);

--- a/tests/test-td-payload/src/testcetshstk.rs
+++ b/tests/test-td-payload/src/testcetshstk.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_std]
+extern crate alloc;
+
+use crate::lib::{TestCase, TestResult};
+use alloc::string::String;
+
+use serde::{Deserialize, Serialize};
+
+/**
+ * Test functionality of CET shadow stack of `td-payload`
+ */
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TestCetShstk {
+    pub name: String,
+    pub result: TestResult,
+    pub run: bool,
+}
+
+/**
+ * Implement the TestCase trait for TestCetShstk
+ */
+impl TestCase for TestCetShstk {
+    /**
+     * set up the Test case of TestCetShstk
+     */
+    fn setup(&mut self) {
+        self.result = TestResult::Fail;
+    }
+
+    /**
+     * run the test case
+     * unable to resume execution after triggering control flow exception
+     * this function will never return
+     */
+    fn run(&mut self) {
+        // Recursive call, ending with a page fault exception
+        unsafe {
+            tamper_return_address();
+        }
+    }
+
+    /**
+     * Tear down the test case.
+     */
+    fn teardown(&mut self) {}
+
+    /**
+     * get the name of the test case.
+     */
+    fn get_name(&mut self) -> String {
+        String::from(&self.name)
+    }
+
+    /**
+     * get the result of the test case.
+     */
+    fn get_result(&mut self) -> TestResult {
+        self.result
+    }
+}
+
+extern "sysv64" {
+    fn tamper_return_address();
+}
+
+core::arch::global_asm!(
+    "
+    .global tamper_return_address
+    tamper_return_address:
+    mov rax, rsp
+    mov dword ptr [rax], 0xfefefefe
+    ret",
+);

--- a/tests/test-td-payload/src/teststackguard.rs
+++ b/tests/test-td-payload/src/teststackguard.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#![no_std]
+extern crate alloc;
+
+use crate::lib::{TestCase, TestResult};
+use alloc::string::String;
+
+use serde::{Deserialize, Serialize};
+
+/**
+ * Test functionality of stack guard (guard page) of `td-payload`
+ */
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TestStackGuard {
+    pub name: String,
+    pub result: TestResult,
+    pub run: bool,
+}
+
+/**
+ * Implement the TestCase trait for TestStackGuard
+ */
+impl TestCase for TestStackGuard {
+    /**
+     * set up the Test case of TestStackGuard
+     */
+    fn setup(&mut self) {
+        self.result = TestResult::Fail;
+    }
+
+    /**
+     * run the test case
+     * unable to resume execution after triggering page fault exception
+     * this function will never return
+     */
+    fn run(&mut self) {
+        // Recursive call, ending with a page fault exception
+        unsafe {
+            recursive();
+        }
+    }
+
+    /**
+     * Tear down the test case.
+     */
+    fn teardown(&mut self) {}
+
+    /**
+     * get the name of the test case.
+     */
+    fn get_name(&mut self) -> String {
+        String::from(&self.name)
+    }
+
+    /**
+     * get the result of the test case.
+     */
+    fn get_result(&mut self) -> TestResult {
+        self.result
+    }
+}
+
+extern "C" {
+    fn recursive();
+}
+
+core::arch::global_asm!(
+    "
+    .global recursive
+    recursive:
+    call recursive
+    ret",
+);


### PR DESCRIPTION
Fix: https://github.com/confidential-containers/td-shim/issues/512

These cases are used to check whether the cet features and stack guard (guard page on the top of the stack) are correctly configured.

When the cet shstk feature is enabled and well configured, control flow exception will be triggered if the return address in the normal stack is not equal to the one in the shadow stack. This feature will be available only if the x86 shadow stack is enabled on the host and the feature is added to the TD configuration.

When the cet ibt feature is enabled and correctly configured, control flow exception will be triggered if the indirect branches are not landed on `endbr/endbr64` instruction. This feature is not fully supported by rust compiler.

Page fault exception will be triggered by stack overflow when the guard page is configured on the top of the stack.