### PR TITLE
introduce xtask to build td-shim image

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,5 @@ kbuild = "build --target x86_64-custom.json -Zbuild-std=core -Zbuild-std-feature
 kimage = "run --target x86_64-custom.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem -- --no-run"
 krun = "run --target x86_64-custom.json -Zbuild-std=core -Zbuild-std-features=compiler-builtins-mem"
 ktest = "xtest --target x86_64-custom.json"
+xtask = "run -p xtask --release --"
+image = "xtask image"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Build image without payload
         run: |
-          cargo run -p td-shim-tools --bin td-shim-ld -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -o target/release/final.bin
+          cargo image --release
       
       - name: Meta data check
         run: |
@@ -90,10 +90,8 @@ jobs:
 
       - name: Build Release Elf format payload
         run: |
-          cargo xbuild -p td-payload --target x86_64-unknown-none --release --bin example --features=tdx,start,cet-shstk,stack-guard
-          cargo run -p td-shim-tools --bin td-shim-ld -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -t executable -p target/x86_64-unknown-none/release/example -o target/release/final-elf.bin
+          cargo image --example-payload --release
 
       - name: Build Debug Elf format payload
         run: |
-          cargo xbuild -p td-payload --bin example --target x86_64-unknown-none --bin example --features=tdx,start,cet-shstk,stack-guard
-          cargo run -p td-shim-tools --bin td-shim-ld -- target/x86_64-unknown-none/debug/ResetVector.bin target/x86_64-unknown-none/debug/td-shim -t executable -p target/x86_64-unknown-none/debug/example -o target/debug/final-elf.bin
+          cargo image --example-payload

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "tests/test-td-exception",
     "tests/test-td-paging",
     "tests/test-td-payload",
+    "xtask",
 ]
 
 # the profile used for `cargo build`

--- a/README.md
+++ b/README.md
@@ -95,19 +95,43 @@ Please follow [Secure Boot Guide](doc/secure_boot_guide.md)
 git submodule update --init --recursive
 ./sh_script/preparation.sh
 ```
+### Use xtask to build TdShim image
 
-### Build TdShim
+Build TdShim image to launch a payload support Linux Boot Protocol
+
+```
+cargo image --release
+
+```
+Build TdShim image to launch an executable payload
+
+```
+cargo image -t executable -p /path/to/payload_binary --release
+```
+
+Build TdShim image to launch the example payload
+
+```
+cargo image --example-payload --release
+```
+
+### Build TdShim manually
+
+Build TdShim to launch a payload support Linux Boot Protocol
+
 ```
 cargo xbuild -p td-shim --target x86_64-unknown-none --release --features=main,tdx
 cargo run -p td-shim-tools --bin td-shim-ld --features=linker -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -o target/release/final.bin
 ```
 
-### Build TdShim to launch a executable payload
+Build TdShim to launch a executable payload
+
 ```
 cargo xbuild -p td-shim --target x86_64-unknown-none --release --features=main,tdx --no-default-features
 ```
 
-### Build Elf format payload
+Build Elf format payload
+
 ```
 cargo xbuild -p td-payload --target x86_64-unknown-none --release --bin example --features=tdx,start,cet-shstk,stack-guard
 cargo run -p td-shim-tools --bin td-shim-ld -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -t executable -p target/x86_64-unknown-none/release/example -o target/release/final-elf.bin

--- a/sh_script/build_final.sh
+++ b/sh_script/build_final.sh
@@ -14,30 +14,13 @@ fi
 
 final_boot_kernel() {
     echo "Build final binary with boot-kernel support"
-    cargo xbuild -p td-shim --target x86_64-unknown-none --release --features=main,tdx
 
-    cargo run -p td-shim-tools --bin td-shim-strip-info -- -n td-shim --target x86_64-unknown-none
-
-    cargo run -p td-shim-tools --features=td-shim/default,td-shim/tdx --bin td-shim-ld -- \
-        target/x86_64-unknown-none/release/ResetVector.bin \
-        target/x86_64-unknown-none/release/td-shim \
-        -o target/release/final-boot-kernel.bin
+    cargo image --release -o target/release/final-boot-kernel.bin
 }
 
 final_elf() {
     echo final-elf
-    cargo xbuild -p td-shim --target x86_64-unknown-none --release --features=main,tdx --no-default-features
-    cargo xbuild -p td-payload --target x86_64-unknown-none --release --bin example --features=tdx,start,cet-shstk,stack-guard
-
-    cargo run -p td-shim-tools --bin td-shim-strip-info -- -n td-shim --target x86_64-unknown-none
-    cargo run -p td-shim-tools --bin td-shim-strip-info -- -n example --target x86_64-unknown-none
-
-    cargo run -p td-shim-tools --bin td-shim-ld -- \
-        target/x86_64-unknown-none/release/ResetVector.bin \
-        target/x86_64-unknown-none/release/td-shim \
-        -t executable \
-        -p target/x86_64-unknown-none/release/example \
-        -o target/release/final-elf.bin 
+    cargo --example-payload -o target/release/final-elf.bin 
 }
 
 final_elf_test() {
@@ -46,70 +29,43 @@ final_elf_test() {
     cargo xbuild -p test-td-payload --target x86_64-unknown-none --release --features=main,tdx --no-default-features
     popd
 
-    cargo xbuild -p td-shim --target x86_64-unknown-none --release --features=main,tdx --no-default-features
-
-    cargo run -p td-shim-tools --bin td-shim-strip-info -- -n td-shim --target x86_64-unknown-none
     cargo run -p td-shim-tools --bin td-shim-strip-info -- -n test-td-payload --target x86_64-unknown-none
-
-    cargo run -p td-shim-tools --bin td-shim-ld -- \
-        target/x86_64-unknown-none/release/ResetVector.bin \
-        target/x86_64-unknown-none/release/td-shim \
-        -t executable \
-        -p target/x86_64-unknown-none/release/test-td-payload \
-        -o target/release/final-elf-test.bin
 
     for ((i=1; i<=${config_num}; i++))
     do
-        cargo run -p td-shim-tools --features="enroller" --bin td-shim-enroll \
-        target/release/final-elf-test.bin \
-        -f F10E684E-3ABD-20E4-5932-8F973C355E57 tests/test-td-payload/config/test_config_${i}.json \
-        -o target/release/final-elf-test${i}.bin
+        cargo image --release -t executable \
+            -p target/x86_64-unknown-none/release/test-td-payload \
+            --enroll-file F10E684E-3ABD-20E4-5932-8F973C355E57,tests/test-td-payload/config/test_config_${i}.json \
+            -o target/release/final-elf-test${i}.bin
     done 
 }
 
 final_elf_sb_test() {
     echo "Build final binaries with ELF format td payload for secure boot test"
-    cargo xbuild -p td-shim --target x86_64-unknown-none --release --features=main,tdx,secure-boot --no-default-features
     cargo xbuild -p td-payload --target x86_64-unknown-none --release --bin example --features=tdx,start,cet-shstk,stack-guard
-
-    cargo run -p td-shim-tools --bin td-shim-strip-info -- -n td-shim --target x86_64-unknown-none
     cargo run -p td-shim-tools --bin td-shim-strip-info -- -n example --target x86_64-unknown-none
 
     cargo run -p td-shim-tools --bin td-shim-sign-payload -- -A ECDSA_NIST_P384_SHA384 data/sample-keys/ecdsa-p384-private.pk8 target/x86_64-unknown-none/release/example 1 1 
 
     echo "Build final binary with unsigned td payload"
-    cargo run -p td-shim-tools --bin td-shim-ld -- \
-        target/x86_64-unknown-none/release/ResetVector.bin \
-        target/x86_64-unknown-none/release/td-shim \
-        -t executable \
+    cargo image --release -t executable --features secure-boot \
         -p target/x86_64-unknown-none/release/example \
-        -o target/release/final-elf-unsigned.bin
-    
-    cargo run -p td-shim-tools --bin td-shim-enroll -- \
-        target/release/final-elf-unsigned.bin \
         -H SHA384 \
-        -k data/sample-keys/ecdsa-p384-public.der \
+        --enroll-key data/sample-keys/ecdsa-p384-public.der \
         -o target/release/final-elf-sb-unsigned.bin
 
     echo "Build final binary with signed td payload and enroll uncorrect public key in CFV"
-    cargo run -p td-shim-tools --bin td-shim-ld -- \
-        target/x86_64-unknown-none/release/ResetVector.bin \
-        target/x86_64-unknown-none/release/td-shim \
-        -t executable \
+    cargo image --release -t executable --features secure-boot \
         -p target/x86_64-unknown-none/release/td-payload-signed \
-        -o target/release/final-elf-signed.bin
-    
-    cargo run -p td-shim-tools --bin td-shim-enroll -- \
-        target/release/final-elf-signed.bin \
         -H SHA384 \
-        -k data/sample-keys/rsa-3072-public.der \
+        --enroll-key data/sample-keys/rsa-3072-public.der \
         -o target/release/final-elf-sb-mismatch-pubkey.bin
 
     echo "Build final binary with signed td payload and enroll correct public key in CFV"
-    cargo run -p td-shim-tools --bin td-shim-enroll -- \
-        target/release/final-elf-signed.bin \
+    cargo image --release -t executable --features secure-boot \
+        -p target/x86_64-unknown-none/release/td-payload-signed \
         -H SHA384 \
-        -k data/sample-keys/ecdsa-p384-public.der \
+        --enroll-key data/sample-keys/ecdsa-p384-public.der \
         -o target/release/final-elf-sb-normal.bin
 }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { version = "4.0", features = ["derive"] }
+xshell = "0.2"
+lazy_static = "1.4.0"
+anyhow = "1.0"

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -1,0 +1,282 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use anyhow::{anyhow, Ok, Result};
+use clap::{Parser, ValueEnum};
+use lazy_static::lazy_static;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+use xshell::{cmd, Shell};
+
+const TD_SHIM_DEFAULT_FEATURES: &str = "main,tdx";
+
+lazy_static! {
+    static ref PROJECT_ROOT: &'static Path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    static ref SHIM_OUTPUT: PathBuf = PROJECT_ROOT.join("target/x86_64-unknown-none/");
+    static ref IMAGE_OUTPUT: PathBuf = PROJECT_ROOT.join("target/release/final.bin");
+    static ref METADATA: PathBuf = PROJECT_ROOT.join("td-shim-tools/etc/metadata.json");
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
+enum PayloadType {
+    /// Payload Binary is bzImage or vmlinux, follow Linux boot protocol
+    Linux,
+    /// Payload Binary is a PE/COFF or ELF executable image as payload
+    Executable,
+}
+
+#[derive(Clone, Parser)]
+pub(crate) struct BuildArgs {
+    /// Build artifacts in release mode, with optimizations and without log messages
+    #[arg(long)]
+    release: bool,
+    /// Type of payload to be launched by td-shim
+    #[arg(short = 't', long)]
+    payload_type: Option<PayloadType>,
+    /// Path of the output td-shim image file
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+    /// List of features of `td-shim` crate to activate in addition to the `main` and `tdx`,
+    /// separated by comma. By default, only the `main` and `tdx` features of `td-shim` are enabled
+    #[arg(long)]
+    features: Option<String>,
+    /// Path of customized metadata configuration file
+    #[arg(short, long)]
+    metadata: Option<PathBuf>,
+    /// Path of customized layout configuration file, the layout source file of the payload
+    /// type specified by `payload-type` will be overwritten
+    #[arg(short, long)]
+    layout: Option<PathBuf>,
+    /// Package the payload binary into td-shim image
+    #[arg(short, long)]
+    payload: Option<PathBuf>,
+    /// Package the example payload binary into td-shim image, payload-type will be set to
+    /// executable.
+    #[arg(long)]
+    example_payload: bool,
+    /// <Guid>,<FilePath> Enroll raw files into into CFV of td-shim image
+    #[arg(long)]
+    enroll_file: Option<Vec<String>>,
+    /// <Guid>,<FilePath> Enroll public key file into CFV of td-shim image
+    #[arg(long, requires = "enroll_key_hash_alg")]
+    enroll_key: Option<String>,
+    /// Hash algorithm used by the enrolling public key file
+    #[arg(long, short = 'H', requires = "enroll_key")]
+    enroll_key_hash_alg: Option<String>,
+}
+
+impl BuildArgs {
+    pub fn build(&self) -> Result<PathBuf> {
+        if let Some(payload_type) = self.payload_type {
+            if payload_type == PayloadType::Linux && self.example_payload {
+                return Err(anyhow!("Invalid payload type for example payload"));
+            }
+        }
+
+        let (reset_vector, shim) = self.build_shim()?;
+
+        let payload = if let Some(payload) = &self.payload {
+            Some(fs::canonicalize(payload)?)
+        } else if self.example_payload {
+            Some(self.build_example_payload()?)
+        } else {
+            None
+        };
+
+        let bin = self.build_image(reset_vector, shim, payload)?;
+        self.enroll(bin.as_path())?;
+
+        Ok(bin)
+    }
+
+    fn build_shim_layout(&self) -> Result<()> {
+        let layout_config = if let Some(layout) = &self.layout {
+            fs::canonicalize(layout)?
+        } else {
+            return Ok(());
+        };
+
+        let sh = Shell::new()?;
+        sh.change_dir(PROJECT_ROOT.join("devtools/td-layout-config"));
+        cmd!(sh, "cargo run -- ")
+            .args(["--config", layout_config.to_str().unwrap()])
+            .arg(PROJECT_ROOT.join("td-layout/src"))
+            .run()?;
+        Ok(())
+    }
+
+    fn build_shim(&self) -> Result<(PathBuf, PathBuf)> {
+        self.build_shim_layout()?;
+
+        let sh = Shell::new()?;
+        cmd!(
+            sh,
+            "cargo xbuild -p td-shim --target x86_64-unknown-none --no-default-features"
+        )
+        .args(["--features", self.features().as_str()])
+        .args(["--profile", self.profile()])
+        .run()?;
+
+        Self::strip("td-shim")?;
+
+        Ok((
+            SHIM_OUTPUT
+                .join(&self.profile_path())
+                .join("ResetVector.bin"),
+            SHIM_OUTPUT.join(&self.profile_path()).join("td-shim"),
+        ))
+    }
+
+    fn build_example_payload(&self) -> Result<PathBuf> {
+        let sh = Shell::new()?;
+        cmd!(
+            sh,
+            "cargo xbuild -p td-payload --bin example --target x86_64-unknown-none"
+        )
+        .args(["--features", "tdx,start,cet-shstk,stack-guard"])
+        .args(["--profile", self.profile()])
+        .run()?;
+
+        Self::strip("example")?;
+
+        Ok(SHIM_OUTPUT.join(&self.profile_path()).join("example"))
+    }
+
+    fn build_image(
+        &self,
+        reset_vector: PathBuf,
+        shim: PathBuf,
+        payload: Option<PathBuf>,
+    ) -> Result<PathBuf> {
+        let sh = Shell::new()?;
+        let mut cmd = cmd!(
+            sh,
+            "cargo run -p td-shim-tools --bin td-shim-ld --features linker --"
+        );
+
+        if self.payload_type() == PayloadType::Executable {
+            cmd = cmd.args(["-t", "executable"]);
+        }
+
+        cmd = cmd
+            .args(&[reset_vector])
+            .args(&[shim])
+            .args(&["-o", self.output()?.to_str().unwrap()]);
+
+        if let Some(metadata) = &self.metadata {
+            cmd = cmd.args(&["-m", fs::canonicalize(metadata)?.to_str().unwrap()]);
+        }
+
+        if let Some(payload) = payload {
+            cmd.args(&["-p", payload.to_str().unwrap()])
+        } else {
+            cmd
+        }
+        .run()?;
+
+        Ok(self.output()?.to_path_buf())
+    }
+
+    fn enroll(&self, image: &Path) -> Result<()> {
+        if self.enroll_file.is_none() && self.enroll_key.is_none() {
+            return Ok(());
+        }
+
+        let sh = Shell::new()?;
+        let mut cmd = cmd!(sh, "cargo run -p td-shim-tools --bin td-shim-enroll")
+            .args(&[image])
+            .args(&["-o", self.output()?.to_str().unwrap()]);
+
+        if let Some(files) = self.enroll_file.as_ref() {
+            for f in files {
+                let f = f.split(",").map(|s| s.to_string()).collect::<Vec<String>>();
+                cmd = cmd.args(&["-f", f[0].as_str()]).arg(f[1].as_str());
+            }
+        }
+
+        if let Some(key) = self.enroll_key.as_ref() {
+            cmd.args(&["-k", key.as_str()])
+                .args(&["-H", self.enroll_key_hash_alg()?.as_str()])
+        } else {
+            cmd
+        }
+        .run()?;
+
+        Ok(())
+    }
+
+    fn payload_type(&self) -> PayloadType {
+        self.payload_type.unwrap_or_else(|| {
+            if self.example_payload {
+                PayloadType::Executable
+            } else {
+                PayloadType::Linux
+            }
+        })
+    }
+
+    fn profile(&self) -> &str {
+        if self.release {
+            "release"
+        } else {
+            "dev"
+        }
+    }
+
+    fn profile_path(&self) -> &str {
+        if self.release {
+            "release"
+        } else {
+            "debug"
+        }
+    }
+
+    fn features(&self) -> String {
+        let mut features: Vec<String> = TD_SHIM_DEFAULT_FEATURES
+            .split(",")
+            .map(|s| s.to_string())
+            .collect();
+
+        if let Some(selected) = &self.features {
+            for s in selected.split(",") {
+                features.push(s.to_string());
+            }
+        }
+
+        features.join(",")
+    }
+
+    fn output(&self) -> Result<PathBuf> {
+        let path = self.output.as_ref().unwrap_or(&IMAGE_OUTPUT);
+
+        // Get the absolute path of the target file
+        let absolute = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            env::current_dir()?.join(path)
+        };
+        Ok(absolute)
+    }
+
+    fn enroll_key_hash_alg(&self) -> Result<String> {
+        self.enroll_key_hash_alg
+            .clone()
+            .ok_or(anyhow!("Hash algorithm of public key is not specified.."))
+    }
+
+    fn strip(name: &str) -> Result<()> {
+        let sh = Shell::new()?;
+        cmd!(
+            sh,
+            "cargo run -p td-shim-tools --bin td-shim-strip-info -- --target x86_64-unknown-none"
+        )
+        .args(["-n", name])
+        .run()?;
+
+        Ok(())
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+mod build;
+
+use std::process::exit;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+struct Program {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Image(build::BuildArgs),
+}
+
+fn main() {
+    match Program::parse().command {
+        Commands::Image(args) => match args.build() {
+            Ok(image) => {
+                println!("Successfully generate TD-Shim image: {}", image.display());
+            }
+            Err(e) => {
+                eprintln!("[ERROR]: {}", e);
+                exit(-1)
+            }
+        },
+    };
+}


### PR DESCRIPTION
Fix: https://github.com/confidential-containers/td-shim/issues/528

Run `cargo image --help`

```
Usage: xtask image [OPTIONS]

Options:
      --release
          Build artifacts in release mode, with optimizations and without log messages

  -t, --payload-type <PAYLOAD_TYPE>
          Type of payload to be launched by td-shim

          Possible values:
          - linux:      Payload Binary is bzImage or vmlinux, follow Linux boot protocol
          - executable: Payload Binary is a PE/COFF or ELF executable image as payload

  -o, --output <OUTPUT>
          Path of the output td-shim image file

      --no-default-features
          Disable the `default` features of td-shim crate, this flag will be set automatically when the payload type is executable

      --features <FEATURES>
          List of features to activate separated by comma

  -m, --metadata <METADATA>
          Path of customized metadata configuration file

  -l, --layout <LAYOUT>
          Path of customized layout configuration file, the layout source file of the payload type specified by `payload-type` will be overwritten

  -p, --payload <PAYLOAD>
          Package the payload binary into td-shim image

      --example-payload
          Package the example payload binary into td-shim image, payload-type will be set to executable

      --enroll-file <ENROLL_FILE>
          <Guid>,<FilePath> Enroll raw files into into CFV of td-shim image

      --enroll-key <ENROLL_KEY>
          <Guid>,<FilePath> Enroll public key file into CFV of td-shim image

  -h, --help
          Print help (see a summary with '-h')
```