### PR TITLE
td-layout: generate new layout with modified `td-layout-config`

### DIFF
--- a/devtools/td-layout-config/config_image.json
+++ b/devtools/td-layout-config/config_image.json
@@ -5,6 +5,6 @@
     "TempStack": "0x020000",
     "TempHeap": "0x020000",
     "Metadata": "0x001000",
-    "Ipl": "0x348000",
+    "Ipl": "0x349000",
     "ResetVector": "0x008000"
 }

--- a/devtools/td-layout-config/config_image.json
+++ b/devtools/td-layout-config/config_image.json
@@ -1,10 +1,10 @@
 {
+    "Payload": "0xC2D000",
     "Config": "0x040000",
     "Mailbox": "0x001000",
     "TempStack": "0x020000",
     "TempHeap": "0x020000",
     "Metadata": "0x001000",
-    "Payload": "0xC2D000",
     "Ipl": "0x348000",
     "ResetVector": "0x008000"
 }

--- a/devtools/td-layout-config/src/image.rs
+++ b/devtools/td-layout-config/src/image.rs
@@ -4,6 +4,8 @@ use super::{layout::LayoutConfig, render};
 
 #[derive(Deserialize, Debug, PartialEq)]
 struct ImageConfig {
+    #[serde(rename = "Payload")]
+    builtin_payload: Option<String>,
     #[serde(rename = "Config")]
     config: String,
     #[serde(rename = "Mailbox")]
@@ -12,8 +14,6 @@ struct ImageConfig {
     temp_stack: String,
     #[serde(rename = "TempHeap")]
     temp_heap: String,
-    #[serde(rename = "Payload")]
-    builtin_payload: Option<String>,
     #[serde(rename = "TdInfo")]
     td_info: Option<String>,
     #[serde(rename = "Metadata")]
@@ -29,6 +29,14 @@ pub fn parse_image(data: String) -> String {
         .expect("Content is configuration file is invalid");
 
     let mut image_layout = LayoutConfig::new(0, 0x100_0000);
+
+    if let Some(payload_config) = image_config.builtin_payload {
+        image_layout.reserve_low(
+            "Payload",
+            parse_int::parse::<u32>(&payload_config).unwrap() as usize,
+            "Reserved",
+        )
+    }
     image_layout.reserve_low(
         "Config",
         parse_int::parse::<u32>(&image_config.config).unwrap() as usize,
@@ -71,14 +79,6 @@ pub fn parse_image(data: String) -> String {
         image_layout.reserve_high(
             "TdInfo",
             parse_int::parse::<u32>(&td_info_config).unwrap() as usize,
-            "Reserved",
-        )
-    }
-
-    if let Some(payload_config) = image_config.builtin_payload {
-        image_layout.reserve_high(
-            "Payload",
-            parse_int::parse::<u32>(&payload_config).unwrap() as usize,
             "Reserved",
         )
     }

--- a/td-layout/src/build_time.rs
+++ b/td-layout/src/build_time.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2023  Intel Corporation
+// Copyright (c) 2021 - 2024  Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -7,55 +7,55 @@
 /*
 Image Layout
 +----------------------------------------+ <- 0x0
-|                 CONFIG                 |   (0x40000) 256 KB
-+----------------------------------------+ <- 0x40000
-|                MAILBOX                 |   (0x1000) 4 KB
-+----------------------------------------+ <- 0x41000
-|               TEMP_STACK               |   (0x20000) 128 KB
-+----------------------------------------+ <- 0x61000
-|               TEMP_HEAP                |   (0x20000) 128 KB
-+----------------------------------------+ <- 0x81000
-|                  FREE                  |   (0x1000) 4 KB
-+----------------------------------------+ <- 0x82000
 |                PAYLOAD                 |   (0xC2D000) 12.18 MB
++----------------------------------------+ <- 0xC2D000
+|                 CONFIG                 |   (0x40000) 256 kB
++----------------------------------------+ <- 0xC6D000
+|                MAILBOX                 |   (0x1000) 4 kB
++----------------------------------------+ <- 0xC6E000
+|               TEMP_STACK               |   (0x20000) 128 kB
++----------------------------------------+ <- 0xC8E000
+|               TEMP_HEAP                |   (0x20000) 128 kB
++----------------------------------------+ <- 0xCAE000
+|                  FREE                  |   (0x1000) 4 kB
 +----------------------------------------+ <- 0xCAF000
-|                METADATA                |   (0x1000) 4 KB
+|                METADATA                |   (0x1000) 4 kB
 +----------------------------------------+ <- 0xCB0000
 |                  IPL                   |   (0x348000) 3.28 MB
 +----------------------------------------+ <- 0xFF8000
-|              RESET_VECTOR              |   (0x8000) 32 KB
+|              RESET_VECTOR              |   (0x8000) 32 kB
 +----------------------------------------+ <- 0x1000000
 Image size: 0x1000000 (16 MB)
 */
 
 // Image Layout Configuration
 
-pub const TD_SHIM_CONFIG_OFFSET: u32 = 0x0;
-pub const TD_SHIM_CONFIG_SIZE: u32 = 0x40000; // 256 KB
-
-pub const TD_SHIM_MAILBOX_OFFSET: u32 = 0x40000;
-pub const TD_SHIM_MAILBOX_SIZE: u32 = 0x1000; // 4 KB
-
-pub const TD_SHIM_TEMP_STACK_OFFSET: u32 = 0x41000;
-pub const TD_SHIM_TEMP_STACK_SIZE: u32 = 0x20000; // 128 KB
-
-pub const TD_SHIM_TEMP_HEAP_OFFSET: u32 = 0x61000;
-pub const TD_SHIM_TEMP_HEAP_SIZE: u32 = 0x20000; // 128 KB
-
-pub const TD_SHIM_FREE_OFFSET: u32 = 0x81000;
-pub const TD_SHIM_FREE_SIZE: u32 = 0x1000; // 4 KB
-
-pub const TD_SHIM_PAYLOAD_OFFSET: u32 = 0x82000;
+pub const TD_SHIM_PAYLOAD_OFFSET: u32 = 0x0;
 pub const TD_SHIM_PAYLOAD_SIZE: u32 = 0xC2D000; // 12.18 MB
 
+pub const TD_SHIM_CONFIG_OFFSET: u32 = 0xC2D000;
+pub const TD_SHIM_CONFIG_SIZE: u32 = 0x40000; // 256 kB
+
+pub const TD_SHIM_MAILBOX_OFFSET: u32 = 0xC6D000;
+pub const TD_SHIM_MAILBOX_SIZE: u32 = 0x1000; // 4 kB
+
+pub const TD_SHIM_TEMP_STACK_OFFSET: u32 = 0xC6E000;
+pub const TD_SHIM_TEMP_STACK_SIZE: u32 = 0x20000; // 128 kB
+
+pub const TD_SHIM_TEMP_HEAP_OFFSET: u32 = 0xC8E000;
+pub const TD_SHIM_TEMP_HEAP_SIZE: u32 = 0x20000; // 128 kB
+
+pub const TD_SHIM_FREE_OFFSET: u32 = 0xCAE000;
+pub const TD_SHIM_FREE_SIZE: u32 = 0x1000; // 4 kB
+
 pub const TD_SHIM_METADATA_OFFSET: u32 = 0xCAF000;
-pub const TD_SHIM_METADATA_SIZE: u32 = 0x1000; // 4 KB
+pub const TD_SHIM_METADATA_SIZE: u32 = 0x1000; // 4 kB
 
 pub const TD_SHIM_IPL_OFFSET: u32 = 0xCB0000;
 pub const TD_SHIM_IPL_SIZE: u32 = 0x348000; // 3.28 MB
 
 pub const TD_SHIM_RESET_VECTOR_OFFSET: u32 = 0xFF8000;
-pub const TD_SHIM_RESET_VECTOR_SIZE: u32 = 0x8000; // 32 KB
+pub const TD_SHIM_RESET_VECTOR_SIZE: u32 = 0x8000; // 32 kB
 
 // Offset when Loading into Memory
 pub const TD_SHIM_FIRMWARE_BASE: u32 = 0xFF000000;
@@ -67,12 +67,12 @@ pub const TD_SHIM_SEC_CORE_INFO_OFFSET: u32 = 0xFFFFAC;
 pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = 0xFFFFFFAC;
 
 // Base Address after Loaded into Memory
-pub const TD_SHIM_CONFIG_BASE: u32 = 0xFF000000;
-pub const TD_SHIM_MAILBOX_BASE: u32 = 0xFF040000;
-pub const TD_SHIM_TEMP_STACK_BASE: u32 = 0xFF041000;
-pub const TD_SHIM_TEMP_HEAP_BASE: u32 = 0xFF061000;
-pub const TD_SHIM_FREE_BASE: u32 = 0xFF081000;
-pub const TD_SHIM_PAYLOAD_BASE: u32 = 0xFF082000;
+pub const TD_SHIM_PAYLOAD_BASE: u32 = 0xFF000000;
+pub const TD_SHIM_CONFIG_BASE: u32 = 0xFFC2D000;
+pub const TD_SHIM_MAILBOX_BASE: u32 = 0xFFC6D000;
+pub const TD_SHIM_TEMP_STACK_BASE: u32 = 0xFFC6E000;
+pub const TD_SHIM_TEMP_HEAP_BASE: u32 = 0xFFC8E000;
+pub const TD_SHIM_FREE_BASE: u32 = 0xFFCAE000;
 pub const TD_SHIM_METADATA_BASE: u32 = 0xFFCAF000;
 pub const TD_SHIM_IPL_BASE: u32 = 0xFFCB0000;
 pub const TD_SHIM_RESET_VECTOR_BASE: u32 = 0xFFFF8000;

--- a/td-layout/src/build_time.rs
+++ b/td-layout/src/build_time.rs
@@ -17,62 +17,53 @@ Image Layout
 +----------------------------------------+ <- 0xC8E000
 |               TEMP_HEAP                |   (0x20000) 128 kB
 +----------------------------------------+ <- 0xCAE000
-|                  FREE                  |   (0x1000) 4 kB
-+----------------------------------------+ <- 0xCAF000
+|                  FREE                  |   (0x0) 0 B
++----------------------------------------+ <- 0xCAE000
 |                METADATA                |   (0x1000) 4 kB
-+----------------------------------------+ <- 0xCB0000
-|                  IPL                   |   (0x348000) 3.28 MB
++----------------------------------------+ <- 0xCAF000
+|                  IPL                   |   (0x349000) 3.29 MB
 +----------------------------------------+ <- 0xFF8000
 |              RESET_VECTOR              |   (0x8000) 32 kB
 +----------------------------------------+ <- 0x1000000
 Image size: 0x1000000 (16 MB)
 */
 
-// Image Layout Configuration
-
+// Image configuration
+pub const TD_SHIM_IMAGE_SIZE: u32 = 0x1000000;
 pub const TD_SHIM_PAYLOAD_OFFSET: u32 = 0x0;
-pub const TD_SHIM_PAYLOAD_SIZE: u32 = 0xC2D000; // 12.18 MB
-
 pub const TD_SHIM_CONFIG_OFFSET: u32 = 0xC2D000;
-pub const TD_SHIM_CONFIG_SIZE: u32 = 0x40000; // 256 kB
-
 pub const TD_SHIM_MAILBOX_OFFSET: u32 = 0xC6D000;
-pub const TD_SHIM_MAILBOX_SIZE: u32 = 0x1000; // 4 kB
-
 pub const TD_SHIM_TEMP_STACK_OFFSET: u32 = 0xC6E000;
-pub const TD_SHIM_TEMP_STACK_SIZE: u32 = 0x20000; // 128 kB
-
 pub const TD_SHIM_TEMP_HEAP_OFFSET: u32 = 0xC8E000;
-pub const TD_SHIM_TEMP_HEAP_SIZE: u32 = 0x20000; // 128 kB
-
 pub const TD_SHIM_FREE_OFFSET: u32 = 0xCAE000;
-pub const TD_SHIM_FREE_SIZE: u32 = 0x1000; // 4 kB
-
-pub const TD_SHIM_METADATA_OFFSET: u32 = 0xCAF000;
-pub const TD_SHIM_METADATA_SIZE: u32 = 0x1000; // 4 kB
-
-pub const TD_SHIM_IPL_OFFSET: u32 = 0xCB0000;
-pub const TD_SHIM_IPL_SIZE: u32 = 0x348000; // 3.28 MB
-
+pub const TD_SHIM_METADATA_OFFSET: u32 = 0xCAE000;
+pub const TD_SHIM_IPL_OFFSET: u32 = 0xCAF000;
 pub const TD_SHIM_RESET_VECTOR_OFFSET: u32 = 0xFF8000;
-pub const TD_SHIM_RESET_VECTOR_SIZE: u32 = 0x8000; // 32 kB
 
-// Offset when Loading into Memory
-pub const TD_SHIM_FIRMWARE_BASE: u32 = 0xFF000000;
-pub const TD_SHIM_FIRMWARE_SIZE: u32 = 0x1000000;
+// Size of regions
+pub const TD_SHIM_PAYLOAD_SIZE: u32 = 0xC2D000;
+pub const TD_SHIM_CONFIG_SIZE: u32 = 0x40000;
+pub const TD_SHIM_MAILBOX_SIZE: u32 = 0x1000;
+pub const TD_SHIM_TEMP_STACK_SIZE: u32 = 0x20000;
+pub const TD_SHIM_TEMP_HEAP_SIZE: u32 = 0x20000;
+pub const TD_SHIM_FREE_SIZE: u32 = 0x0;
+pub const TD_SHIM_METADATA_SIZE: u32 = 0x1000;
+pub const TD_SHIM_IPL_SIZE: u32 = 0x349000;
+pub const TD_SHIM_RESET_VECTOR_SIZE: u32 = 0x8000;
 
-// TD_SHIM_SEC_INFO_OFFSET equals to firmware size - metadata pointer offset -
-// OVMF GUID table size - SEC Core information size.
-pub const TD_SHIM_SEC_CORE_INFO_OFFSET: u32 = 0xFFFFAC;
-pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = 0xFFFFFFAC;
-
-// Base Address after Loaded into Memory
-pub const TD_SHIM_PAYLOAD_BASE: u32 = 0xFF000000;
+// ROM configuration
+pub const TD_SHIM_FIRMWARE_BASE: u32 = 0xFFC2D000;
+pub const TD_SHIM_FIRMWARE_SIZE: u32 = 0x3D3000;
 pub const TD_SHIM_CONFIG_BASE: u32 = 0xFFC2D000;
 pub const TD_SHIM_MAILBOX_BASE: u32 = 0xFFC6D000;
 pub const TD_SHIM_TEMP_STACK_BASE: u32 = 0xFFC6E000;
 pub const TD_SHIM_TEMP_HEAP_BASE: u32 = 0xFFC8E000;
 pub const TD_SHIM_FREE_BASE: u32 = 0xFFCAE000;
-pub const TD_SHIM_METADATA_BASE: u32 = 0xFFCAF000;
-pub const TD_SHIM_IPL_BASE: u32 = 0xFFCB0000;
+pub const TD_SHIM_METADATA_BASE: u32 = 0xFFCAE000;
+pub const TD_SHIM_IPL_BASE: u32 = 0xFFCAF000;
 pub const TD_SHIM_RESET_VECTOR_BASE: u32 = 0xFFFF8000;
+
+// TD_SHIM_SEC_INFO_OFFSET equals to firmware size - metadata pointer offset -
+// OVMF GUID table size - SEC Core information size.
+pub const TD_SHIM_SEC_CORE_INFO_OFFSET: u32 = 0xFFFFAC;
+pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = 0xFFFFFFAC;

--- a/td-layout/src/memslice.rs
+++ b/td-layout/src/memslice.rs
@@ -12,7 +12,7 @@ pub enum SliceType {
     Config,
     /// The `TD_HOB` region in image file
     TdHob,
-    /// The `Payload and Metadata` region in image file
+    /// The `Payload Image` region in runtime memory layout
     ShimPayload,
     /// The `TD_MAILBOX` region in image file
     MailBox,
@@ -69,10 +69,6 @@ pub fn get_mem_slice<'a>(t: SliceType) -> &'a [u8] {
                 TD_SHIM_CONFIG_BASE as *const u8,
                 TD_SHIM_CONFIG_SIZE as usize,
             ),
-            SliceType::ShimPayload => core::slice::from_raw_parts(
-                TD_SHIM_PAYLOAD_BASE as *const u8,
-                TD_SHIM_PAYLOAD_SIZE as usize,
-            ),
             SliceType::MailBox => core::slice::from_raw_parts(
                 TD_SHIM_MAILBOX_BASE as *const u8,
                 TD_SHIM_MAILBOX_SIZE as usize,
@@ -94,7 +90,7 @@ pub unsafe fn get_mem_slice_mut<'a>(t: SliceType) -> &'a mut [u8] {
             TD_SHIM_MAILBOX_BASE as *const u8 as *mut u8,
             TD_SHIM_MAILBOX_SIZE as usize,
         ),
-        SliceType::Config | SliceType::ShimPayload => {
+        SliceType::Config => {
             panic!("get_mem_slice_mut: read only")
         }
         _ => panic!("get_mem_slice_mut: not support"),
@@ -109,12 +105,6 @@ mod test {
     fn test_get_mem_slice_with_type_config() {
         let config = get_mem_slice(SliceType::Config);
         assert_eq!(config.len(), TD_SHIM_CONFIG_SIZE as usize);
-    }
-
-    #[test]
-    fn test_get_mem_slice_with_type_builtin_payload() {
-        let payload = get_mem_slice(SliceType::ShimPayload);
-        assert_eq!(payload.len(), TD_SHIM_PAYLOAD_SIZE as usize);
     }
 
     #[test]
@@ -151,14 +141,6 @@ mod test {
     fn test_get_mem_slice_mut_with_type_mailbox() {
         let mailbox = unsafe { get_mem_slice_mut(SliceType::MailBox) };
         assert_eq!(mailbox.len(), TD_SHIM_MAILBOX_SIZE as usize);
-    }
-
-    #[test]
-    #[should_panic(expected = "get_mem_slice_mut: read only")]
-    fn test_get_mem_slice_mut_with_type_builtin_payload() {
-        unsafe {
-            get_mem_slice_mut(SliceType::ShimPayload);
-        }
     }
 
     #[test]

--- a/td-layout/src/runtime/exec.rs
+++ b/td-layout/src/runtime/exec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2023  Intel Corporation
+// Copyright (c) 2021 - 2024  Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -10,40 +10,45 @@ Top of Low Memory: 0x80000000
 +----------------------------------------+ <- 0x80000000
 |               EVENT_LOG                |   (0x100000) 1 MB
 +----------------------------------------+ <- 0x7FF00000
-|           RELOCATED_MAILBOX            |   (0x2000) 8 KB
+|           RELOCATED_MAILBOX            |   (0x2000) 8 kB
 +----------------------------------------+ <- 0x7FEFE000
-|           PAYLOAD_PAGE_TABLE           |   (0x20000) 128 KB
+|           PAYLOAD_PAGE_TABLE           |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x7FEDE000
 |                PAYLOAD                 |   (0x2000000) 32 MB
 +----------------------------------------+ <- 0x7DEDE000
 |                  ACPI                  |   (0x100000) 1 MB
 +----------------------------------------+ <- 0x7DDDE000
-|                  FREE                  |   (0x7D5BE000) 1.96 GB
+|                  FREE                  |   (0x7C991000) 1.95 GB
++----------------------------------------+ <- 0x144D000
+|              SHIM_PAYLOAD              |   (0xC2D000) 12.18 MB
 +----------------------------------------+ <- 0x820000
-|                 TD_HOB                 |   (0x20000) 128 KB
+|                 TD_HOB                 |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x800000
 |               BOOTLOADER               |   (0x800000) 8 MB
 +----------------------------------------+ <- 0x0
-Total Usage: 0x2A42000 (42.26 MB)
+Total Usage: 0x366F000 (54.43 MB)
 */
 
-pub const TOTAL_USAGE: usize = 0x2A42000; // (42.26 MB)
+pub const TOTAL_USAGE: usize = 0x366F000; // (54.43 MB)
 
 // Runtime Layout Configuration
 pub const BOOTLOADER_BASE: usize = 0x0;
 pub const BOOTLOADER_SIZE: usize = 0x800000; // 8 MB
 pub const TD_HOB_BASE: usize = 0x800000;
-pub const TD_HOB_SIZE: usize = 0x20000; // 128 KB
+pub const TD_HOB_SIZE: usize = 0x20000; // 128 kB
+pub const SHIM_PAYLOAD_BASE: usize = 0x820000;
+pub const SHIM_PAYLOAD_SIZE: usize = 0xC2D000; // 12.18 MB
 pub const ACPI_SIZE: usize = 0x100000; // 1 MB
 pub const PAYLOAD_SIZE: usize = 0x2000000; // 32 MB
-pub const PAYLOAD_PAGE_TABLE_SIZE: usize = 0x20000; // 128 KB
-pub const RELOCATED_MAILBOX_SIZE: usize = 0x2000; // 8 KB
+pub const PAYLOAD_PAGE_TABLE_SIZE: usize = 0x20000; // 128 kB
+pub const RELOCATED_MAILBOX_SIZE: usize = 0x2000; // 8 kB
 pub const EVENT_LOG_SIZE: usize = 0x100000; // 1 MB
 
-pub const MEMORY_LAYOUT_CONFIG: &[(&str, usize, &str)] = &[
+pub const MEMORY_LAYOUT_CONFIG: &[(&'static str, usize, &'static str)] = &[
     // (name of memory region, region size, region type)
     ("Bootloader", 0x800000, "Memory"),
     ("TdHob", 0x20000, "Memory"),
+    ("ShimPayload", 0xC2D000, "Memory"),
     ("Acpi", 0x100000, "Acpi"),
     ("Payload", 0x2000000, "Reserved"),
     ("PayloadPageTable", 0x20000, "Reserved"),

--- a/td-shim-tools/src/linker.rs
+++ b/td-shim-tools/src/linker.rs
@@ -10,11 +10,12 @@ use log::trace;
 use r_efi::base::Guid;
 use scroll::Pwrite;
 use td_layout::build_time::{
-    TD_SHIM_FIRMWARE_BASE, TD_SHIM_FIRMWARE_SIZE, TD_SHIM_IPL_OFFSET, TD_SHIM_IPL_SIZE,
-    TD_SHIM_MAILBOX_OFFSET, TD_SHIM_METADATA_OFFSET, TD_SHIM_PAYLOAD_BASE, TD_SHIM_PAYLOAD_OFFSET,
-    TD_SHIM_PAYLOAD_SIZE, TD_SHIM_RESET_VECTOR_SIZE, TD_SHIM_SEC_CORE_INFO_OFFSET,
+    TD_SHIM_IMAGE_SIZE, TD_SHIM_IPL_BASE, TD_SHIM_IPL_OFFSET, TD_SHIM_IPL_SIZE,
+    TD_SHIM_MAILBOX_OFFSET, TD_SHIM_METADATA_OFFSET, TD_SHIM_PAYLOAD_OFFSET, TD_SHIM_PAYLOAD_SIZE,
+    TD_SHIM_RESET_VECTOR_OFFSET, TD_SHIM_RESET_VECTOR_SIZE, TD_SHIM_SEC_CORE_INFO_OFFSET,
 };
 use td_layout::mailbox::TdxMpWakeupMailbox;
+use td_layout::runtime::exec::SHIM_PAYLOAD_BASE;
 use td_loader::{elf, pe};
 use td_shim::fv::{
     FvFfsFileHeader, FvFfsSectionHeader, FvHeader, IplFvFfsHeader, IplFvFfsSectionHeader,
@@ -247,7 +248,7 @@ pub fn build_ovmf_guid_table() -> Vec<u8> {
     let mut table = Vec::new();
 
     let metadata_offset =
-        TD_SHIM_FIRMWARE_SIZE - (TD_SHIM_METADATA_OFFSET + size_of::<TdxMetadataGuid>() as u32);
+        TD_SHIM_IMAGE_SIZE - (TD_SHIM_METADATA_OFFSET + size_of::<TdxMetadataGuid>() as u32);
     let metadata_block_size = size_of::<u32>() + size_of::<u16>() + size_of::<Guid>();
 
     // The data layout of the entry is:
@@ -376,7 +377,7 @@ impl TdShimLinker {
                 let reloc = pe::relocate(
                     &payload_bin.data,
                     &mut payload_reloc_buf,
-                    TD_SHIM_PAYLOAD_BASE as usize + payload_header.data.len(),
+                    SHIM_PAYLOAD_BASE as usize,
                 )
                 .ok_or_else(|| {
                     io::Error::new(io::ErrorKind::Other, "Can not relocate payload content")
@@ -409,21 +410,28 @@ impl TdShimLinker {
             0x100000
         );
         let entry_point = (reloc.0 - 0x100000) as u32;
-        let current_pos = output_file.current_pos()?;
         let reset_vector_info = ResetVectorParams {
             entry_point,
-            img_base: TD_SHIM_FIRMWARE_BASE + current_pos as u32,
+            img_base: TD_SHIM_IPL_BASE + size_of::<IplFvHeaderByte>() as u32,
             img_size: ipl_bin.data.len() as u32,
         };
 
         output_file.write(&ipl_reloc_buf, "internal payload content")?;
 
         let reset_vector_header = ResetVectorHeader::build_tdx_reset_vector_header();
-        output_file.write(reset_vector_header.as_bytes(), "reset vector header")?;
-        output_file.write(&reset_vector_bin.data, "reset vector content")?;
+        output_file.seek_and_write(
+            TD_SHIM_RESET_VECTOR_OFFSET as u64 - size_of::<ResetVectorHeader>() as u64,
+            reset_vector_header.as_bytes(),
+            "reset vector header",
+        )?;
+        output_file.seek_and_write(
+            TD_SHIM_RESET_VECTOR_OFFSET as u64,
+            &reset_vector_bin.data,
+            "reset vector content",
+        )?;
 
         let current_pos = output_file.current_pos()?;
-        assert_eq!(current_pos, TD_SHIM_FIRMWARE_SIZE as u64);
+        assert_eq!(current_pos, TD_SHIM_IMAGE_SIZE as u64);
 
         // Overwrite the ResetVectorParams and TdxMetadataPtr.
         let pos = TD_SHIM_SEC_CORE_INFO_OFFSET as u64;
@@ -433,7 +441,7 @@ impl TdShimLinker {
         let ovmf_guid_table = build_ovmf_guid_table();
         assert_eq!(
             ovmf_guid_table.len(),
-            (TD_SHIM_FIRMWARE_SIZE - TD_SHIM_SEC_CORE_INFO_OFFSET) as usize
+            (TD_SHIM_IMAGE_SIZE - TD_SHIM_SEC_CORE_INFO_OFFSET) as usize
                 - size_of::<ResetVectorParams>()
                 - 0x20
         );

--- a/td-shim-tools/src/metadata.rs
+++ b/td-shim-tools/src/metadata.rs
@@ -6,6 +6,7 @@ use serde::de::Error;
 use serde::{de, Deserialize};
 use std::{mem::size_of, vec::Vec};
 use td_layout::build_time::*;
+use td_layout::runtime::exec::SHIM_PAYLOAD_BASE;
 use td_layout::runtime::*;
 use td_shim_interface::metadata::{
     TdxMetadataDescriptor, TDX_METADATA_ATTRIBUTES_EXTENDMR, TDX_METADATA_GUID,
@@ -210,7 +211,7 @@ pub fn default_metadata_sections(payload_type: PayloadType) -> MetadataSections 
         metadata_sections.add(TdxMetadataSection {
             data_offset: TD_SHIM_PAYLOAD_OFFSET,
             raw_data_size: TD_SHIM_PAYLOAD_SIZE as u32,
-            memory_address: TD_SHIM_PAYLOAD_BASE as u64,
+            memory_address: SHIM_PAYLOAD_BASE as u64,
             memory_data_size: TD_SHIM_PAYLOAD_SIZE as u64,
             #[cfg(feature = "exec-payload-section")]
             r#type: TDX_METADATA_SECTION_TYPE_PAYLOAD,

--- a/td-shim-tools/src/metadata.rs
+++ b/td-shim-tools/src/metadata.rs
@@ -8,11 +8,12 @@ use std::{mem::size_of, vec::Vec};
 use td_layout::build_time::*;
 use td_layout::runtime::*;
 use td_shim_interface::metadata::{
-    TdxMetadataDescriptor, TDX_METADATA_GUID, TDX_METADATA_SECTION_TYPE_BFV,
-    TDX_METADATA_SECTION_TYPE_CFV, TDX_METADATA_SECTION_TYPE_PAYLOAD,
-    TDX_METADATA_SECTION_TYPE_PAYLOAD_PARAM, TDX_METADATA_SECTION_TYPE_PERM_MEM,
-    TDX_METADATA_SECTION_TYPE_TD_HOB, TDX_METADATA_SECTION_TYPE_TD_INFO,
-    TDX_METADATA_SECTION_TYPE_TEMP_MEM, TDX_METADATA_SIGNATURE, TDX_METADATA_VERSION,
+    TdxMetadataDescriptor, TDX_METADATA_ATTRIBUTES_EXTENDMR, TDX_METADATA_GUID,
+    TDX_METADATA_SECTION_TYPE_BFV, TDX_METADATA_SECTION_TYPE_CFV,
+    TDX_METADATA_SECTION_TYPE_PAYLOAD, TDX_METADATA_SECTION_TYPE_PAYLOAD_PARAM,
+    TDX_METADATA_SECTION_TYPE_PERM_MEM, TDX_METADATA_SECTION_TYPE_TD_HOB,
+    TDX_METADATA_SECTION_TYPE_TD_INFO, TDX_METADATA_SECTION_TYPE_TEMP_MEM, TDX_METADATA_SIGNATURE,
+    TDX_METADATA_VERSION,
 };
 use td_shim_interface::td_uefi_pi::pi::guid::Guid;
 
@@ -100,35 +101,14 @@ impl MetadataSections {
     }
 }
 
-fn basic_metadata_sections(payload_type: PayloadType) -> MetadataSections {
-    use td_shim_interface::metadata::TDX_METADATA_ATTRIBUTES_EXTENDMR;
-
+fn basic_metadata_sections() -> MetadataSections {
     let mut metadata_sections = MetadataSections::new();
 
-    // BFV
-    let bfv_offset =
-        if cfg!(any(feature = "exec-payload-section")) || payload_type == PayloadType::Linux {
-            TD_SHIM_METADATA_OFFSET
-        } else {
-            TD_SHIM_PAYLOAD_OFFSET
-        };
-
+    // BFV (Reset Vector, IPL and Metadata)
+    let bfv_offset = TD_SHIM_METADATA_OFFSET;
     let bfv_data_size =
-        if cfg!(any(feature = "exec-payload-section")) || payload_type == PayloadType::Linux {
-            (TD_SHIM_METADATA_SIZE + TD_SHIM_IPL_SIZE + TD_SHIM_RESET_VECTOR_SIZE) as u64
-        } else {
-            (TD_SHIM_PAYLOAD_SIZE
-                + TD_SHIM_METADATA_SIZE
-                + TD_SHIM_IPL_SIZE
-                + TD_SHIM_RESET_VECTOR_SIZE) as u64
-        };
-
-    let bfv_memory_address =
-        if cfg!(any(feature = "exec-payload-section")) || payload_type == PayloadType::Linux {
-            TD_SHIM_METADATA_BASE
-        } else {
-            TD_SHIM_PAYLOAD_BASE
-        };
+        (TD_SHIM_METADATA_SIZE + TD_SHIM_IPL_SIZE + TD_SHIM_RESET_VECTOR_SIZE) as u64;
+    let bfv_memory_address = TD_SHIM_METADATA_BASE;
 
     metadata_sections.add(TdxMetadataSection {
         data_offset: bfv_offset,
@@ -183,7 +163,7 @@ fn basic_metadata_sections(payload_type: PayloadType) -> MetadataSections {
 }
 
 pub fn default_metadata_sections(payload_type: PayloadType) -> MetadataSections {
-    let mut metadata_sections = basic_metadata_sections(payload_type);
+    let mut metadata_sections = basic_metadata_sections();
 
     if payload_type == PayloadType::Linux {
         // TD_HOB
@@ -226,18 +206,21 @@ pub fn default_metadata_sections(payload_type: PayloadType) -> MetadataSections 
             attributes: 0,
         });
 
-        if cfg!(feature = "exec-payload-section") {
-            println!("default_metadata_sections_exec_payload");
-            // payload image
-            metadata_sections.add(TdxMetadataSection {
-                data_offset: TD_SHIM_PAYLOAD_OFFSET,
-                raw_data_size: TD_SHIM_PAYLOAD_SIZE,
-                memory_address: TD_SHIM_PAYLOAD_BASE as u64,
-                memory_data_size: TD_SHIM_PAYLOAD_SIZE as u64,
-                r#type: TDX_METADATA_SECTION_TYPE_PAYLOAD,
-                attributes: 0,
-            });
-        }
+        // payload image
+        metadata_sections.add(TdxMetadataSection {
+            data_offset: TD_SHIM_PAYLOAD_OFFSET,
+            raw_data_size: TD_SHIM_PAYLOAD_SIZE as u32,
+            memory_address: TD_SHIM_PAYLOAD_BASE as u64,
+            memory_data_size: TD_SHIM_PAYLOAD_SIZE as u64,
+            #[cfg(feature = "exec-payload-section")]
+            r#type: TDX_METADATA_SECTION_TYPE_PAYLOAD,
+            #[cfg(not(feature = "exec-payload-section"))]
+            r#type: TDX_METADATA_SECTION_TYPE_BFV,
+            #[cfg(feature = "exec-payload-section")]
+            attributes: 0,
+            #[cfg(not(feature = "exec-payload-section"))]
+            attributes: TDX_METADATA_ATTRIBUTES_EXTENDMR,
+        });
     }
 
     metadata_sections

--- a/td-shim/src/bin/td-shim/payload_hob.rs
+++ b/td-shim/src/bin/td-shim/payload_hob.rs
@@ -8,6 +8,7 @@ use core::mem::size_of;
 use r_efi::efi;
 use scroll::Pwrite;
 use td_layout::build_time::*;
+use td_layout::runtime::exec::{SHIM_PAYLOAD_BASE, SHIM_PAYLOAD_SIZE};
 use td_layout::runtime::*;
 use td_shim::e820::E820Type;
 use td_shim::{TD_ACPI_TABLE_HOB_GUID, TD_E820_TABLE_HOB_GUID};
@@ -170,7 +171,7 @@ pub fn build_payload_hob(acpi_tables: &Vec<&[u8]>, memory: &Memory) -> Option<Pa
         PayloadHob::new(memory.get_dynamic_mem_slice_mut(memslice::SliceType::Acpi))?;
 
     payload_hob.add_cpu(memory::cpu_get_memory_space_size(), 16);
-    payload_hob.add_fv(TD_SHIM_PAYLOAD_BASE as u64, TD_SHIM_PAYLOAD_SIZE as u64);
+    payload_hob.add_fv(SHIM_PAYLOAD_BASE as u64, SHIM_PAYLOAD_SIZE as u64);
 
     for &table in acpi_tables {
         payload_hob

--- a/td-shim/src/bin/td-shim/shim_info.rs
+++ b/td-shim/src/bin/td-shim/shim_info.rs
@@ -7,7 +7,7 @@ use core::mem::size_of;
 use core::str::FromStr;
 use log::error;
 use scroll::{Pread, Pwrite};
-use td_layout::build_time::{TD_SHIM_FIRMWARE_BASE, TD_SHIM_FIRMWARE_SIZE};
+use td_layout::build_time::{TD_SHIM_FIRMWARE_BASE, TD_SHIM_FIRMWARE_SIZE, TD_SHIM_PAYLOAD_SIZE};
 use td_layout::memslice;
 use td_shim::speculation_barrier;
 use td_shim::{
@@ -35,7 +35,8 @@ impl BootTimeStatic {
     // Validate the metadata and get the basic infomation from
     // it if any
     pub fn new() -> Option<Self> {
-        let metadata_offset = unsafe { *((u32::MAX - TDX_METADATA_OFFSET + 1) as *const u32) };
+        let metadata_offset =
+            unsafe { *((u32::MAX - TDX_METADATA_OFFSET + 1) as *const u32) } - TD_SHIM_PAYLOAD_SIZE;
         if metadata_offset >= TD_SHIM_FIRMWARE_SIZE
             || metadata_offset < size_of::<Guid>() as u32
             || metadata_offset > TD_SHIM_FIRMWARE_SIZE - size_of::<TdxMetadataDescriptor>() as u32


### PR DESCRIPTION
Location of `Payload` image at runtime is changed from ROM to physical
momory, so the layout config of it is moved from `build_time` module
into `runtime/exec`.
