### PR TITLE
Modification on `devtools/td-layout-config`

### DIFF
--- a/devtools/td-layout-config/config_image.json
+++ b/devtools/td-layout-config/config_image.json
@@ -1,10 +1,10 @@
 {
+    "Payload": "0xC2D000",
     "Config": "0x040000",
     "Mailbox": "0x001000",
     "TempStack": "0x020000",
     "TempHeap": "0x020000",
     "Metadata": "0x001000",
-    "Payload": "0xC2D000",
     "Ipl": "0x348000",
     "ResetVector": "0x008000"
 }

--- a/devtools/td-layout-config/config_memory_exec.json
+++ b/devtools/td-layout-config/config_memory_exec.json
@@ -11,6 +11,11 @@
             "type": "Memory"
         },
         {
+            "name": "ShimPayload",
+            "size": "0xC2D000",
+            "type": "Memory"
+        },
+        {
             "name": "EventLog",
             "size": "0x100000",
             "type": "Nvs"

--- a/devtools/td-layout-config/src/image.rs
+++ b/devtools/td-layout-config/src/image.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 use super::{layout::LayoutConfig, render};
 
-const FIRMWARE_ROM_BASE: usize = 0xFF00_0000;
+const FIRMWARE_ROM_TOP: usize = 0x1_0000_0000;
 const FIRMWARE_ROM_SIZE: usize = 0x100_0000;
 
 #[derive(Deserialize, Debug, PartialEq)]
@@ -75,16 +75,13 @@ pub fn parse_image(data: String) -> String {
 
     // Build ROM layout at memory space: 0xFF00_0000 - 0xFFFF_FFFF
     // Payload image is not loaded into ROM space.
-    let mut rom_layout =
-        LayoutConfig::new(FIRMWARE_ROM_BASE, FIRMWARE_ROM_BASE + FIRMWARE_ROM_SIZE);
+    let rom_size = image_size - payload_size;
+    let mut rom_layout = LayoutConfig::new(FIRMWARE_ROM_TOP - rom_size, FIRMWARE_ROM_TOP);
 
     if image_size > FIRMWARE_ROM_SIZE {
         panic!("Image size exceeds the maximum ROM space");
     }
 
-    if payload_size != 0 {
-        image_layout.reserve_low("Payload", payload_size, "Rom")
-    }
     rom_layout.reserve_low("Config", config_size, "Rom");
     rom_layout.reserve_low("Mailbox", mailbox_size, "Rom");
     rom_layout.reserve_low("TempStack", temp_stack_size, "Rom");

--- a/devtools/td-layout-config/src/image.rs
+++ b/devtools/td-layout-config/src/image.rs
@@ -2,6 +2,9 @@ use serde::Deserialize;
 
 use super::{layout::LayoutConfig, render};
 
+const FIRMWARE_ROM_BASE: usize = 0xFF00_0000;
+const FIRMWARE_ROM_SIZE: usize = 0x100_0000;
+
 #[derive(Deserialize, Debug, PartialEq)]
 struct ImageConfig {
     #[serde(rename = "Payload")]
@@ -28,60 +31,70 @@ pub fn parse_image(data: String) -> String {
     let image_config = serde_json::from_str::<ImageConfig>(&data)
         .expect("Content is configuration file is invalid");
 
-    let mut image_layout = LayoutConfig::new(0, 0x100_0000);
+    let config_size = parse_int::parse::<u32>(&image_config.config).unwrap() as usize;
+    let mailbox_size = parse_int::parse::<u32>(&image_config.mailbox).unwrap() as usize;
+    let temp_stack_size = parse_int::parse::<u32>(&image_config.temp_stack).unwrap() as usize;
+    let temp_heap_size = parse_int::parse::<u32>(&image_config.temp_heap).unwrap() as usize;
+    let reset_vector_size = parse_int::parse::<u32>(&image_config.reset_vector).unwrap() as usize;
+    let ipl_size = parse_int::parse::<u32>(&image_config.bootloader).unwrap() as usize;
+    let metadata_size = parse_int::parse::<u32>(&image_config.metadata).unwrap() as usize;
+    let payload_size = parse_int::parse::<u32>(
+        &image_config
+            .builtin_payload
+            .unwrap_or_else(|| "0".to_string()),
+    )
+    .unwrap() as usize;
+    let td_info_size =
+        parse_int::parse::<u32>(&image_config.td_info.unwrap_or_else(|| "0".to_string())).unwrap()
+            as usize;
 
-    if let Some(payload_config) = image_config.builtin_payload {
-        image_layout.reserve_low(
-            "Payload",
-            parse_int::parse::<u32>(&payload_config).unwrap() as usize,
-            "Reserved",
-        )
+    // Build firmware image layout
+    let image_size = config_size
+        + reset_vector_size
+        + mailbox_size
+        + temp_heap_size
+        + temp_stack_size
+        + ipl_size
+        + metadata_size
+        + payload_size
+        + td_info_size;
+    let mut image_layout = LayoutConfig::new(0, image_size);
+    if payload_size != 0 {
+        image_layout.reserve_low("Payload", payload_size, "Image")
     }
-    image_layout.reserve_low(
-        "Config",
-        parse_int::parse::<u32>(&image_config.config).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_low(
-        "Mailbox",
-        parse_int::parse::<u32>(&image_config.mailbox).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_low(
-        "TempStack",
-        parse_int::parse::<u32>(&image_config.temp_stack).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_low(
-        "TempHeap",
-        parse_int::parse::<u32>(&image_config.temp_heap).unwrap() as usize,
-        "Reserved",
-    );
-
-    image_layout.reserve_high(
-        "ResetVector",
-        parse_int::parse::<u32>(&image_config.reset_vector).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_high(
-        "Ipl",
-        parse_int::parse::<u32>(&image_config.bootloader).unwrap() as usize,
-        "Reserved",
-    );
-
-    image_layout.reserve_high(
-        "Metadata",
-        parse_int::parse::<u32>(&image_config.metadata).unwrap() as usize,
-        "Reserved",
-    );
-
-    if let Some(td_info_config) = image_config.td_info {
-        image_layout.reserve_high(
-            "TdInfo",
-            parse_int::parse::<u32>(&td_info_config).unwrap() as usize,
-            "Reserved",
-        )
+    image_layout.reserve_low("Config", config_size, "Image");
+    image_layout.reserve_low("Mailbox", mailbox_size, "Image");
+    image_layout.reserve_low("TempStack", temp_stack_size, "Image");
+    image_layout.reserve_low("TempHeap", temp_heap_size, "Image");
+    image_layout.reserve_high("ResetVector", reset_vector_size, "Image");
+    image_layout.reserve_high("Ipl", ipl_size, "Image");
+    image_layout.reserve_high("Metadata", metadata_size, "Image");
+    if td_info_size != 0 {
+        image_layout.reserve_high("TdInfo", td_info_size, "Image")
     }
 
-    render::render_image(&image_layout).expect("Render image layout failed!")
+    // Build ROM layout at memory space: 0xFF00_0000 - 0xFFFF_FFFF
+    // Payload image is not loaded into ROM space.
+    let mut rom_layout =
+        LayoutConfig::new(FIRMWARE_ROM_BASE, FIRMWARE_ROM_BASE + FIRMWARE_ROM_SIZE);
+
+    if image_size > FIRMWARE_ROM_SIZE {
+        panic!("Image size exceeds the maximum ROM space");
+    }
+
+    if payload_size != 0 {
+        image_layout.reserve_low("Payload", payload_size, "Rom")
+    }
+    rom_layout.reserve_low("Config", config_size, "Rom");
+    rom_layout.reserve_low("Mailbox", mailbox_size, "Rom");
+    rom_layout.reserve_low("TempStack", temp_stack_size, "Rom");
+    rom_layout.reserve_low("TempHeap", temp_heap_size, "Rom");
+    rom_layout.reserve_high("ResetVector", reset_vector_size, "Rom");
+    rom_layout.reserve_high("Ipl", ipl_size, "Rom");
+    rom_layout.reserve_high("Metadata", metadata_size, "Rom");
+    if td_info_size != 0 {
+        rom_layout.reserve_high("TdInfo", td_info_size, "Rom")
+    }
+
+    render::render_image(&image_layout, &rom_layout).expect("Render image layout failed!")
 }

--- a/devtools/td-layout-config/src/image.rs
+++ b/devtools/td-layout-config/src/image.rs
@@ -4,6 +4,8 @@ use super::{layout::LayoutConfig, render};
 
 #[derive(Deserialize, Debug, PartialEq)]
 struct ImageConfig {
+    #[serde(rename = "Payload")]
+    builtin_payload: Option<String>,
     #[serde(rename = "Config")]
     config: String,
     #[serde(rename = "Mailbox")]
@@ -12,8 +14,6 @@ struct ImageConfig {
     temp_stack: String,
     #[serde(rename = "TempHeap")]
     temp_heap: String,
-    #[serde(rename = "Payload")]
-    builtin_payload: Option<String>,
     #[serde(rename = "TdInfo")]
     td_info: Option<String>,
     #[serde(rename = "Metadata")]
@@ -29,6 +29,14 @@ pub fn parse_image(data: String) -> String {
         .expect("Content is configuration file is invalid");
 
     let mut image_layout = LayoutConfig::new(0, 0x100_0000);
+
+    if let Some(payload_config) = image_config.builtin_payload {
+        image_layout.reserve_low(
+            "Payload",
+            parse_int::parse::<u32>(&payload_config).unwrap() as usize,
+            "Reserved",
+        )
+    }
     image_layout.reserve_low(
         "Config",
         parse_int::parse::<u32>(&image_config.config).unwrap() as usize,
@@ -71,14 +79,6 @@ pub fn parse_image(data: String) -> String {
         image_layout.reserve_high(
             "TdInfo",
             parse_int::parse::<u32>(&td_info_config).unwrap() as usize,
-            "Reserved",
-        )
-    }
-
-    if let Some(payload_config) = image_config.builtin_payload {
-        image_layout.reserve_high(
-            "Payload",
-            parse_int::parse::<u32>(&payload_config).unwrap() as usize,
             "Reserved",
         )
     }

--- a/devtools/td-layout-config/src/render.rs
+++ b/devtools/td-layout-config/src/render.rs
@@ -9,7 +9,7 @@ use tera::{Context, Result, Tera};
 use super::layout::{LayoutConfig, ENTRY_TYPE_FILTER};
 
 /// Render image layout file.
-pub fn render_image(image_layout: &LayoutConfig) -> Result<String> {
+pub fn render_image(image_layout: &LayoutConfig, rom_layout: &LayoutConfig) -> Result<String> {
     let mut tera = Tera::default();
     tera.register_filter("format_hex", format_hex);
     tera.register_filter("format_name", format_name);
@@ -19,12 +19,12 @@ pub fn render_image(image_layout: &LayoutConfig) -> Result<String> {
     let mut context = Context::new();
     context.insert("image_regions", image_layout.get_regions());
     context.insert("image_size", &image_layout.get_top());
+    context.insert("rom_regions", &rom_layout.get_regions());
+    context.insert("rom_size", &(rom_layout.get_top() - rom_layout.get_base()));
     // Image size - metadata pointer offset(0x20) - OVMF GUID table size(0x28) - SEC Core information size(0xC).
     context.insert("sec_info_offset", &(image_layout.get_top() - 0x54));
-    context.insert(
-        "memory_offset",
-        &(u32::MAX as usize + 1 - &image_layout.get_top()),
-    );
+    context.insert("sec_info_base", &(rom_layout.get_top() - 0x54));
+    context.insert("rom_base", &rom_layout.get_base());
     context.insert("entry_type_filter", ENTRY_TYPE_FILTER);
     tera.render("image.rs", &context)
 }

--- a/devtools/td-layout-config/src/template/image.jinja
+++ b/devtools/td-layout-config/src/template/image.jinja
@@ -14,21 +14,26 @@ Image Layout
 Image size: {{image_size|format_hex}} ({{image_size|filesizeformat}})
 */
 
-// Image Layout Configuration
-{%for i in image_regions%}
+// Image configuration
+pub const TD_SHIM_IMAGE_SIZE: u32 = {{image_size | format_hex }};
+{%-for i in image_regions%}
 pub const TD_SHIM_{{i.name_screaming_snake_case}}_OFFSET: u32 = {{i.region.start | format_hex }};
-pub const TD_SHIM_{{i.name_screaming_snake_case}}_SIZE: u32 = {{i.region.end - i.region.start | format_hex }}; // {{i.region.end - i.region.start|filesizeformat}}
-{%endfor%}
-// Offset when Loading into Memory
-pub const TD_SHIM_FIRMWARE_BASE: u32 = {{memory_offset | format_hex }};
-pub const TD_SHIM_FIRMWARE_SIZE: u32 = {{image_size | format_hex }};
+{%-endfor%}
+
+// Size of regions
+{%-for i in image_regions%}
+pub const TD_SHIM_{{i.name_screaming_snake_case}}_SIZE: u32 = {{i.region.end - i.region.start | format_hex }};
+{%-endfor%}
+
+// ROM configuration
+pub const TD_SHIM_FIRMWARE_BASE: u32 = {{rom_base | format_hex }};
+pub const TD_SHIM_FIRMWARE_SIZE: u32 = {{rom_size | format_hex }};
+
+{%-for i in rom_regions%}
+pub const TD_SHIM_{{i.name_screaming_snake_case}}_BASE: u32 = {{i.region.start | format_hex }};
+{%-endfor%}
 
 // TD_SHIM_SEC_INFO_OFFSET equals to firmware size - metadata pointer offset -
 // OVMF GUID table size - SEC Core information size.
 pub const TD_SHIM_SEC_CORE_INFO_OFFSET: u32 = {{sec_info_offset | format_hex }};
-pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = {{memory_offset + sec_info_offset | format_hex }};
-
-// Base Address after Loaded into Memory
-{%-for i in image_regions%}
-pub const TD_SHIM_{{i.name_screaming_snake_case}}_BASE: u32 = {{memory_offset + i.region.start | format_hex }};
-{%-endfor%}
+pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = {{sec_info_base | format_hex }};

--- a/td-layout/src/build_time.rs
+++ b/td-layout/src/build_time.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2023  Intel Corporation
+// Copyright (c) 2021 - 2024  Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -7,55 +7,55 @@
 /*
 Image Layout
 +----------------------------------------+ <- 0x0
-|                 CONFIG                 |   (0x40000) 256 KB
-+----------------------------------------+ <- 0x40000
-|                MAILBOX                 |   (0x1000) 4 KB
-+----------------------------------------+ <- 0x41000
-|               TEMP_STACK               |   (0x20000) 128 KB
-+----------------------------------------+ <- 0x61000
-|               TEMP_HEAP                |   (0x20000) 128 KB
-+----------------------------------------+ <- 0x81000
-|                  FREE                  |   (0x1000) 4 KB
-+----------------------------------------+ <- 0x82000
 |                PAYLOAD                 |   (0xC2D000) 12.18 MB
++----------------------------------------+ <- 0xC2D000
+|                 CONFIG                 |   (0x40000) 256 kB
++----------------------------------------+ <- 0xC6D000
+|                MAILBOX                 |   (0x1000) 4 kB
++----------------------------------------+ <- 0xC6E000
+|               TEMP_STACK               |   (0x20000) 128 kB
++----------------------------------------+ <- 0xC8E000
+|               TEMP_HEAP                |   (0x20000) 128 kB
++----------------------------------------+ <- 0xCAE000
+|                  FREE                  |   (0x1000) 4 kB
 +----------------------------------------+ <- 0xCAF000
-|                METADATA                |   (0x1000) 4 KB
+|                METADATA                |   (0x1000) 4 kB
 +----------------------------------------+ <- 0xCB0000
 |                  IPL                   |   (0x348000) 3.28 MB
 +----------------------------------------+ <- 0xFF8000
-|              RESET_VECTOR              |   (0x8000) 32 KB
+|              RESET_VECTOR              |   (0x8000) 32 kB
 +----------------------------------------+ <- 0x1000000
 Image size: 0x1000000 (16 MB)
 */
 
 // Image Layout Configuration
 
-pub const TD_SHIM_CONFIG_OFFSET: u32 = 0x0;
-pub const TD_SHIM_CONFIG_SIZE: u32 = 0x40000; // 256 KB
-
-pub const TD_SHIM_MAILBOX_OFFSET: u32 = 0x40000;
-pub const TD_SHIM_MAILBOX_SIZE: u32 = 0x1000; // 4 KB
-
-pub const TD_SHIM_TEMP_STACK_OFFSET: u32 = 0x41000;
-pub const TD_SHIM_TEMP_STACK_SIZE: u32 = 0x20000; // 128 KB
-
-pub const TD_SHIM_TEMP_HEAP_OFFSET: u32 = 0x61000;
-pub const TD_SHIM_TEMP_HEAP_SIZE: u32 = 0x20000; // 128 KB
-
-pub const TD_SHIM_FREE_OFFSET: u32 = 0x81000;
-pub const TD_SHIM_FREE_SIZE: u32 = 0x1000; // 4 KB
-
-pub const TD_SHIM_PAYLOAD_OFFSET: u32 = 0x82000;
+pub const TD_SHIM_PAYLOAD_OFFSET: u32 = 0x0;
 pub const TD_SHIM_PAYLOAD_SIZE: u32 = 0xC2D000; // 12.18 MB
 
+pub const TD_SHIM_CONFIG_OFFSET: u32 = 0xC2D000;
+pub const TD_SHIM_CONFIG_SIZE: u32 = 0x40000; // 256 kB
+
+pub const TD_SHIM_MAILBOX_OFFSET: u32 = 0xC6D000;
+pub const TD_SHIM_MAILBOX_SIZE: u32 = 0x1000; // 4 kB
+
+pub const TD_SHIM_TEMP_STACK_OFFSET: u32 = 0xC6E000;
+pub const TD_SHIM_TEMP_STACK_SIZE: u32 = 0x20000; // 128 kB
+
+pub const TD_SHIM_TEMP_HEAP_OFFSET: u32 = 0xC8E000;
+pub const TD_SHIM_TEMP_HEAP_SIZE: u32 = 0x20000; // 128 kB
+
+pub const TD_SHIM_FREE_OFFSET: u32 = 0xCAE000;
+pub const TD_SHIM_FREE_SIZE: u32 = 0x1000; // 4 kB
+
 pub const TD_SHIM_METADATA_OFFSET: u32 = 0xCAF000;
-pub const TD_SHIM_METADATA_SIZE: u32 = 0x1000; // 4 KB
+pub const TD_SHIM_METADATA_SIZE: u32 = 0x1000; // 4 kB
 
 pub const TD_SHIM_IPL_OFFSET: u32 = 0xCB0000;
 pub const TD_SHIM_IPL_SIZE: u32 = 0x348000; // 3.28 MB
 
 pub const TD_SHIM_RESET_VECTOR_OFFSET: u32 = 0xFF8000;
-pub const TD_SHIM_RESET_VECTOR_SIZE: u32 = 0x8000; // 32 KB
+pub const TD_SHIM_RESET_VECTOR_SIZE: u32 = 0x8000; // 32 kB
 
 // Offset when Loading into Memory
 pub const TD_SHIM_FIRMWARE_BASE: u32 = 0xFF000000;
@@ -67,12 +67,12 @@ pub const TD_SHIM_SEC_CORE_INFO_OFFSET: u32 = 0xFFFFAC;
 pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = 0xFFFFFFAC;
 
 // Base Address after Loaded into Memory
-pub const TD_SHIM_CONFIG_BASE: u32 = 0xFF000000;
-pub const TD_SHIM_MAILBOX_BASE: u32 = 0xFF040000;
-pub const TD_SHIM_TEMP_STACK_BASE: u32 = 0xFF041000;
-pub const TD_SHIM_TEMP_HEAP_BASE: u32 = 0xFF061000;
-pub const TD_SHIM_FREE_BASE: u32 = 0xFF081000;
-pub const TD_SHIM_PAYLOAD_BASE: u32 = 0xFF082000;
+pub const TD_SHIM_PAYLOAD_BASE: u32 = 0xFF000000;
+pub const TD_SHIM_CONFIG_BASE: u32 = 0xFFC2D000;
+pub const TD_SHIM_MAILBOX_BASE: u32 = 0xFFC6D000;
+pub const TD_SHIM_TEMP_STACK_BASE: u32 = 0xFFC6E000;
+pub const TD_SHIM_TEMP_HEAP_BASE: u32 = 0xFFC8E000;
+pub const TD_SHIM_FREE_BASE: u32 = 0xFFCAE000;
 pub const TD_SHIM_METADATA_BASE: u32 = 0xFFCAF000;
 pub const TD_SHIM_IPL_BASE: u32 = 0xFFCB0000;
 pub const TD_SHIM_RESET_VECTOR_BASE: u32 = 0xFFFF8000;

--- a/td-shim-tools/src/metadata.rs
+++ b/td-shim-tools/src/metadata.rs
@@ -8,11 +8,12 @@ use std::{mem::size_of, vec::Vec};
 use td_layout::build_time::*;
 use td_layout::runtime::*;
 use td_shim_interface::metadata::{
-    TdxMetadataDescriptor, TDX_METADATA_GUID, TDX_METADATA_SECTION_TYPE_BFV,
-    TDX_METADATA_SECTION_TYPE_CFV, TDX_METADATA_SECTION_TYPE_PAYLOAD,
-    TDX_METADATA_SECTION_TYPE_PAYLOAD_PARAM, TDX_METADATA_SECTION_TYPE_PERM_MEM,
-    TDX_METADATA_SECTION_TYPE_TD_HOB, TDX_METADATA_SECTION_TYPE_TD_INFO,
-    TDX_METADATA_SECTION_TYPE_TEMP_MEM, TDX_METADATA_SIGNATURE, TDX_METADATA_VERSION,
+    TdxMetadataDescriptor, TDX_METADATA_ATTRIBUTES_EXTENDMR, TDX_METADATA_GUID,
+    TDX_METADATA_SECTION_TYPE_BFV, TDX_METADATA_SECTION_TYPE_CFV,
+    TDX_METADATA_SECTION_TYPE_PAYLOAD, TDX_METADATA_SECTION_TYPE_PAYLOAD_PARAM,
+    TDX_METADATA_SECTION_TYPE_PERM_MEM, TDX_METADATA_SECTION_TYPE_TD_HOB,
+    TDX_METADATA_SECTION_TYPE_TD_INFO, TDX_METADATA_SECTION_TYPE_TEMP_MEM, TDX_METADATA_SIGNATURE,
+    TDX_METADATA_VERSION,
 };
 use td_shim_interface::td_uefi_pi::pi::guid::Guid;
 
@@ -100,35 +101,14 @@ impl MetadataSections {
     }
 }
 
-fn basic_metadata_sections(payload_type: PayloadType) -> MetadataSections {
-    use td_shim_interface::metadata::TDX_METADATA_ATTRIBUTES_EXTENDMR;
-
+fn basic_metadata_sections() -> MetadataSections {
     let mut metadata_sections = MetadataSections::new();
 
-    // BFV
-    let bfv_offset =
-        if cfg!(any(feature = "exec-payload-section")) || payload_type == PayloadType::Linux {
-            TD_SHIM_METADATA_OFFSET
-        } else {
-            TD_SHIM_PAYLOAD_OFFSET
-        };
-
+    // BFV (Reset Vector, IPL and Metadata)
+    let bfv_offset = TD_SHIM_METADATA_OFFSET;
     let bfv_data_size =
-        if cfg!(any(feature = "exec-payload-section")) || payload_type == PayloadType::Linux {
-            (TD_SHIM_METADATA_SIZE + TD_SHIM_IPL_SIZE + TD_SHIM_RESET_VECTOR_SIZE) as u64
-        } else {
-            (TD_SHIM_PAYLOAD_SIZE
-                + TD_SHIM_METADATA_SIZE
-                + TD_SHIM_IPL_SIZE
-                + TD_SHIM_RESET_VECTOR_SIZE) as u64
-        };
-
-    let bfv_memory_address =
-        if cfg!(any(feature = "exec-payload-section")) || payload_type == PayloadType::Linux {
-            TD_SHIM_METADATA_BASE
-        } else {
-            TD_SHIM_PAYLOAD_BASE
-        };
+        (TD_SHIM_METADATA_SIZE + TD_SHIM_IPL_SIZE + TD_SHIM_RESET_VECTOR_SIZE) as u64;
+    let bfv_memory_address = TD_SHIM_METADATA_BASE;
 
     metadata_sections.add(TdxMetadataSection {
         data_offset: bfv_offset,
@@ -183,7 +163,7 @@ fn basic_metadata_sections(payload_type: PayloadType) -> MetadataSections {
 }
 
 pub fn default_metadata_sections(payload_type: PayloadType) -> MetadataSections {
-    let mut metadata_sections = basic_metadata_sections(payload_type);
+    let mut metadata_sections = basic_metadata_sections();
 
     if payload_type == PayloadType::Linux {
         // TD_HOB
@@ -226,18 +206,21 @@ pub fn default_metadata_sections(payload_type: PayloadType) -> MetadataSections 
             attributes: 0,
         });
 
-        if cfg!(feature = "exec-payload-section") {
-            println!("default_metadata_sections_exec_payload");
-            // payload image
-            metadata_sections.add(TdxMetadataSection {
-                data_offset: TD_SHIM_PAYLOAD_OFFSET,
-                raw_data_size: TD_SHIM_PAYLOAD_SIZE,
-                memory_address: TD_SHIM_PAYLOAD_BASE as u64,
-                memory_data_size: TD_SHIM_PAYLOAD_SIZE as u64,
-                r#type: TDX_METADATA_SECTION_TYPE_PAYLOAD,
-                attributes: 0,
-            });
-        }
+        // payload image
+        metadata_sections.add(TdxMetadataSection {
+            data_offset: TD_SHIM_PAYLOAD_OFFSET,
+            raw_data_size: TD_SHIM_PAYLOAD_SIZE as u32,
+            memory_address: TD_SHIM_PAYLOAD_BASE as u64,
+            memory_data_size: TD_SHIM_PAYLOAD_SIZE as u64,
+            #[cfg(feature = "exec-payload-section")]
+            r#type: TDX_METADATA_SECTION_TYPE_PAYLOAD,
+            #[cfg(not(feature = "exec-payload-section"))]
+            r#type: TDX_METADATA_SECTION_TYPE_BFV,
+            #[cfg(feature = "exec-payload-section")]
+            attributes: 0,
+            #[cfg(not(feature = "exec-payload-section"))]
+            attributes: TDX_METADATA_ATTRIBUTES_EXTENDMR,
+        });
     }
 
     metadata_sections


### PR DESCRIPTION
 - Seperate the image file layout and ROM layout in the internal implementation
 - Remove the payload region from image layout and add it into memory configuration.