### PR TITLE
td-shim: Fix a typo in build script

### DIFF
--- a/td-shim/build.rs
+++ b/td-shim/build.rs
@@ -157,7 +157,7 @@ fn real_main() -> Result<()> {
 
     println!(
         "cargo:rerun-if-changed={}",
-        Path::new("ResetVector/ResetVector.asm").to_str().unwrap()
+        Path::new("ResetVector/ResetVector.nasm").to_str().unwrap()
     );
 
     let reset_vector_src_dir = get_cargo_manifest_dir().join("ResetVector");


### PR DESCRIPTION
The current script is checking if there is a change in ResetVector.asm file then re-run the cargo build script, but the filename is ResetVector.nasm instead.