### PR TITLE
add `Dockerfile` for reproducible build

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ REF: https://github.com/tianocore/edk2-staging/tree/TDVF
 ./launch-rust-td.sh
 ```
 
+## Reproducible Build
+Reproducible build of td-shim binary requires same system user and
+source code path (see https://github.com/confidential-containers/td-shim/issues/604).
+
+The [Dockerfile](./Dockerfile) is provided to build the docker image with
+the `td-shim` compilation environment for reproducible build. You can use
+the [docker.sh](./sh_script/docker.sh) to build and run the docker container:
+
+```
+./sh_script/docker.sh -f devtools/dev_container
+```
+
 ## Code Contributions
 
 1.  install [pre-commit](https://pre-commit.com/#install)

--- a/devtools/dev_container/Dockerfile
+++ b/devtools/dev_container/Dockerfile
@@ -37,3 +37,5 @@ RUN set -eux; \
     git clone https://github.com/sslab-gatech/Rudra.git; \
     cd Rudra; \
     ./install-release.sh;
+
+RUN git clone https://github.com/confidential-containers/td-shim.git

--- a/sh_script/docker.sh
+++ b/sh_script/docker.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+FOLDER=""
+
+usage() {
+    cat << EOM
+Usage: $(basename "$0") [OPTION]...
+  -d <docker file>     Path of Dockerfile.
+EOM
+}
+
+error() {
+    echo -e "\e[1;31mERROR: $*\e[0;0m"
+    exit 1
+}
+
+process_args() {
+    while getopts ":f:h" option; do
+        case "$option" in
+            f) FOLDER=$OPTARG;;
+            h) usage
+               exit 0
+               ;;
+            *)
+               echo "Invalid option '-$OPTARG'"
+               usage
+               exit 1
+               ;;
+        esac
+    done
+
+    if [[ -z ${FOLDER} ]]; then
+        error "Please specify the folder of where the Dockerfile is located through -f."
+    fi
+
+    if [[ ! -f "${FOLDER}/Dockerfile" ]]; then
+        error "Dockerfile does not exist."
+    fi
+}
+
+process_args $@
+
+pushd ${FOLDER}
+
+# If the docker image does not exist, build the docker image
+set +e && docker image inspect tdshim.build.env:latest > /dev/null 2>&1 && set -e
+if [ $? != 0 ]; then
+    docker build -t tdshim.build.env \
+            --build-arg https_proxy=$https_proxy \
+            --build-arg http_proxy=$http_proxy \
+            .
+fi
+
+popd
+
+# Run the docker image
+docker run -it --rm tdshim.build.env


### PR DESCRIPTION
The reproducibility of td-shim is limited by the same system user and source code path, so we can use a Docker container to reproduce binaries.

Resolves: https://github.com/confidential-containers/td-shim/issues/604