### PR TITLE
misc: Upgrade to latest version of zerocopy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.4"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20707b61725734c595e840fb3704378a0cd2b9c74cc9e6e20724838fc6a1e2f9"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -1769,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.4"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56097d5b91d711293a42be9289403896b68654625021732067eac7a4ca388a1f"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cc-measurement/Cargo.toml
+++ b/cc-measurement/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 sha2 = { version = "0.10.6", default-features = false, features = ["force-soft"], optional = true }
 ring = { version = "0.17.6", default-features = false, features = ["alloc"], optional = true }
-zerocopy = "0.6.0"
+zerocopy = { version = "0.7.31", features = ["derive"] }
 
 [features]
 default = ["sha2"]

--- a/cc-measurement/src/lib.rs
+++ b/cc-measurement/src/lib.rs
@@ -11,7 +11,7 @@ extern crate alloc;
 
 use alloc::{vec, vec::Vec};
 use core::mem::size_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 pub const SHA384_DIGEST_SIZE: usize = 48;
 pub const TPML_ALG_SHA384: u16 = 0xc;
@@ -35,7 +35,7 @@ const VENDOR_INFO: &[u8; VENDOR_INFO_SIZE] = b"td-shim";
 /// Defined in TCG PC Client Platform Firmware Profile Specification:
 /// 'Table 20 TCG_EfiSpecIdEvent'
 #[repr(C, packed)]
-#[derive(AsBytes, FromBytes)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
 pub struct TcgEfiSpecIdevent {
     pub signature: [u8; 16],
     pub platform_class: u32,
@@ -81,7 +81,7 @@ impl Default for TcgEfiSpecIdevent {
 }
 
 #[repr(C, packed)]
-#[derive(AsBytes, FromBytes)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
 pub struct TcgEfiSpecIdEventAlgorithmSize {
     algorithm_id: u16,
     digest_size: u16,
@@ -121,7 +121,7 @@ impl UefiPlatformFirmwareBlob2 {
 }
 
 #[repr(C, packed)]
-#[derive(Default, FromBytes, AsBytes)]
+#[derive(Default, FromBytes, AsBytes, FromZeroes)]
 pub struct CcEventHeader {
     pub mr_index: u32,
     pub event_type: u32,
@@ -149,7 +149,7 @@ impl core::fmt::Display for CcEventHeader {
 }
 
 #[repr(C, packed)]
-#[derive(Default, FromBytes, AsBytes)]
+#[derive(Default, FromBytes, AsBytes, FromZeroes)]
 pub struct TpmlDigestValues {
     pub count: u32,
     pub digests: [TpmtHa; PCR_DIGEST_NUM],
@@ -171,14 +171,14 @@ impl core::fmt::Display for TpmlDigestValues {
 }
 
 #[repr(C, packed)]
-#[derive(Default, FromBytes, AsBytes)]
+#[derive(Default, FromBytes, AsBytes, FromZeroes)]
 pub struct TpmtHa {
     pub hash_alg: u16,
     pub digest: TpmuHa,
 }
 
 #[repr(C, packed)]
-#[derive(FromBytes, AsBytes)]
+#[derive(FromBytes, AsBytes, FromZeroes)]
 pub struct TpmuHa {
     pub sha384: [u8; SHA384_DIGEST_SIZE],
 }
@@ -192,7 +192,7 @@ impl Default for TpmuHa {
 }
 
 #[repr(C, packed)]
-#[derive(Default, FromBytes, AsBytes)]
+#[derive(Default, FromBytes, AsBytes, FromZeroes)]
 pub struct TcgPcrEventHeader {
     pub mr_index: u32,
     pub event_type: u32,

--- a/td-payload/Cargo.toml
+++ b/td-payload/Cargo.toml
@@ -30,7 +30,7 @@ x86 = "0.47.0"
 x86_64 = "0.14"
 td-benchmark = { path = "../devtools/td-benchmark", optional = true }
 tdx-tdcall = { path = "../tdx-tdcall", optional = true }
-zerocopy = "0.6.0"
+zerocopy = { version = "0.7.31", features = ["derive"] }
 
 minicov = { version = "0.2", default-features = false, optional = true }
 

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -25,7 +25,7 @@ scroll = { version = "0.10", default-features = false, features = ["derive"] }
 td-layout = { path = "../td-layout" }
 td-uefi-pi =  { path = "../td-uefi-pi" }
 cc-measurement = { path = "../cc-measurement" }
-zerocopy = "0.6.0"
+zerocopy = { version = "0.7.31", features = ["derive"] }
 
 td-loader = { path = "../td-loader", optional = true }
 linked_list_allocator = { version = "0.10", optional = true }

--- a/td-shim/src/acpi.rs
+++ b/td-shim/src/acpi.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 use core::mem::size_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 pub const ACPI_TABLES_MAX_NUM: usize = 20;
 pub const ACPI_RSDP_REVISION: u8 = 2;
@@ -19,7 +19,7 @@ pub fn calculate_checksum(data: &[u8]) -> u8 {
 }
 
 #[repr(packed)]
-#[derive(Default, AsBytes, FromBytes)]
+#[derive(Default, AsBytes, FromBytes, FromZeroes)]
 pub struct Rsdp {
     pub signature: [u8; 8],
     pub checksum: u8,
@@ -61,7 +61,7 @@ impl Rsdp {
 }
 
 #[repr(C, packed)]
-#[derive(Default, AsBytes, FromBytes)]
+#[derive(Default, AsBytes, FromBytes, FromZeroes)]
 pub struct GenericSdtHeader {
     pub signature: [u8; 4],
     pub length: u32,
@@ -95,7 +95,7 @@ impl GenericSdtHeader {
 }
 
 #[repr(C, packed)]
-#[derive(Default, AsBytes, FromBytes)]
+#[derive(Default, AsBytes, FromBytes, FromZeroes)]
 pub struct Xsdt {
     pub header: GenericSdtHeader,
     pub tables: [u64; ACPI_TABLES_MAX_NUM],
@@ -134,7 +134,7 @@ impl Xsdt {
 }
 
 #[repr(C, packed)]
-#[derive(Default, AsBytes, FromBytes)]
+#[derive(Default, AsBytes, FromBytes, FromZeroes)]
 pub struct Ccel {
     pub header: GenericSdtHeader,
     pub cc_type: u8,

--- a/td-shim/src/bin/td-shim/linux/kernel_param.rs
+++ b/td-shim/src/bin/td-shim/linux/kernel_param.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use core::mem::size_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 use td_shim::e820::E820Entry;
 
@@ -18,7 +18,7 @@ pub const HDR_TYPE_LOADER: u8 = 0xff;
 pub const HDR_LOAD_HIGH: u8 = 0x01;
 pub const HDR_MIN_VERSION: u16 = 0x0200;
 
-#[derive(Clone, Copy, Default, Debug, AsBytes, FromBytes)]
+#[derive(Clone, Copy, Default, Debug, AsBytes, FromBytes, FromZeroes)]
 #[repr(C, packed)]
 pub struct SetupHeader {
     pub setup_sects: u8,

--- a/td-shim/src/bin/td-shim/mp.rs
+++ b/td-shim/src/bin/td-shim/mp.rs
@@ -4,7 +4,7 @@
 
 use core::convert::TryInto;
 use core::mem::size_of;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 use td_shim::acpi::{self, GenericSdtHeader};
 
@@ -49,7 +49,7 @@ impl Madt {
 }
 
 #[repr(packed)]
-#[derive(Default, AsBytes, FromBytes)]
+#[derive(Default, AsBytes, FromBytes, FromZeroes)]
 struct LocalApic {
     pub r#type: u8,
     pub length: u8,
@@ -59,7 +59,7 @@ struct LocalApic {
 }
 
 #[repr(packed)]
-#[derive(Default, AsBytes, FromBytes)]
+#[derive(Default, AsBytes, FromBytes, FromZeroes)]
 struct MadtMpwkStruct {
     r#type: u8,
     length: u8,

--- a/td-shim/src/e820.rs
+++ b/td-shim/src/e820.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u32)]
@@ -51,7 +51,7 @@ impl From<u32> for E820Type {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, FromBytes, AsBytes, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, FromBytes, AsBytes, FromZeroes, PartialEq)]
 #[repr(C, packed)]
 pub struct E820Entry {
     pub addr: u64,

--- a/tests/test-td-payload/Cargo.toml
+++ b/tests/test-td-payload/Cargo.toml
@@ -25,7 +25,7 @@ x86 = { version = "0.47.0" }
 ring = { version = "0.17.6", default-features = false, features = ["alloc"] }
 td-shim = { path = "../../td-shim" }
 td-payload = { path = "../../td-payload", features = ["tdx","cet-shstk","stack-guard"] }
-zerocopy = "0.6.0"
+zerocopy = { version = "0.7.31", features = ["derive"] }
 
 minicov = { version = "0.2", default-features = false, optional = true }
 


### PR DESCRIPTION
cargo-deny has reported security vulnerability against older version of zerocopy crate. Thus, we should upgrade to the latest version.

Advisory: https://rustsec.org/advisories/RUSTSEC-2023-0074