### PR TITLE
devtools: adjust image config to make the sum of region sizes align 0x10000

### DIFF
--- a/devtools/td-layout-config/config_image.json
+++ b/devtools/td-layout-config/config_image.json
@@ -5,6 +5,6 @@
     "TempHeap": "0x020000",
     "Metadata": "0x001000",
     "Payload": "0xC2D000",
-    "Ipl": "0x348000",
+    "Ipl": "0x349000",
     "ResetVector": "0x008000"
 }


### PR DESCRIPTION
The bios image size alignment is checked by qemu. Remove the unused hole in the image