### PR TITLE
td-layout: load payload image into physical memory space

### DIFF
--- a/devtools/td-layout-config/config_memory_exec.json
+++ b/devtools/td-layout-config/config_memory_exec.json
@@ -11,6 +11,11 @@
             "type": "Memory"
         },
         {
+            "name": "PayloadImage",
+            "size": "0xC2D000",
+            "type": "Memory"
+        },
+        {
             "name": "EventLog",
             "size": "0x100000",
             "type": "Nvs"

--- a/devtools/td-layout-config/config_memory_exec.json
+++ b/devtools/td-layout-config/config_memory_exec.json
@@ -11,7 +11,7 @@
             "type": "Memory"
         },
         {
-            "name": "PayloadImage",
+            "name": "ShimPayload",
             "size": "0xC2D000",
             "type": "Memory"
         },

--- a/devtools/td-layout-config/src/image.rs
+++ b/devtools/td-layout-config/src/image.rs
@@ -2,6 +2,9 @@ use serde::Deserialize;
 
 use super::{layout::LayoutConfig, render};
 
+const FIRMWARE_ROM_BASE: usize = 0xFF00_0000;
+const FIRMWARE_ROM_SIZE: usize = 0x100_0000;
+
 #[derive(Deserialize, Debug, PartialEq)]
 struct ImageConfig {
     #[serde(rename = "Config")]
@@ -28,60 +31,62 @@ pub fn parse_image(data: String) -> String {
     let image_config = serde_json::from_str::<ImageConfig>(&data)
         .expect("Content is configuration file is invalid");
 
-    let mut image_layout = LayoutConfig::new(0, 0x100_0000);
-    image_layout.reserve_low(
-        "Config",
-        parse_int::parse::<u32>(&image_config.config).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_low(
-        "Mailbox",
-        parse_int::parse::<u32>(&image_config.mailbox).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_low(
-        "TempStack",
-        parse_int::parse::<u32>(&image_config.temp_stack).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_low(
-        "TempHeap",
-        parse_int::parse::<u32>(&image_config.temp_heap).unwrap() as usize,
-        "Reserved",
-    );
+    let config_size = parse_int::parse::<u32>(&image_config.config).unwrap() as usize;
+    let mailbox_size = parse_int::parse::<u32>(&image_config.mailbox).unwrap() as usize;
+    let temp_stack_size = parse_int::parse::<u32>(&image_config.temp_stack).unwrap() as usize;
+    let temp_heap_size = parse_int::parse::<u32>(&image_config.temp_heap).unwrap() as usize;
+    let reset_vector_size = parse_int::parse::<u32>(&image_config.reset_vector).unwrap() as usize;
+    let ipl_size = parse_int::parse::<u32>(&image_config.bootloader).unwrap() as usize;
+    let metadata_size = parse_int::parse::<u32>(&image_config.metadata).unwrap() as usize;
+    let payload_size = parse_int::parse::<u32>(
+        &image_config
+            .builtin_payload
+            .unwrap_or_else(|| "0".to_string()),
+    )
+    .unwrap() as usize;
+    let td_info_size =
+        parse_int::parse::<u32>(&image_config.td_info.unwrap_or_else(|| "0".to_string())).unwrap()
+            as usize;
 
-    image_layout.reserve_high(
-        "ResetVector",
-        parse_int::parse::<u32>(&image_config.reset_vector).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_high(
-        "Ipl",
-        parse_int::parse::<u32>(&image_config.bootloader).unwrap() as usize,
-        "Reserved",
-    );
-
-    image_layout.reserve_high(
-        "Metadata",
-        parse_int::parse::<u32>(&image_config.metadata).unwrap() as usize,
-        "Reserved",
-    );
-
-    if let Some(td_info_config) = image_config.td_info {
-        image_layout.reserve_high(
-            "TdInfo",
-            parse_int::parse::<u32>(&td_info_config).unwrap() as usize,
-            "Reserved",
-        )
+    // Build firmware image layout
+    let image_size = config_size
+        + reset_vector_size
+        + mailbox_size
+        + temp_heap_size
+        + temp_stack_size
+        + ipl_size
+        + metadata_size
+        + payload_size
+        + td_info_size;
+    let mut image_layout = LayoutConfig::new(0, image_size);
+    image_layout.reserve_low("Config", config_size, "Image");
+    image_layout.reserve_low("Mailbox", mailbox_size, "Rom");
+    image_layout.reserve_low("TempStack", temp_stack_size, "Rom");
+    image_layout.reserve_low("TempHeap", temp_heap_size, "Rom");
+    image_layout.reserve_high("ResetVector", reset_vector_size, "Image");
+    image_layout.reserve_high("Ipl", ipl_size, "Image");
+    image_layout.reserve_high("Metadata", metadata_size, "Image");
+    if td_info_size != 0 {
+        image_layout.reserve_high("TdInfo", td_info_size, "Image")
+    }
+    if payload_size != 0 {
+        image_layout.reserve_high("Payload", payload_size, "Image")
     }
 
-    if let Some(payload_config) = image_config.builtin_payload {
-        image_layout.reserve_high(
-            "Payload",
-            parse_int::parse::<u32>(&payload_config).unwrap() as usize,
-            "Reserved",
-        )
+    // Build ROM layout at memory space: 0xFF00_0000 - 0xFFFF_FFFF
+    // Payload image is not loaded into ROM space.
+    let mut rom_layout =
+        LayoutConfig::new(FIRMWARE_ROM_BASE, FIRMWARE_ROM_BASE + FIRMWARE_ROM_SIZE);
+    rom_layout.reserve_low("Config", config_size, "Rom");
+    rom_layout.reserve_low("Mailbox", mailbox_size, "Rom");
+    rom_layout.reserve_low("TempStack", temp_stack_size, "Rom");
+    rom_layout.reserve_low("TempHeap", temp_heap_size, "Rom");
+    rom_layout.reserve_high("ResetVector", reset_vector_size, "Rom");
+    rom_layout.reserve_high("Ipl", ipl_size, "Rom");
+    rom_layout.reserve_high("Metadata", metadata_size, "Rom");
+    if td_info_size != 0 {
+        rom_layout.reserve_high("TdInfo", td_info_size, "Rom")
     }
 
-    render::render_image(&image_layout).expect("Render image layout failed!")
+    render::render_image(&image_layout, &rom_layout).expect("Render image layout failed!")
 }

--- a/devtools/td-layout-config/src/render.rs
+++ b/devtools/td-layout-config/src/render.rs
@@ -9,7 +9,7 @@ use tera::{Context, Result, Tera};
 use super::layout::{LayoutConfig, ENTRY_TYPE_FILTER};
 
 /// Render image layout file.
-pub fn render_image(image_layout: &LayoutConfig) -> Result<String> {
+pub fn render_image(image_layout: &LayoutConfig, rom_layout: &LayoutConfig) -> Result<String> {
     let mut tera = Tera::default();
     tera.register_filter("format_hex", format_hex);
     tera.register_filter("format_name", format_name);
@@ -19,12 +19,12 @@ pub fn render_image(image_layout: &LayoutConfig) -> Result<String> {
     let mut context = Context::new();
     context.insert("image_regions", image_layout.get_regions());
     context.insert("image_size", &image_layout.get_top());
+    context.insert("rom_regions", &rom_layout.get_regions());
+    context.insert("rom_size", &(rom_layout.get_top() - rom_layout.get_base()));
     // Image size - metadata pointer offset(0x20) - OVMF GUID table size(0x28) - SEC Core information size(0xC).
     context.insert("sec_info_offset", &(image_layout.get_top() - 0x54));
-    context.insert(
-        "memory_offset",
-        &(u32::MAX as usize + 1 - &image_layout.get_top()),
-    );
+    context.insert("sec_info_base", &(rom_layout.get_top() - 0x54));
+    context.insert("rom_base", &rom_layout.get_base());
     context.insert("entry_type_filter", ENTRY_TYPE_FILTER);
     tera.render("image.rs", &context)
 }

--- a/devtools/td-layout-config/src/template/image.jinja
+++ b/devtools/td-layout-config/src/template/image.jinja
@@ -14,21 +14,26 @@ Image Layout
 Image size: {{image_size|format_hex}} ({{image_size|filesizeformat}})
 */
 
-// Image Layout Configuration
-{%for i in image_regions%}
+// Image configuration
+pub const TD_SHIM_IMAGE_SIZE: u32 = {{image_size | format_hex }};
+{%-for i in image_regions%}
 pub const TD_SHIM_{{i.name_screaming_snake_case}}_OFFSET: u32 = {{i.region.start | format_hex }};
-pub const TD_SHIM_{{i.name_screaming_snake_case}}_SIZE: u32 = {{i.region.end - i.region.start | format_hex }}; // {{i.region.end - i.region.start|filesizeformat}}
-{%endfor%}
-// Offset when Loading into Memory
-pub const TD_SHIM_FIRMWARE_BASE: u32 = {{memory_offset | format_hex }};
-pub const TD_SHIM_FIRMWARE_SIZE: u32 = {{image_size | format_hex }};
+{%-endfor%}
+
+// Size of regions
+{%-for i in image_regions%}
+pub const TD_SHIM_{{i.name_screaming_snake_case}}_SIZE: u32 = {{i.region.end - i.region.start | format_hex }};
+{%-endfor%}
+
+pub const TD_SHIM_FIRMWARE_BASE: u32 = {{rom_base | format_hex }};
+pub const TD_SHIM_FIRMWARE_SIZE: u32 = {{rom_size | format_hex }};
+
+// ROM configuration
+{%-for i in rom_regions%}
+pub const TD_SHIM_{{i.name_screaming_snake_case}}_BASE: u32 = {{i.region.start | format_hex }};
+{%-endfor%}
 
 // TD_SHIM_SEC_INFO_OFFSET equals to firmware size - metadata pointer offset -
 // OVMF GUID table size - SEC Core information size.
 pub const TD_SHIM_SEC_CORE_INFO_OFFSET: u32 = {{sec_info_offset | format_hex }};
-pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = {{memory_offset + sec_info_offset | format_hex }};
-
-// Base Address after Loaded into Memory
-{%-for i in image_regions%}
-pub const TD_SHIM_{{i.name_screaming_snake_case}}_BASE: u32 = {{memory_offset + i.region.start | format_hex }};
-{%-endfor%}
+pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = {{sec_info_base | format_hex }};

--- a/td-layout/src/build_time.rs
+++ b/td-layout/src/build_time.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2023  Intel Corporation
+// Copyright (c) 2021 - 2024  Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -7,72 +7,64 @@
 /*
 Image Layout
 +----------------------------------------+ <- 0x0
-|                 CONFIG                 |   (0x40000) 256 KB
+|                 CONFIG                 |   (0x40000) 256 kB
 +----------------------------------------+ <- 0x40000
-|                MAILBOX                 |   (0x1000) 4 KB
+|                MAILBOX                 |   (0x1000) 4 kB
 +----------------------------------------+ <- 0x41000
-|               TEMP_STACK               |   (0x20000) 128 KB
+|               TEMP_STACK               |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x61000
-|               TEMP_HEAP                |   (0x20000) 128 KB
+|               TEMP_HEAP                |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x81000
-|                  FREE                  |   (0x1000) 4 KB
-+----------------------------------------+ <- 0x82000
-|                PAYLOAD                 |   (0xC2D000) 12.18 MB
+|                  FREE                  |   (0x0) 0 B
++----------------------------------------+ <- 0x81000
+|                PAYLOAD                 |   (0xC2E000) 12.18 MB
 +----------------------------------------+ <- 0xCAF000
-|                METADATA                |   (0x1000) 4 KB
+|                METADATA                |   (0x1000) 4 kB
 +----------------------------------------+ <- 0xCB0000
 |                  IPL                   |   (0x348000) 3.28 MB
 +----------------------------------------+ <- 0xFF8000
-|              RESET_VECTOR              |   (0x8000) 32 KB
+|              RESET_VECTOR              |   (0x8000) 32 kB
 +----------------------------------------+ <- 0x1000000
 Image size: 0x1000000 (16 MB)
 */
 
-// Image Layout Configuration
-
+// Image configuration
+pub const TD_SHIM_IMAGE_SIZE: u32 = 0x1000000;
 pub const TD_SHIM_CONFIG_OFFSET: u32 = 0x0;
-pub const TD_SHIM_CONFIG_SIZE: u32 = 0x40000; // 256 KB
-
 pub const TD_SHIM_MAILBOX_OFFSET: u32 = 0x40000;
-pub const TD_SHIM_MAILBOX_SIZE: u32 = 0x1000; // 4 KB
-
 pub const TD_SHIM_TEMP_STACK_OFFSET: u32 = 0x41000;
-pub const TD_SHIM_TEMP_STACK_SIZE: u32 = 0x20000; // 128 KB
-
 pub const TD_SHIM_TEMP_HEAP_OFFSET: u32 = 0x61000;
-pub const TD_SHIM_TEMP_HEAP_SIZE: u32 = 0x20000; // 128 KB
-
 pub const TD_SHIM_FREE_OFFSET: u32 = 0x81000;
-pub const TD_SHIM_FREE_SIZE: u32 = 0x1000; // 4 KB
-
-pub const TD_SHIM_PAYLOAD_OFFSET: u32 = 0x82000;
-pub const TD_SHIM_PAYLOAD_SIZE: u32 = 0xC2D000; // 12.18 MB
-
+pub const TD_SHIM_PAYLOAD_OFFSET: u32 = 0x81000;
 pub const TD_SHIM_METADATA_OFFSET: u32 = 0xCAF000;
-pub const TD_SHIM_METADATA_SIZE: u32 = 0x1000; // 4 KB
-
 pub const TD_SHIM_IPL_OFFSET: u32 = 0xCB0000;
-pub const TD_SHIM_IPL_SIZE: u32 = 0x348000; // 3.28 MB
-
 pub const TD_SHIM_RESET_VECTOR_OFFSET: u32 = 0xFF8000;
-pub const TD_SHIM_RESET_VECTOR_SIZE: u32 = 0x8000; // 32 KB
 
-// Offset when Loading into Memory
+// Size of regions
+pub const TD_SHIM_CONFIG_SIZE: u32 = 0x40000;
+pub const TD_SHIM_MAILBOX_SIZE: u32 = 0x1000;
+pub const TD_SHIM_TEMP_STACK_SIZE: u32 = 0x20000;
+pub const TD_SHIM_TEMP_HEAP_SIZE: u32 = 0x20000;
+pub const TD_SHIM_FREE_SIZE: u32 = 0x0;
+pub const TD_SHIM_PAYLOAD_SIZE: u32 = 0xC2E000;
+pub const TD_SHIM_METADATA_SIZE: u32 = 0x1000;
+pub const TD_SHIM_IPL_SIZE: u32 = 0x348000;
+pub const TD_SHIM_RESET_VECTOR_SIZE: u32 = 0x8000;
+
 pub const TD_SHIM_FIRMWARE_BASE: u32 = 0xFF000000;
 pub const TD_SHIM_FIRMWARE_SIZE: u32 = 0x1000000;
 
-// TD_SHIM_SEC_INFO_OFFSET equals to firmware size - metadata pointer offset -
-// OVMF GUID table size - SEC Core information size.
-pub const TD_SHIM_SEC_CORE_INFO_OFFSET: u32 = 0xFFFFAC;
-pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = 0xFFFFFFAC;
-
-// Base Address after Loaded into Memory
+// ROM configuration
 pub const TD_SHIM_CONFIG_BASE: u32 = 0xFF000000;
 pub const TD_SHIM_MAILBOX_BASE: u32 = 0xFF040000;
 pub const TD_SHIM_TEMP_STACK_BASE: u32 = 0xFF041000;
 pub const TD_SHIM_TEMP_HEAP_BASE: u32 = 0xFF061000;
 pub const TD_SHIM_FREE_BASE: u32 = 0xFF081000;
-pub const TD_SHIM_PAYLOAD_BASE: u32 = 0xFF082000;
 pub const TD_SHIM_METADATA_BASE: u32 = 0xFFCAF000;
 pub const TD_SHIM_IPL_BASE: u32 = 0xFFCB0000;
 pub const TD_SHIM_RESET_VECTOR_BASE: u32 = 0xFFFF8000;
+
+// TD_SHIM_SEC_INFO_OFFSET equals to firmware size - metadata pointer offset -
+// OVMF GUID table size - SEC Core information size.
+pub const TD_SHIM_SEC_CORE_INFO_OFFSET: u32 = 0xFFFFAC;
+pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = 0xFFFFFFAC;

--- a/td-layout/src/memslice.rs
+++ b/td-layout/src/memslice.rs
@@ -12,7 +12,7 @@ pub enum SliceType {
     Config,
     /// The `TD_HOB` region in image file
     TdHob,
-    /// The `Payload and Metadata` region in image file
+    /// The `Payload Image` region in runtime memory layout
     ShimPayload,
     /// The `TD_MAILBOX` region in image file
     MailBox,
@@ -69,10 +69,6 @@ pub fn get_mem_slice<'a>(t: SliceType) -> &'a [u8] {
                 TD_SHIM_CONFIG_BASE as *const u8,
                 TD_SHIM_CONFIG_SIZE as usize,
             ),
-            SliceType::ShimPayload => core::slice::from_raw_parts(
-                TD_SHIM_PAYLOAD_BASE as *const u8,
-                TD_SHIM_PAYLOAD_SIZE as usize,
-            ),
             SliceType::MailBox => core::slice::from_raw_parts(
                 TD_SHIM_MAILBOX_BASE as *const u8,
                 TD_SHIM_MAILBOX_SIZE as usize,
@@ -94,7 +90,7 @@ pub unsafe fn get_mem_slice_mut<'a>(t: SliceType) -> &'a mut [u8] {
             TD_SHIM_MAILBOX_BASE as *const u8 as *mut u8,
             TD_SHIM_MAILBOX_SIZE as usize,
         ),
-        SliceType::Config | SliceType::ShimPayload => {
+        SliceType::Config => {
             panic!("get_mem_slice_mut: read only")
         }
         _ => panic!("get_mem_slice_mut: not support"),
@@ -109,12 +105,6 @@ mod test {
     fn test_get_mem_slice_with_type_config() {
         let config = get_mem_slice(SliceType::Config);
         assert_eq!(config.len(), TD_SHIM_CONFIG_SIZE as usize);
-    }
-
-    #[test]
-    fn test_get_mem_slice_with_type_builtin_payload() {
-        let payload = get_mem_slice(SliceType::ShimPayload);
-        assert_eq!(payload.len(), TD_SHIM_PAYLOAD_SIZE as usize);
     }
 
     #[test]
@@ -151,14 +141,6 @@ mod test {
     fn test_get_mem_slice_mut_with_type_mailbox() {
         let mailbox = unsafe { get_mem_slice_mut(SliceType::MailBox) };
         assert_eq!(mailbox.len(), TD_SHIM_MAILBOX_SIZE as usize);
-    }
-
-    #[test]
-    #[should_panic(expected = "get_mem_slice_mut: read only")]
-    fn test_get_mem_slice_mut_with_type_builtin_payload() {
-        unsafe {
-            get_mem_slice_mut(SliceType::ShimPayload);
-        }
     }
 
     #[test]

--- a/td-layout/src/runtime/exec.rs
+++ b/td-layout/src/runtime/exec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2023  Intel Corporation
+// Copyright (c) 2021 - 2024  Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -10,40 +10,45 @@ Top of Low Memory: 0x80000000
 +----------------------------------------+ <- 0x80000000
 |               EVENT_LOG                |   (0x100000) 1 MB
 +----------------------------------------+ <- 0x7FF00000
-|           RELOCATED_MAILBOX            |   (0x2000) 8 KB
+|           RELOCATED_MAILBOX            |   (0x2000) 8 kB
 +----------------------------------------+ <- 0x7FEFE000
-|           PAYLOAD_PAGE_TABLE           |   (0x20000) 128 KB
+|           PAYLOAD_PAGE_TABLE           |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x7FEDE000
 |                PAYLOAD                 |   (0x2000000) 32 MB
 +----------------------------------------+ <- 0x7DEDE000
 |                  ACPI                  |   (0x100000) 1 MB
 +----------------------------------------+ <- 0x7DDDE000
-|                  FREE                  |   (0x7D5BE000) 1.96 GB
+|                  FREE                  |   (0x7C950000) 1.95 GB
++----------------------------------------+ <- 0x148E000
+|             PAYLOAD_IMAGE              |   (0xC6E000) 12.43 MB
 +----------------------------------------+ <- 0x820000
-|                 TD_HOB                 |   (0x20000) 128 KB
+|                 TD_HOB                 |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x800000
 |               BOOTLOADER               |   (0x800000) 8 MB
 +----------------------------------------+ <- 0x0
-Total Usage: 0x2A42000 (42.26 MB)
+Total Usage: 0x36B0000 (54.69 MB)
 */
 
-pub const TOTAL_USAGE: usize = 0x2A42000; // (42.26 MB)
+pub const TOTAL_USAGE: usize = 0x36B0000; // (54.69 MB)
 
 // Runtime Layout Configuration
 pub const BOOTLOADER_BASE: usize = 0x0;
 pub const BOOTLOADER_SIZE: usize = 0x800000; // 8 MB
 pub const TD_HOB_BASE: usize = 0x800000;
-pub const TD_HOB_SIZE: usize = 0x20000; // 128 KB
+pub const TD_HOB_SIZE: usize = 0x20000; // 128 kB
+pub const PAYLOAD_IMAGE_BASE: usize = 0x820000;
+pub const PAYLOAD_IMAGE_SIZE: usize = 0xC6E000; // 12.43 MB
 pub const ACPI_SIZE: usize = 0x100000; // 1 MB
 pub const PAYLOAD_SIZE: usize = 0x2000000; // 32 MB
-pub const PAYLOAD_PAGE_TABLE_SIZE: usize = 0x20000; // 128 KB
-pub const RELOCATED_MAILBOX_SIZE: usize = 0x2000; // 8 KB
+pub const PAYLOAD_PAGE_TABLE_SIZE: usize = 0x20000; // 128 kB
+pub const RELOCATED_MAILBOX_SIZE: usize = 0x2000; // 8 kB
 pub const EVENT_LOG_SIZE: usize = 0x100000; // 1 MB
 
-pub const MEMORY_LAYOUT_CONFIG: &[(&str, usize, &str)] = &[
+pub const MEMORY_LAYOUT_CONFIG: &[(&'static str, usize, &'static str)] = &[
     // (name of memory region, region size, region type)
     ("Bootloader", 0x800000, "Memory"),
     ("TdHob", 0x20000, "Memory"),
+    ("ShimPayload", 0xC6E000, "Memory"),
     ("Acpi", 0x100000, "Acpi"),
     ("Payload", 0x2000000, "Reserved"),
     ("PayloadPageTable", 0x20000, "Reserved"),

--- a/td-shim-interface/src/metadata.rs
+++ b/td-shim-interface/src/metadata.rs
@@ -18,6 +18,21 @@ pub const TDX_METADATA_GUID: Guid = Guid::from_fields(
     [0xA8, 0xEB, 0x7F, 0x4D, 0x87, 0x38, 0xF6, 0xAE],
 );
 
+pub const OVMF_TABLE_FOOTER_GUID_OFFSET: u32 = 0x30;
+pub const OVMF_TABLE_FOOTER_GUID: Guid = Guid::from_fields(
+    0x96b582de,
+    0x1fb2,
+    0x45f7,
+    [0xba, 0xea, 0xa3, 0x66, 0xc5, 0x5a, 0x08, 0x2d],
+);
+
+pub const OVMF_TABLE_TDX_METADATA_GUID: Guid = Guid::from_fields(
+    0xe47a6535,
+    0x984a,
+    0x4798,
+    [0x86, 0x5e, 0x46, 0x85, 0xa7, 0xbf, 0x8e, 0xc2],
+);
+
 /// 'TDVF' signature
 pub const TDX_METADATA_SIGNATURE: u32 = 0x46564454;
 /// Version of the `TdxMetadataDescriptor` structure. It must be 1.

--- a/td-shim-tools/src/linker.rs
+++ b/td-shim-tools/src/linker.rs
@@ -22,7 +22,9 @@ use td_shim::fv::{
 };
 use td_shim::reset_vector::{ResetVectorHeader, ResetVectorParams};
 use td_shim::write_u24;
-use td_shim_interface::metadata::{TdxMetadataGuid, TdxMetadataPtr};
+use td_shim_interface::metadata::{
+    TdxMetadataGuid, TdxMetadataPtr, OVMF_TABLE_FOOTER_GUID, OVMF_TABLE_TDX_METADATA_GUID,
+};
 use td_shim_interface::td_uefi_pi::pi::fv::{
     FfsFileHeader, FV_FILETYPE_SECURITY_CORE, SECTION_PE32,
 };
@@ -35,24 +37,6 @@ pub const MAX_IPL_CONTENT_SIZE: usize =
 pub const MAX_PAYLOAD_CONTENT_SIZE: usize =
     TD_SHIM_PAYLOAD_SIZE as usize - size_of::<FvHeaderByte>();
 pub const MAX_METADATA_CONFIG_SIZE: usize = 1024 * 1024;
-
-pub const OVMF_TABLE_FOOTER_GUID: Guid = Guid::from_fields(
-    0x96b582de,
-    0x1fb2,
-    0x45f7,
-    0xba,
-    0xea,
-    &[0xa3, 0x66, 0xc5, 0x5a, 0x08, 0x2d],
-);
-
-pub const OVMF_TABLE_TDX_METADATA_GUID: Guid = Guid::from_fields(
-    0xe47a6535,
-    0x984a,
-    0x4798,
-    0x86,
-    0x5e,
-    &[0x46, 0x85, 0xa7, 0xbf, 0x8e, 0xc2],
-);
 
 #[repr(C, align(4))]
 pub struct FvHeaderByte {

--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -218,7 +218,7 @@ fn boot_builtin_payload(
     acpi_tables: &Vec<&[u8]>,
 ) {
     // Get and parse image file from the payload firmware volume.
-    let mut payload_bin = memslice::get_mem_slice(memslice::SliceType::ShimPayload);
+    let mut payload_bin = mem.get_dynamic_mem_slice(SliceType::ShimPayload);
 
     #[cfg(feature = "secure-boot")]
     {

--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -218,13 +218,7 @@ fn boot_builtin_payload(
     acpi_tables: &Vec<&[u8]>,
 ) {
     // Get and parse image file from the payload firmware volume.
-    let fv_buffer = memslice::get_mem_slice(memslice::SliceType::ShimPayload);
-    let mut payload_bin = fv::get_image_from_fv(
-        fv_buffer,
-        pi::fv::FV_FILETYPE_DXE_CORE,
-        pi::fv::SECTION_PE32,
-    )
-    .expect("Failed to get image file from Firmware Volume");
+    let mut payload_bin = memslice::get_mem_slice(memslice::SliceType::ShimPayload);
 
     #[cfg(feature = "secure-boot")]
     {

--- a/td-shim/src/bin/td-shim/payload_hob.rs
+++ b/td-shim/src/bin/td-shim/payload_hob.rs
@@ -170,7 +170,6 @@ pub fn build_payload_hob(acpi_tables: &Vec<&[u8]>, memory: &Memory) -> Option<Pa
         PayloadHob::new(memory.get_dynamic_mem_slice_mut(memslice::SliceType::Acpi))?;
 
     payload_hob.add_cpu(memory::cpu_get_memory_space_size(), 16);
-    payload_hob.add_fv(TD_SHIM_PAYLOAD_BASE as u64, TD_SHIM_PAYLOAD_SIZE as u64);
 
     for &table in acpi_tables {
         payload_hob


### PR DESCRIPTION
The old implementation loads the payload image into ROM space which limited the size of the payload to be smaller than 16MiB.

 - The previous layout 1:1 maps the image to the ROM space, as we move payload to physical memory space, ROM layout and image layout will be different in `td-layout-config` tool.
 - Firmware volume header has limitation on the size of the data inside which needs to be smaller than maximum value of u24 (0xffffff). To lift the restriction, FV header is removed for payload images as it is not mandatory.
 - At runtime, if td-shim image is not loaded into memory 1:1, the metadata offset at firmware_end - 0x20 will be invalid because it is the offset from the beginning of the image. The value inside the OVMF GUID table is the offset from the end of the image which is not changed after loading into memory.

Related issue: https://github.com/confidential-containers/td-shim/issues/665
