### PR TITLE
.github: remove `Swatinem/rust-cache@v2`

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -55,9 +55,6 @@ jobs:
           toolchain: ${{ env.NIGHTLY_RUST_TOOLCHAIN }}
           override: true
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Preparation work
         run: make preparation
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,9 +49,6 @@ jobs:
           override: true
           components: rust-src, llvm-tools-preview
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Run cargo install cargo-xbuild
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -105,9 +105,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Preparation Work
         run: make preparation
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,9 +53,6 @@ jobs:
           override: true
           components: rust-src
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Run cargo install cargo-xbuild
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,9 +35,6 @@ jobs:
           override: true
           components: rust-src
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Run cargo install cargo-xbuild
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Remove the using of caches to avoid the `can't find crate` errors in CI.