### PR TITLE
upgrade `ring` to `0.17.5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,16 +978,14 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.5"
 dependencies = [
  "cc",
  "getrandom",
  "libc",
- "once_cell",
- "spin 0.5.2",
+ "spin 0.9.8",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1586,9 +1584,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"
@@ -1686,16 +1684,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
-
-[[package]]
-name = "web-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "which"

--- a/cc-measurement/Cargo.toml
+++ b/cc-measurement/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 sha2 = { version = "0.10.6", default-features = false, features = ["force-soft"], optional = true }
-ring = { version = "0.16.20", default-features = false, features = ["alloc"], optional = true }
+ring = { version = "0.17.5", default-features = false, features = ["alloc"], optional = true }
 zerocopy = "0.6.0"
 
 [features]

--- a/library/patches/ring.diff
+++ b/library/patches/ring.diff
@@ -1,90 +1,109 @@
 diff --git a/Cargo.toml b/Cargo.toml
-index c9daac82e..f9e578e39 100644
+index 3378dc84b..f65fd70bd 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -302,6 +302,7 @@ name = "ring"
+@@ -171,7 +171,7 @@ all-features = true
+ name = "ring"
  
  [dependencies]
- untrusted = { version = "0.7.1" }
-+getrandom = { version = "0.2.8", features = ["rdrand"] }
+-getrandom = { version = "0.2.10" }
++getrandom = { version = "0.2.10", features = ["rdrand"] }
+ untrusted = { version = "0.9" }
  
- [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux"))))'.dependencies]
- spin = { version = "0.5.2", default-features = false }
-@@ -327,7 +328,7 @@ libc = { version = "0.2.80", default-features = false }
- 
- # Keep this in sync with `[dependencies]` in pregenerate_asm/Cargo.toml.
- [build-dependencies]
--cc = { version = "1.0.62", default-features = false }
-+cc = { version = "1.0.63", default-features = false }
- 
- [features]
- # These features are documented in the top-level module's documentation.
+ [target.'cfg(any(target_arch = "x86",target_arch = "x86_64", all(any(target_arch = "aarch64", target_arch = "arm"), any(target_os = "android", target_os = "fuchsia", target_os = "linux", target_os = "windows"))))'.dependencies]
 diff --git a/build.rs b/build.rs
-index a5a8e1995..c67e4bfb0 100644
+index f7b94108b..3bdc8cd29 100644
 --- a/build.rs
 +++ b/build.rs
-@@ -580,7 +580,7 @@ fn cc(
-     //
+@@ -121,7 +121,9 @@ fn cpp_flags(compiler: &cc::Tool) -> &'static [&'static str] {
+             "-Wenum-compare",
+             "-Wfloat-equal",
+             "-Wformat=2",
+-            "-Winline",
++            // Clear the `-Winline` because warnings will be treated as errors
++            // when `ring` is used as git submodules.
++            // "-Winline",
+             "-Winvalid-pch",
+             "-Wmissing-field-initializers",
+             "-Wmissing-include-dirs",
+@@ -260,6 +262,8 @@ const LINUX_ABI: &[&str] = &[
+     "linux",
+     "redox",
+     "solaris",
++    // For `x86_64-unknown-none` target
++    "none",
+ ];
+ 
+ /// Operating systems that have the same ABI as macOS on every architecture
+@@ -604,16 +608,29 @@ fn configure_cc(c: &mut cc::Build, target: &Target, include_dir: &Path) {
      // poly1305_vec.c requires <emmintrin.h> which requires <stdlib.h>.
-     if (target.arch == "wasm32" && target.os == "unknown")
--        || (target.os == "linux" && is_musl && target.arch != "x86_64")
-+        || (target.os == "linux" && is_musl && target.arch != "x86_64" || target.os == "none")
+     if (target.arch == "wasm32")
+         || (target.os == "linux" && target.is_musl && target.arch != "x86_64")
++        || (target.os == "none")
      {
          if let Ok(compiler) = c.try_get_compiler() {
              // TODO: Expand this to non-clang compilers in 0.17.0 if practical.
-@@ -589,6 +589,9 @@ fn cc(
-                 let _ = c.define("GFp_NOSTDLIBINC", "1");
+             if compiler.is_like_clang() {
+                 let _ = c.flag("-nostdlibinc");
++                // Required on windows for cross compilation to `x86_64-unknown-none`
++                let _ = c.flag("-ffreestanding");
+                 let _ = c.define("RING_CORE_NOSTDLIBINC", "1");
              }
          }
-+        if target.os == "none" {
-+            let _ = c.flag("-ffreestanding");
-+        }
      }
  
-     if warnings_are_errors {
-@@ -626,7 +629,7 @@ fn nasm(file: &Path, arch: &str, out_file: &Path) -> Command {
-         "x86" => ("win32"),
-         _ => panic!("unsupported arch: {}", arch),
-     };
--    let mut c = Command::new("./target/tools/nasm");
++    // `clang` does not define `__ELF__` for `x86_64-unknown-none` target.
++    // Manually define it.
++    if target.os == "none" {
++        if let Ok(compiler) = c.try_get_compiler() {
++            if compiler.is_like_clang() {
++                let _ = c.define("__ELF__", None);
++            }
++        }
++    }
++
+     if target.force_warnings_into_errors {
+         c.warnings_into_errors(true);
+     }
+@@ -645,7 +662,7 @@ fn nasm(file: &Path, arch: &str, include_dir: &Path, out_file: &Path) -> Command
+         std::path::MAIN_SEPARATOR,
+     )));
+ 
+-    let mut c = Command::new("./target/tools/windows/nasm/nasm");
 +    let mut c = Command::new("nasm");
      let _ = c
          .arg("-o")
          .arg(out_file.to_str().expect("Invalid path"))
 diff --git a/src/rand.rs b/src/rand.rs
-index 9d1864fa1..6ac5cc727 100644
+index 78f4bdc3c..2d1028b84 100644
 --- a/src/rand.rs
 +++ b/src/rand.rs
-@@ -195,6 +195,9 @@ use self::darwin::fill as fill_impl;
- #[cfg(any(target_os = "fuchsia"))]
- use self::fuchsia::fill as fill_impl;
+@@ -148,6 +148,7 @@ impl crate::sealed::Sealed for SystemRandom {}
+             all(target_os = "unknown", feature = "wasm32_unknown_unknown_js")
+         )
+     ),
++    all(target_arch = "x86_64", target_os = "none"),
+ ))]
+ impl sealed::SecureRandom for SystemRandom {
+     #[inline(always)]
+diff --git a/third_party/fiat/curve25519_64_adx.h b/third_party/fiat/curve25519_64_adx.h
+index 9dcbb69fa..0906fda81 100644
+--- a/third_party/fiat/curve25519_64_adx.h
++++ b/third_party/fiat/curve25519_64_adx.h
+@@ -1,7 +1,6 @@
+ #include <stdbool.h>
+ #include <stdint.h>
+ #include <immintrin.h>
+-#include <string.h>
  
-+#[cfg(any(target_os = "none"))]
-+use self::no_std::fill as fill_impl;
-+
- #[cfg(any(target_os = "android", target_os = "linux"))]
- mod sysrand_chunk {
-     use crate::{c, error};
-@@ -431,3 +434,22 @@ mod fuchsia {
-         fn zx_cprng_draw(buffer: *mut u8, length: usize);
-     }
- }
-+
-+#[cfg(any(target_os = "none"))]
-+mod no_std {
-+    use crate::error;
-+
-+    pub fn fill(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-+        fill_impl(dest)
-+    }
-+
-+    #[cfg(not(any(target_arch = "x86_64")))]
-+    fn fill_impl(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-+        Err(error::Unspecified)
-+    }
-+
-+    #[cfg(any(target_arch = "x86_64"))]
-+    fn fill_impl(dest: &mut [u8]) -> Result<(), error::Unspecified> {
-+        getrandom::getrandom(dest).map_err(|_| error::Unspecified)
-+    }
-+}
+ typedef uint64_t fe4[4];
+ typedef uint8_t fiat_uint1;
+@@ -469,7 +468,7 @@ __attribute__((target("adx,bmi2")))
+ void x25519_scalar_mult_adx(uint8_t out[32], const uint8_t scalar[32],
+                             const uint8_t point[32]) {
+   uint8_t e[32];
+-  memcpy(e, scalar, 32);
++  OPENSSL_memcpy(e, scalar, 32);
+   e[0] &= 248;
+   e[31] &= 127;
+   e[31] |= 64;

--- a/sh_script/preparation.sh
+++ b/sh_script/preparation.sh
@@ -3,7 +3,7 @@
 preparation() {
     # apply the patch set for ring
     pushd library/ring
-    git reset --hard 9cc0d45f4d8521f467bb3a621e74b1535e118188
+    git reset --hard c3fda8b4dd57d658923c397c6cfaa33591f6f256
     git clean -f -d
     patch -p 1 -i ../patches/ring.diff
     popd

--- a/td-shim-tools/Cargo.toml
+++ b/td-shim-tools/Cargo.toml
@@ -52,7 +52,7 @@ der = { version = "0.4.5", features = ["oid"], optional = true }
 env_logger = { version = "0.9.0", optional = true }
 log = { version = "0.4.5", optional = true }
 td-loader = { path = "../td-loader", optional = true }
-ring = { version = "0.16.20", optional = true }
+ring = { version = "0.17.5", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 hex = { version = "0.4", features = ["serde"], optional = true }

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -30,7 +30,7 @@ zerocopy = "0.6.0"
 td-loader = { path = "../td-loader", optional = true }
 linked_list_allocator = { version = "0.10", optional = true }
 log = { version = "0.4.13", features = ["release_max_level_off"], optional = true }
-ring = { version = "0.16.20", default-features = false, features = ["alloc"], optional = true }
+ring = { version = "0.17.5", default-features = false, features = ["alloc"], optional = true }
 spin = { version = "0.9.2", optional = true }
 td-exception =  { path = "../td-exception", features = ["tdx"], optional = true }
 td-logger =  { path = "../td-logger", optional = true }

--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -428,3 +428,9 @@ fn secure_boot_verify_payload<'a>(
     return PayloadVerifier::get_payload_image(payload)
         .expect("Unable to get payload image from signed binary");
 }
+
+#[cfg(feature = "secure-boot")]
+#[no_mangle]
+extern "C" fn __assert_fail() {
+    panic!("__assert_fail");
+}

--- a/tests/test-td-payload/Cargo.toml
+++ b/tests/test-td-payload/Cargo.toml
@@ -22,7 +22,7 @@ scroll = { version = "0.10.0", default-features = false, features = ["derive"]}
 serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 x86 = { version = "0.47.0" }
-ring = { version = "0.16.20", default-features = false, features = ["alloc"] }
+ring = { version = "0.17.5", default-features = false, features = ["alloc"] }
 td-shim = { path = "../../td-shim" }
 td-payload = { path = "../../td-payload", features = ["tdx","cet-shstk","stack-guard"] }
 zerocopy = "0.6.0"


### PR DESCRIPTION
 - Upgrade `ring` git submodule.
 - Update patch and patch script `preparation.h`.
 - Update the use of `PublicKey` to follow the latest API.
 - Update `Cargo.toml`s and `Cargo.lock`.
 - Add `__assert_fail__` required by `ring` in `main.rs` .

Closes https://github.com/confidential-containers/td-shim/issues/613