### PR TITLE
set optimizations only for `td-shim` and `td-payload` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,9 @@ members = [
     "xtask",
 ]
 
-# the profile used for `cargo build`
-[profile.dev]
+# the profile used for debug build of `td-shim` and `td-payload`
+[profile.dev-opt]
+inherits = "dev"
 panic = "abort" # disable stack unwinding on panic
 opt-level = "z"
 lto = true

--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ cargo xbuild -p td-payload --target x86_64-unknown-none --release --bin example 
 cargo run -p td-shim-tools --bin td-shim-ld -- target/x86_64-unknown-none/release/ResetVector.bin target/x86_64-unknown-none/release/td-shim -t executable -p target/x86_64-unknown-none/release/example -o target/release/final-elf.bin
 ```
 
+To build the debug TdShim, please use `dev-opt` profile to build `td-shim` binary. For example:
+
+```
+cargo xbuild -p td-shim --target x86_64-unknown-none --profile dev-opt --features=main,tdx
+cargo run -p td-shim-tools --bin td-shim-ld --features=linker -- target/x86_64-unknown-none/dev-opt/ResetVector.bin target/x86_64-unknown-none/dev-opt/td-shim -o target/release/final.bin
+```
+
 ## Run
 REF: https://github.com/tianocore/edk2-staging/tree/TDVF
 

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -227,7 +227,7 @@ impl BuildArgs {
         if self.release {
             "release"
         } else {
-            "dev"
+            "dev-opt"
         }
     }
 
@@ -235,7 +235,7 @@ impl BuildArgs {
         if self.release {
             "release"
         } else {
-            "debug"
+            "dev-opt"
         }
     }
 


### PR DESCRIPTION
Binary size is not critical for tools so we can only set optimizations for debug build of `td-shim` and `td-payload`.

By renaming the `profile.dev`, we can use the `dev-opt` profile for required packages and use the default `dev` profile for others.

Resolves https://github.com/confidential-containers/td-shim/issues/593