### PR TITLE
tdx-tdcall: use interrupt blocked flag for TDVMCALL HLT

### DIFF
--- a/tdx-tdcall/Cargo.toml
+++ b/tdx-tdcall/Cargo.toml
@@ -12,6 +12,7 @@ lazy_static = { version = "1.0", features = ["spin_no_std"] }
 log = "0.4.13"
 scroll = { version = "0.10", default-features = false, features = ["derive"] }
 spin = "0.9.2"
+x86_64 = "0.14.9"
 
 [features]
 default = []

--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -14,6 +14,7 @@
 use core::result::Result;
 use core::sync::atomic::{fence, Ordering};
 use lazy_static::lazy_static;
+use x86_64::registers::rflags::{self, RFlags};
 
 use crate::*;
 
@@ -78,8 +79,11 @@ lazy_static! {
 ///
 /// Details can be found in TDX GHCI spec section 'TDG.VP.VMCALL<Instruction.HLT>'
 pub fn tdvmcall_halt() {
+    let interrupt_blocked = !rflags::read().contains(RFlags::INTERRUPT_FLAG);
+
     let mut args = TdVmcallArgs {
         r11: TDVMCALL_HALT,
+        r12: interrupt_blocked as u64,
         ..Default::default()
     };
 


### PR DESCRIPTION
Fix: https://github.com/confidential-containers/td-shim/issues/558
According to GHCI, interrupt blocked flag should be cleared if `RFLAGS.IF=1` or the `tdcall` instruction immediately follows an `sti` instruction, otherwise this flag should be set
