### PR TITLE
Add function to perform `sti;halt` operation

### DIFF
--- a/td-payload/src/arch/x86_64/apic.rs
+++ b/td-payload/src/arch/x86_64/apic.rs
@@ -27,6 +27,9 @@ pub fn enable_apic_interrupt() {
 }
 
 pub fn enable_and_hlt() {
+    #[cfg(feature = "tdx")]
+    tdx_tdcall::tdx::tdvmcall_sti_halt();
+    #[cfg(not(feature = "tdx"))]
     x86_64::instructions::interrupts::enable_and_hlt()
 }
 

--- a/tdx-tdcall/src/asm/mod.rs
+++ b/tdx-tdcall/src/asm/mod.rs
@@ -18,5 +18,5 @@ global_asm!(include_str!("tdvmcall.asm"));
 
 extern "win64" {
     pub(crate) fn asm_td_call(args: *mut c_void) -> u64;
-    pub(crate) fn asm_td_vmcall(args: *mut c_void) -> u64;
+    pub(crate) fn asm_td_vmcall(args: *mut c_void, do_sti: u64) -> u64;
 }

--- a/tdx-tdcall/src/asm/tdvmcall.asm
+++ b/tdx-tdcall/src/asm/tdvmcall.asm
@@ -23,6 +23,7 @@
 
 # asm_td_vmcall -> u64 (
 #   args: *mut TdVmcallArgs,
+#   do_sti: u64,
 # )
 .global asm_td_vmcall
 asm_td_vmcall:
@@ -40,6 +41,8 @@ asm_td_vmcall:
 
         # Use RDI to save RCX value
         mov rdi, rcx
+        # Use RSI to save RDX value
+        mov rsi, rdx
 
         # Test if input pointer is valid
         test rdi, rdi
@@ -59,6 +62,12 @@ asm_td_vmcall:
         # Set exposed register mask
         mov ecx, TDVMCALL_EXPOSE_REGS_MASK
 
+        # Test if the `sti` is needed
+        test rsi, rsi
+        jz .Ldo_tdcall
+
+        sti
+.Ldo_tdcall:
         # TDCALL
        .byte 0x66,0x0f,0x01,0xcc
 

--- a/tdx-tdcall/src/lib.rs
+++ b/tdx-tdcall/src/lib.rs
@@ -81,7 +81,14 @@ const TDVMCALL_STATUS_SUCCESS: u64 = 0;
 // * R8-R9, R12-R15, RBX, RBP, RDI, RSI - Correspond to each TDG.VP.VMCALL sub-function.
 //
 pub fn td_vmcall(args: &mut TdVmcallArgs) -> u64 {
-    unsafe { asm::asm_td_vmcall(args as *mut TdVmcallArgs as *mut c_void) }
+    unsafe { asm::asm_td_vmcall(args as *mut TdVmcallArgs as *mut c_void, 0) }
+}
+
+// An extended public wrapper for use of asm_td_vmcall.
+//
+// `do_sti` is a flag used to determine whether to execute `sti` instruction before `tdcall`
+pub fn td_vmcall_ex(args: &mut TdVmcallArgs, do_sti: bool) -> u64 {
+    unsafe { asm::asm_td_vmcall(args as *mut TdVmcallArgs as *mut c_void, do_sti as u64) }
 }
 
 // Wrapper for use of asm_td_call, this function takes a mutable reference of a

--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -90,6 +90,21 @@ pub fn tdvmcall_halt() {
     let _ = td_vmcall(&mut args);
 }
 
+/// Executing `hlt` instruction will cause a #VE to emulate the instruction. Safe halt operation
+/// `sti;hlt` which typically used for idle is not working in this case since `hlt` instruction
+/// must be the instruction next to `sti`. To use safe halt, `sti` must be executed just before
+/// `tdcall` instruction.
+pub fn tdvmcall_sti_halt() {
+    let mut args = TdVmcallArgs {
+        r11: TDVMCALL_HALT,
+        ..Default::default()
+    };
+
+    // Set the `do_sti` flag to execute `sti` before `tdcall` instruction
+    // Result is always `TDG.VP.VMCALL_SUCCESS`
+    let _ = td_vmcall_ex(&mut args, true);
+}
+
 /// Request the VMM perform single byte IO read operation
 ///
 /// Details can be found in TDX GHCI spec section 'TDG.VP.VMCALL<Instruction.IO>'


### PR DESCRIPTION
Fix: https://github.com/confidential-containers/td-shim/issues/561
Executing `hlt` instruction will cause a #VE to emulate the instruction. Safe halt operation `sti;hlt` which typically used for idle is not working in this case since `hlt` instruction must be the instruction next to `sti`. To use safe halt, `sti` must be executed just before `tdcall` instruction.