### PR TITLE
use `[patch.crates-io]` for ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ lto = true
 [profile.release]
 panic = "abort"    # disable stack unwinding on panic
 lto = true         # Link-time optimization
+
+[patch.crates-io]
+ring = { path = "library/ring" }

--- a/cc-measurement/Cargo.toml
+++ b/cc-measurement/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 sha2 = { version = "0.10.6", default-features = false, features = ["force-soft"], optional = true }
-ring = { path = "../library/ring", default-features = false, features = ["alloc"], optional = true }
+ring = { version = "0.16.20", default-features = false, features = ["alloc"], optional = true }
 zerocopy = "0.6.0"
 
 [features]

--- a/td-shim-tools/Cargo.toml
+++ b/td-shim-tools/Cargo.toml
@@ -52,7 +52,7 @@ der = { version = "0.4.5", features = ["oid"], optional = true }
 env_logger = { version = "0.9.0", optional = true }
 log = { version = "0.4.5", optional = true }
 td-loader = { path = "../td-loader", optional = true }
-ring = { path = "../library/ring", optional = true }
+ring = { version = "0.16.20", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 hex = { version = "0.4", features = ["serde"], optional = true }

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -30,7 +30,7 @@ zerocopy = "0.6.0"
 td-loader = { path = "../td-loader", optional = true }
 linked_list_allocator = { version = "0.10", optional = true }
 log = { version = "0.4.13", features = ["release_max_level_off"], optional = true }
-ring = { path = "../library/ring", default-features = false, features = ["alloc"], optional = true }
+ring = { version = "0.16.20", default-features = false, features = ["alloc"], optional = true }
 spin = { version = "0.9.2", optional = true }
 td-exception =  { path = "../td-exception", features = ["tdx"], optional = true }
 td-logger =  { path = "../td-logger", optional = true }

--- a/tests/test-td-payload/Cargo.toml
+++ b/tests/test-td-payload/Cargo.toml
@@ -22,7 +22,7 @@ scroll = { version = "0.10.0", default-features = false, features = ["derive"]}
 serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 x86 = { version = "0.47.0" }
-ring = { path = "../../library/ring", default-features = false, features = ["alloc"] }
+ring = { version = "0.16.20", default-features = false, features = ["alloc"] }
 td-shim = { path = "../../td-shim" }
 td-payload = { path = "../../td-payload", features = ["tdx","cet-shstk","stack-guard"] }
 zerocopy = "0.6.0"


### PR DESCRIPTION
Remove the `path` of patched ring in Cargo.toml to avoid the conflict when other crates use `td-shim` or `cc-measurement` and `ring` at the same time.

Fix: https://github.com/confidential-containers/td-shim/issues/569