### PR TITLE
tdx-tdcall: use shared GPA for `TDG.VP.VMCALL<Service>`

### DIFF
--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -411,8 +411,8 @@ pub fn tdvmcall_service(
     interrupt: u64,
     wait_time: u64,
 ) -> Result<(), TdVmcallError> {
-    let command = command.as_ptr() as u64;
-    let response = response.as_mut_ptr() as u64;
+    let command = command.as_ptr() as u64 | *SHARED_MASK;
+    let response = response.as_mut_ptr() as u64 | *SHARED_MASK;
 
     // Ensure the address is aligned to 4K bytes
     if (command & 0xfff) != 0 || (response & 0xfff) != 0 {


### PR DESCRIPTION
Address of command and response buffer should be shared GPA according to GHCI.

Fix: https://github.com/confidential-containers/td-shim/issues/556