### PR TITLE
td-shim-tools/tee-info-hash: add option of string format output

### DIFF
--- a/td-shim-tools/src/bin/td-shim-tee-info-hash/main.rs
+++ b/td-shim-tools/src/bin/td-shim-tee-info-hash/main.rs
@@ -145,5 +145,12 @@ fn main() -> io::Result<()> {
         &config.output.display()
     );
 
+    println!(
+        "{}",
+        hash.iter()
+            .map(|byte| format!("{:02x}", byte))
+            .collect::<String>()
+    );
+
     Ok(())
 }


### PR DESCRIPTION
https://github.com/confidential-containers/td-shim/issues/568

Add an option to output the hash of tee info to stdout in string format