### PR TITLE
sh_script: fix build_final.sh

### DIFF
--- a/sh_script/build_final.sh
+++ b/sh_script/build_final.sh
@@ -77,5 +77,5 @@ case "${1:-}" in
     elf) final_elf ;;
     elf_test) final_elf_test ;;
     elf_sb_test) final_elf_sb_test ;;
-    *) final_boot_kernel && final_pe && final_elf && final_elf_test && final_elf_sb_test;; 
+    *) final_boot_kernel && final_elf && final_elf_test && final_elf_sb_test;; 
 esac


### PR DESCRIPTION
Now no option named `pe` is in build_final.sh. This will lead to error when cutting release.

Fixes #572