### PR TITLE
td-shim: init event log memory with `0xff`

### DIFF
--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -127,6 +127,8 @@ pub extern "win64" fn _start(
     // Set up the TD event log buffer.
     // Safe because it's used to initialize the EventLog subsystem which ensures safety.
     let event_log_buf = mem.get_dynamic_mem_slice_mut(memslice::SliceType::EventLog);
+    // Initialize event log memory with 0xff which help OS to know the last entry.
+    event_log_buf.fill(0xff);
     let mut td_event_log = CcEventLogWriter::new(event_log_buf, Box::new(td::extend_rtmr))
         .expect("Failed to create and initialize the event log");
 


### PR DESCRIPTION
Align with `EDK2` implementation, to help OS to find the last event log entry.

Fix: https://github.com/confidential-containers/td-shim/issues/607