### PR TITLE
use `repr(C)` layout for `GuidExtension`

### DIFF
--- a/td-uefi-pi/src/pi/hob.rs
+++ b/td-uefi-pi/src/pi/hob.rs
@@ -351,6 +351,7 @@ impl Cpu {
 /// whose types are not included in this specification. Specifically, writers of executable content
 /// in the HOB producer phase can generate a GUID and name their own HOB entries using this
 /// module specific value.
+#[repr(C)]
 #[derive(Copy, Clone, Debug, Pread, Pwrite)]
 pub struct GuidExtension {
     pub header: Header,


### PR DESCRIPTION
It is important to use `repr(C)` layout for structures that are used for decoding/encoding from/into bytes.

Fix: https://github.com/confidential-containers/td-shim/issues/586