### PR TITLE
xtask: strip info only for the release build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,10 @@ jobs:
         run: |
           cargo run -p td-shim-tools --bin td-shim-checker  --no-default-features --features=loader -- target/release/final.bin
 
+      - name: Build debug image without payload
+        run: |
+          cargo image
+
       - name: Build Release Elf format payload
         run: |
           cargo image --example-payload --release

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -121,7 +121,9 @@ impl BuildArgs {
         .args(["--profile", self.profile()])
         .run()?;
 
-        Self::strip("td-shim")?;
+        if self.release {
+            Self::strip("td-shim")?;
+        }
 
         Ok((
             SHIM_OUTPUT
@@ -141,7 +143,9 @@ impl BuildArgs {
         .args(["--profile", self.profile()])
         .run()?;
 
-        Self::strip("example")?;
+        if self.release {
+            Self::strip("example")?;
+        }
 
         Ok(SHIM_OUTPUT.join(&self.profile_path()).join("example"))
     }


### PR DESCRIPTION
Fix: https://github.com/confidential-containers/td-shim/issues/553

Strip is not necessary for debug build. 