### PR TITLE
td-shim: remove the FV header for payload image

### DIFF
--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -218,13 +218,7 @@ fn boot_builtin_payload(
     acpi_tables: &Vec<&[u8]>,
 ) {
     // Get and parse image file from the payload firmware volume.
-    let fv_buffer = memslice::get_mem_slice(memslice::SliceType::ShimPayload);
-    let mut payload_bin = fv::get_image_from_fv(
-        fv_buffer,
-        pi::fv::FV_FILETYPE_DXE_CORE,
-        pi::fv::SECTION_PE32,
-    )
-    .expect("Failed to get image file from Firmware Volume");
+    let mut payload_bin = memslice::get_mem_slice(memslice::SliceType::ShimPayload);
 
     #[cfg(feature = "secure-boot")]
     {

--- a/td-shim/src/bin/td-shim/payload_hob.rs
+++ b/td-shim/src/bin/td-shim/payload_hob.rs
@@ -170,7 +170,6 @@ pub fn build_payload_hob(acpi_tables: &Vec<&[u8]>, memory: &Memory) -> Option<Pa
         PayloadHob::new(memory.get_dynamic_mem_slice_mut(memslice::SliceType::Acpi))?;
 
     payload_hob.add_cpu(memory::cpu_get_memory_space_size(), 16);
-    payload_hob.add_fv(TD_SHIM_PAYLOAD_BASE as u64, TD_SHIM_PAYLOAD_SIZE as u64);
 
     for &table in acpi_tables {
         payload_hob


### PR DESCRIPTION
Firmware volume header has limitation on the size of the data inside which needs to be smaller than maximum value of u24 (0xffffff).

To lift the restriction, FV header is removed for payload images as it is not mandatory.