### PR TITLE
Split file operation from loader.rs and change parse() API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
       
       - name: Meta data check
         run: |
-          cargo run -p td-shim-tools --bin td-shim-checker  --no-default-features --features=loader -- target/release/final.bin
+          cargo run -p td-shim-tools --bin td-shim-checker  --no-default-features --features=loader,read_file -- target/release/final.bin
 
       - name: Build debug image without payload
         run: |

--- a/td-shim-tools/Cargo.toml
+++ b/td-shim-tools/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["signer"]
 
 [[bin]]
 name = "td-shim-checker"
-required-features = ["loader"]
+required-features = ["loader", "read_file"]
 
 [[bin]]
 name = "td-shim-strip-info"
@@ -61,11 +61,12 @@ byteorder = { version = "1.4.3", optional = true }
 parse_int = { version = "0.6.0", optional = true }
 
 [features]
-default = ["enroller", "linker", "signer", "loader", "tee", "calculator"]
+default = ["enroller", "linker", "signer", "loader", "tee", "calculator", "read_file"]
 enroller = ["clap", "der", "env_logger", "log", "ring", "td-shim/secure-boot"]
 linker = ["clap", "env_logger", "log", "parse_int", "serde_json", "serde", "td-loader"]
 signer = ["clap", "der", "env_logger", "log", "ring", "td-shim/secure-boot"]
 loader = ["clap", "env_logger", "log"]
+read_file = ["clap", "env_logger", "log", "anyhow"]
 tee = ["clap", "env_logger", "log", "serde_json", "serde", "hex", "sha2", "byteorder"]
 calculator = ["clap", "hex", "parse_int", "sha2", "anyhow", "block-padding"]
 exec-payload-section = []

--- a/td-shim-tools/src/bin/td-shim-checker/main.rs
+++ b/td-shim-tools/src/bin/td-shim-checker/main.rs
@@ -12,6 +12,7 @@ use std::vec::Vec;
 use std::{env, io};
 use td_shim::metadata::{TdxMetadataDescriptor, TdxMetadataSection};
 use td_shim_tools::loader::TdShimLoader;
+use td_shim_tools::read_file::read_from_binary_file;
 
 struct Config {
     // Input file path to be read
@@ -101,7 +102,9 @@ fn main() -> io::Result<()> {
         "Parse td-shim binary [{}] to get TdxMetadata ...",
         config.input
     );
-    let tdx_metadata = TdShimLoader::parse(&config.input);
+
+    let tdx_file_buff = read_from_binary_file(&config.input).unwrap();
+    let tdx_metadata = TdShimLoader::parse(tdx_file_buff);
     if tdx_metadata.is_none() {
         println!(
             "Failed to parse td-shim binary [{}] to get TdxMetadata",

--- a/td-shim-tools/src/lib.rs
+++ b/td-shim-tools/src/lib.rs
@@ -27,6 +27,9 @@ pub mod signer;
 #[cfg(feature = "loader")]
 pub mod loader;
 
+#[cfg(feature = "read_file")]
+pub mod read_file;
+
 #[cfg(feature = "tee")]
 pub mod tee_info_hash;
 

--- a/td-shim-tools/src/read_file.rs
+++ b/td-shim-tools/src/read_file.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use anyhow::*;
+use log::debug;
+use std::fs;
+use std::io::Read;
+use std::io::Seek;
+use td_shim::metadata::TDX_METADATA_OFFSET;
+
+fn read_from_file(file: &mut std::fs::File, pos: u64, buffer: &mut [u8]) -> Result<()> {
+    debug!("Read at pos={0:X}, len={1:X}", pos, buffer.len());
+    let _pos = std::io::SeekFrom::Start(pos);
+    file.seek(_pos)?;
+    file.read_exact(buffer)?;
+    debug!("{:X?}", buffer);
+    Ok(())
+}
+
+pub fn read_from_binary_file(filename: &String) -> Result<Vec<u8>> {
+    let f = fs::File::open(filename);
+    if f.is_err() {
+        bail!("Problem opening the file");
+    }
+
+    let mut file = f.unwrap();
+
+    let file_metadata = fs::metadata(filename);
+    if file_metadata.is_err() {
+        bail!("Problem read file meatadata");
+    }
+
+    let file_metadata = file_metadata.unwrap();
+    let file_size = file_metadata.len();
+
+    // Then read 4 bytes at the pos of [file_len - 0x20]
+    // This is the offset of TdxMetadata
+    let mut metadata_buffer: Vec<u8> = vec![0; 4];
+    if read_from_file(
+        &mut file,
+        file_size - TDX_METADATA_OFFSET as u64,
+        &mut metadata_buffer,
+    )
+    .is_err()
+    {
+        bail!("Failed to read metadata offset");
+    }
+
+    // Read whole binary file and return binary string
+    let mut buffer: Vec<u8> = vec![0; file_size as usize];
+    if read_from_file(&mut file, 0, &mut buffer).is_err() {
+        bail!("Failed to read tdshim binary file");
+    }
+    Ok(buffer)
+}


### PR DESCRIPTION
Fix: #654

Splited the file operation and std env from loader.rs. Moved the read file operation to read_file.rs.

Test the final.bin with td-shim-checker tool and it can get the right result.