### PR TITLE
misc: Fix reported clippy warnings

### DIFF
--- a/cc-measurement/src/log.rs
+++ b/cc-measurement/src/log.rs
@@ -127,7 +127,7 @@ impl<'a> CcEventLogWriter<'a> {
 
         // Write the event header into event log memory and update the 'size' and 'last'
         let event_offset = self
-            .log_cc_event_header(mr_index, event_type, &sha384, event_data_size as u32)
+            .log_cc_event_header(mr_index, event_type, sha384, event_data_size as u32)
             .ok_or(CcEventLogError::OutOfResource)?;
 
         let mut data_offset = size_of::<CcEventHeader>();
@@ -242,10 +242,10 @@ impl<'a> Iterator for CcEvents<'a> {
         if end_of_event < self.bytes.len() {
             let event_data = &self.bytes[size_of::<CcEventHeader>()..end_of_event];
             self.bytes = &self.bytes[end_of_event..];
-            return Some((event_header, event_data));
+            Some((event_header, event_data))
         } else {
-            return None;
-        };
+            None
+        }
     }
 }
 
@@ -277,7 +277,7 @@ impl<'a> CcEventLogReader<'a> {
             specific_id_event,
         };
 
-        return Some(cc_event_log);
+        Some(cc_event_log)
     }
 
     pub fn query(&self, key: &[u8]) -> Option<CcEventHeader> {

--- a/td-exception/src/idt.rs
+++ b/td-exception/src/idt.rs
@@ -102,12 +102,12 @@ impl Idt {
         current_idt[20].set_func(interrupt::default_exception as usize);
         current_idt[21].set_func(interrupt::control_flow as usize);
         // reset exception reserved
-        for i in 22..32 {
-            current_idt[i].set_func(interrupt::default_exception as usize);
+        for idt in current_idt.iter_mut().take(32).skip(22) {
+            idt.set_func(interrupt::default_exception as usize);
         }
         // Setup reset potential interrupt handler.
-        for i in 32..IDT_ENTRY_COUNT {
-            current_idt[i].set_func(interrupt::default_interrupt as usize);
+        for idt in current_idt.iter_mut().take(IDT_ENTRY_COUNT).skip(32) {
+            idt.set_func(interrupt::default_interrupt as usize);
         }
     }
 
@@ -179,7 +179,7 @@ impl IdtEntry {
     // A function to set the offset more easily
     pub fn set_func(&mut self, func: usize) {
         self.set_flags(IdtFlags::PRESENT | IdtFlags::INTERRUPT);
-        self.set_offset(CS::get_reg().0, func as usize); // GDT_KERNEL_CODE 1u16
+        self.set_offset(CS::get_reg().0, func); // GDT_KERNEL_CODE 1u16
     }
 
     pub fn set_ist(&mut self, index: u8) {

--- a/td-layout/src/lib.rs
+++ b/td-layout/src/lib.rs
@@ -93,7 +93,7 @@ impl RuntimeMemoryLayout {
         self.regions
             .iter()
             .find(|item| item.name == name.as_str())
-            .map(|region| *region)
+            .copied()
     }
 
     pub unsafe fn get_mem_slice(&self, name: SliceType) -> Option<&'static [u8]> {

--- a/td-layout/src/runtime/exec.rs
+++ b/td-layout/src/runtime/exec.rs
@@ -40,7 +40,7 @@ pub const PAYLOAD_PAGE_TABLE_SIZE: usize = 0x20000; // 128 KB
 pub const RELOCATED_MAILBOX_SIZE: usize = 0x2000; // 8 KB
 pub const EVENT_LOG_SIZE: usize = 0x100000; // 1 MB
 
-pub const MEMORY_LAYOUT_CONFIG: &[(&'static str, usize, &'static str)] = &[
+pub const MEMORY_LAYOUT_CONFIG: &[(&str, usize, &str)] = &[
     // (name of memory region, region size, region type)
     ("Bootloader", 0x800000, "Memory"),
     ("TdHob", 0x20000, "Memory"),

--- a/td-layout/src/runtime/linux.rs
+++ b/td-layout/src/runtime/linux.rs
@@ -49,7 +49,7 @@ pub const PAYLOAD_PAGE_TABLE_SIZE: usize = 0x20000; // 128 KB
 pub const RELOCATED_MAILBOX_SIZE: usize = 0x2000; // 8 KB
 pub const EVENT_LOG_SIZE: usize = 0x100000; // 1 MB
 
-pub const MEMORY_LAYOUT_CONFIG: &[(&'static str, usize, &'static str)] = &[
+pub const MEMORY_LAYOUT_CONFIG: &[(&str, usize, &str)] = &[
     // (name of memory region, region size, region type)
     ("Bootloader", 0x800000, "Memory"),
     ("TdHob", 0x20000, "Memory"),

--- a/td-loader/src/elf.rs
+++ b/td-loader/src/elf.rs
@@ -81,9 +81,9 @@ pub fn relocate_elf_with_per_program_header(
     }
 
     Some((
-        elf.header.e_entry.checked_add(new_image_base as u64)? as u64,
-        bottom as u64,
-        top.checked_sub(bottom)? as u64,
+        elf.header.e_entry.checked_add(new_image_base as u64)?,
+        bottom,
+        top.checked_sub(bottom)?,
     ))
 }
 
@@ -108,9 +108,9 @@ pub fn parse_finit_array_section(loaded_image: &[u8]) -> Option<Range<usize>> {
 /// flag true align to low address else high address
 fn align_value(value: u64, align: u64, flag: bool) -> u64 {
     if flag {
-        value & ((!(align - 1)) as u64)
+        value & (!(align - 1))
     } else {
-        value - (value & (align - 1)) as u64 + align
+        value - (value & (align - 1)) + align
     }
 }
 

--- a/td-logger/src/lib.rs
+++ b/td-logger/src/lib.rs
@@ -58,7 +58,7 @@ const SERIAL_IO_PORT: u16 = 0x3F8;
 
 #[cfg(feature = "tdx")]
 fn dbg_port_write(byte: u8) {
-    let _ = tdx_tdcall::tdx::tdvmcall_io_write_8(SERIAL_IO_PORT, byte);
+    tdx_tdcall::tdx::tdvmcall_io_write_8(SERIAL_IO_PORT, byte);
 }
 
 #[cfg(all(not(feature = "tdx"), feature = "serial-port"))]

--- a/td-paging/src/page_table.rs
+++ b/td-paging/src/page_table.rs
@@ -87,7 +87,7 @@ pub fn create_mapping_with_flags(
         || va.as_u64() & (ALIGN_4K - 1) != 0
         || sz & (ALIGN_4K - 1) != 0
         || ps.count_ones() != 1
-        || ps < ALIGN_4K as u64
+        || ps < ALIGN_4K
     {
         return Err(Error::InvalidArguments);
     }

--- a/td-payload/src/arch/x86_64/shared.rs
+++ b/td-payload/src/arch/x86_64/shared.rs
@@ -23,7 +23,7 @@ pub fn encrypt(addr: u64, length: usize) {
     if tdx_tdcall::tdx::tdvmcall_mapgpa(false, addr, length).is_err() {
         panic!("Fail to map GPA to private memory with TDVMCALL");
     }
-    accept_memory(addr, length as usize);
+    accept_memory(addr, length);
 }
 
 fn accept_memory(addr: u64, length: usize) {

--- a/td-payload/src/mm/mod.rs
+++ b/td-payload/src/mm/mod.rs
@@ -73,7 +73,7 @@ pub fn get_usable(size: usize) -> Option<u64> {
 
         if entry.r#type == E820Type::Memory as u32 && entry.size >= size as u64 {
             entry.size -= size as u64;
-            return Some(entry.addr + entry.size as u64);
+            return Some(entry.addr + entry.size);
         }
     }
 

--- a/td-shim/src/acpi.rs
+++ b/td-shim/src/acpi.rs
@@ -116,7 +116,7 @@ impl Xsdt {
             let table_num =
                 (self.header.length as usize - size_of::<GenericSdtHeader>()) / size_of::<u64>();
             if table_num < ACPI_TABLES_MAX_NUM {
-                self.tables[table_num] = addr as u64;
+                self.tables[table_num] = addr;
                 self.header.length += size_of::<u64>() as u32;
                 Ok(())
             } else {

--- a/td-shim/src/bin/td-shim/memory.rs
+++ b/td-shim/src/bin/td-shim/memory.rs
@@ -239,7 +239,7 @@ impl<'a> Memory<'a> {
         false
     }
 
-    #[cfg(all(feature = "tdx"))]
+    #[cfg(feature = "tdx")]
     /// Build a 2M granularity bitmap for kernel to track the unaccepted memory
     pub fn build_unaccepted_memory_bitmap(&self) -> u64 {
         #[cfg(not(feature = "lazy-accept"))]

--- a/td-shim/src/metadata.rs
+++ b/td-shim/src/metadata.rs
@@ -171,7 +171,7 @@ impl TdxMetadataGuid {
     /// * `buffer` - A buffer contains TdxMetadata guid.
     pub fn from_bytes(buffer: &[u8; 16]) -> Option<TdxMetadataGuid> {
         let guid = Guid::from_bytes(buffer);
-        let metadata_guid = TdxMetadataGuid { guid: guid };
+        let metadata_guid = TdxMetadataGuid { guid };
         if metadata_guid.is_valid() {
             Some(metadata_guid)
         } else {
@@ -428,10 +428,10 @@ pub fn validate_sections(sections: &[TdxMetadataSection]) -> Result<(), TdxMetad
     }
 
     //TdInfo. If present, it shall be included in BFV section.
-    if td_info_cnt != 0 {
-        if td_info_start < bfv_start || td_info_start >= bfv_end || td_info_end > bfv_end {
-            return Err(TdxMetadataError::InvalidSection);
-        }
+    if td_info_cnt != 0
+        && (td_info_start < bfv_start || td_info_start >= bfv_end || td_info_end > bfv_end)
+    {
+        return Err(TdxMetadataError::InvalidSection);
     }
 
     Ok(())

--- a/td-uefi-pi/src/pi/fv.rs
+++ b/td-uefi-pi/src/pi/fv.rs
@@ -268,8 +268,8 @@ impl FfsFileHeader {
     // Validate the checksum of the FfsFileHeader
     pub fn validate_checksum(&self) -> bool {
         let sum = sum8(self.as_bytes());
-        sum ^ ((EFI_FILE_HEADER_CONSTRUCTION | EFI_FILE_HEADER_VALID | EFI_FILE_DATA_VALID) as u8
-            + FFS_FIXED_CHECKSUM as u8)
+        sum ^ ((EFI_FILE_HEADER_CONSTRUCTION | EFI_FILE_HEADER_VALID | EFI_FILE_DATA_VALID)
+            + FFS_FIXED_CHECKSUM)
             == 0
     }
 }

--- a/td-uefi-pi/src/pi/hob.rs
+++ b/td-uefi-pi/src/pi/hob.rs
@@ -150,7 +150,7 @@ impl MemoryAllocation {
     pub fn dump(&self) {
         log::info!(
             "MemoryAllocation type: 0x{:08x} base: 0x{:016x} length: 0x{:016x}\n",
-            self.alloc_descriptor.memory_type as u32,
+            self.alloc_descriptor.memory_type,
             self.alloc_descriptor.memory_base_address,
             self.alloc_descriptor.memory_length
         );

--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -402,7 +402,7 @@ pub fn tdvmcall_cpuid(eax: u32, ecx: u32) -> CpuIdInfo {
 pub fn tdvmcall_setup_event_notify(vector: u64) -> Result<(), TdVmcallError> {
     let mut args = TdVmcallArgs {
         r11: TDVMCALL_SETUPEVENTNOTIFY,
-        r12: vector as u64,
+        r12: vector,
         ..Default::default()
     };
 


### PR DESCRIPTION
Various components are throwing some trivial clippy warnings which are against the idiomatic rust pattterns.