### PR TITLE
devtools/td-layout-config: support large payload

### DIFF
--- a/devtools/td-layout-config/config_image.json
+++ b/devtools/td-layout-config/config_image.json
@@ -1,4 +1,5 @@
 {
+    "LargePayload": "0x0",
     "Config": "0x040000",
     "Mailbox": "0x001000",
     "TempStack": "0x020000",

--- a/devtools/td-layout-config/config_memory_exec.json
+++ b/devtools/td-layout-config/config_memory_exec.json
@@ -11,6 +11,11 @@
             "type": "Memory"
         },
         {
+            "name": "LargePayload",
+            "size": "0x0",
+            "type": "Memory"
+        },
+        {
             "name": "EventLog",
             "size": "0x100000",
             "type": "Nvs"

--- a/devtools/td-layout-config/src/image.rs
+++ b/devtools/td-layout-config/src/image.rs
@@ -2,8 +2,13 @@ use serde::Deserialize;
 
 use super::{layout::LayoutConfig, render};
 
+const ROM_BASE: usize = 0xFF00_0000;
+const ROM_SIZE: usize = 0x100_0000;
+
 #[derive(Deserialize, Debug, PartialEq)]
 struct ImageConfig {
+    #[serde(rename = "LargePayload")]
+    large_payload: Option<String>,
     #[serde(rename = "Config")]
     config: String,
     #[serde(rename = "Mailbox")]
@@ -28,60 +33,66 @@ pub fn parse_image(data: String) -> String {
     let image_config = serde_json::from_str::<ImageConfig>(&data)
         .expect("Content is configuration file is invalid");
 
-    let mut image_layout = LayoutConfig::new(0, 0x100_0000);
-    image_layout.reserve_low(
-        "Config",
-        parse_int::parse::<u32>(&image_config.config).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_low(
-        "Mailbox",
-        parse_int::parse::<u32>(&image_config.mailbox).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_low(
-        "TempStack",
-        parse_int::parse::<u32>(&image_config.temp_stack).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_low(
-        "TempHeap",
-        parse_int::parse::<u32>(&image_config.temp_heap).unwrap() as usize,
-        "Reserved",
-    );
+    let large_payload_size = image_config
+        .large_payload
+        .map(|large_payload| parse_int::parse::<u32>(&large_payload).unwrap() as usize);
+    let config_size = parse_int::parse::<u32>(&image_config.config).unwrap() as usize;
+    let mailbox_size = parse_int::parse::<u32>(&image_config.mailbox).unwrap() as usize;
+    let temp_stack_size = parse_int::parse::<u32>(&image_config.temp_stack).unwrap() as usize;
+    let temp_heap_size = parse_int::parse::<u32>(&image_config.temp_heap).unwrap() as usize;
+    let reset_vector_size = parse_int::parse::<u32>(&image_config.reset_vector).unwrap() as usize;
+    let bootloader_size = parse_int::parse::<u32>(&image_config.bootloader).unwrap() as usize;
+    let metadata_size = parse_int::parse::<u32>(&image_config.metadata).unwrap() as usize;
+    let td_info_size = image_config
+        .td_info
+        .map(|td_info| parse_int::parse::<u32>(&td_info).unwrap() as usize);
+    let payload_size = image_config
+        .builtin_payload
+        .map(|payload| parse_int::parse::<u32>(&payload).unwrap() as usize);
 
-    image_layout.reserve_high(
-        "ResetVector",
-        parse_int::parse::<u32>(&image_config.reset_vector).unwrap() as usize,
-        "Reserved",
-    );
-    image_layout.reserve_high(
-        "Ipl",
-        parse_int::parse::<u32>(&image_config.bootloader).unwrap() as usize,
-        "Reserved",
-    );
+    let image_size = large_payload_size.unwrap_or(0)
+        + config_size
+        + mailbox_size
+        + temp_stack_size
+        + temp_heap_size
+        + reset_vector_size
+        + bootloader_size
+        + metadata_size
+        + td_info_size.unwrap_or(0)
+        + payload_size.unwrap_or(0);
 
-    image_layout.reserve_high(
-        "Metadata",
-        parse_int::parse::<u32>(&image_config.metadata).unwrap() as usize,
-        "Reserved",
-    );
-
-    if let Some(td_info_config) = image_config.td_info {
-        image_layout.reserve_high(
-            "TdInfo",
-            parse_int::parse::<u32>(&td_info_config).unwrap() as usize,
-            "Reserved",
-        )
+    let mut image_layout = LayoutConfig::new(0, image_size);
+    if let Some(size) = large_payload_size {
+        image_layout.reserve_low("LargePayload", size, "Reserved")
+    }
+    image_layout.reserve_low("Config", config_size, "Reserved");
+    image_layout.reserve_low("Mailbox", mailbox_size, "Reserved");
+    image_layout.reserve_low("TempStack", temp_stack_size, "Reserved");
+    image_layout.reserve_low("TempHeap", temp_heap_size, "Reserved");
+    image_layout.reserve_high("ResetVector", reset_vector_size, "Reserved");
+    image_layout.reserve_high("Ipl", bootloader_size, "Reserved");
+    image_layout.reserve_high("Metadata", metadata_size, "Reserved");
+    if let Some(size) = td_info_size {
+        image_layout.reserve_high("TdInfo", size, "Reserved")
+    }
+    if let Some(size) = payload_size {
+        image_layout.reserve_high("Payload", size, "Reserved")
     }
 
-    if let Some(payload_config) = image_config.builtin_payload {
-        image_layout.reserve_high(
-            "Payload",
-            parse_int::parse::<u32>(&payload_config).unwrap() as usize,
-            "Reserved",
-        )
+    let mut rom_layout = LayoutConfig::new(ROM_BASE, ROM_BASE + ROM_SIZE);
+    rom_layout.reserve_low("Config", config_size, "Reserved");
+    rom_layout.reserve_low("Mailbox", mailbox_size, "Reserved");
+    rom_layout.reserve_low("TempStack", temp_stack_size, "Reserved");
+    rom_layout.reserve_low("TempHeap", temp_heap_size, "Reserved");
+    rom_layout.reserve_high("ResetVector", reset_vector_size, "Reserved");
+    rom_layout.reserve_high("Ipl", bootloader_size, "Reserved");
+    rom_layout.reserve_high("Metadata", metadata_size, "Reserved");
+    if let Some(size) = td_info_size {
+        rom_layout.reserve_high("TdInfo", size, "Reserved")
+    }
+    if let Some(size) = payload_size {
+        rom_layout.reserve_high("Payload", size, "Reserved")
     }
 
-    render::render_image(&image_layout).expect("Render image layout failed!")
+    render::render_image(&image_layout, &rom_layout).expect("Render image layout failed!")
 }

--- a/devtools/td-layout-config/src/render.rs
+++ b/devtools/td-layout-config/src/render.rs
@@ -9,7 +9,7 @@ use tera::{Context, Result, Tera};
 use super::layout::{LayoutConfig, ENTRY_TYPE_FILTER};
 
 /// Render image layout file.
-pub fn render_image(image_layout: &LayoutConfig) -> Result<String> {
+pub fn render_image(image_layout: &LayoutConfig, rom_layout: &LayoutConfig) -> Result<String> {
     let mut tera = Tera::default();
     tera.register_filter("format_hex", format_hex);
     tera.register_filter("format_name", format_name);
@@ -19,8 +19,12 @@ pub fn render_image(image_layout: &LayoutConfig) -> Result<String> {
     let mut context = Context::new();
     context.insert("image_regions", image_layout.get_regions());
     context.insert("image_size", &image_layout.get_top());
+    context.insert("rom_regions", &rom_layout.get_regions());
+    context.insert("rom_size", &(rom_layout.get_top() - rom_layout.get_base()));
+    context.insert("rom_base", &rom_layout.get_base());
     // Image size - metadata pointer offset(0x20) - OVMF GUID table size(0x28) - SEC Core information size(0xC).
     context.insert("sec_info_offset", &(image_layout.get_top() - 0x54));
+    context.insert("sec_info_base", &(rom_layout.get_top() - 0x54));
     context.insert(
         "memory_offset",
         &(u32::MAX as usize + 1 - &image_layout.get_top()),

--- a/devtools/td-layout-config/src/template/image.jinja
+++ b/devtools/td-layout-config/src/template/image.jinja
@@ -15,20 +15,19 @@ Image size: {{image_size|format_hex}} ({{image_size|filesizeformat}})
 */
 
 // Image Layout Configuration
+pub const TD_SHIM_FIRMWARE_SIZE: u32 = {{image_size | format_hex }};
 {%for i in image_regions%}
 pub const TD_SHIM_{{i.name_screaming_snake_case}}_OFFSET: u32 = {{i.region.start | format_hex }};
 pub const TD_SHIM_{{i.name_screaming_snake_case}}_SIZE: u32 = {{i.region.end - i.region.start | format_hex }}; // {{i.region.end - i.region.start|filesizeformat}}
 {%endfor%}
-// Offset when Loading into Memory
-pub const TD_SHIM_FIRMWARE_BASE: u32 = {{memory_offset | format_hex }};
-pub const TD_SHIM_FIRMWARE_SIZE: u32 = {{image_size | format_hex }};
-
 // TD_SHIM_SEC_INFO_OFFSET equals to firmware size - metadata pointer offset -
 // OVMF GUID table size - SEC Core information size.
 pub const TD_SHIM_SEC_CORE_INFO_OFFSET: u32 = {{sec_info_offset | format_hex }};
-pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = {{memory_offset + sec_info_offset | format_hex }};
+pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = {{sec_info_base | format_hex }};
 
-// Base Address after Loaded into Memory
-{%-for i in image_regions%}
-pub const TD_SHIM_{{i.name_screaming_snake_case}}_BASE: u32 = {{memory_offset + i.region.start | format_hex }};
+// Rom Configuration
+
+pub const TD_SHIM_FIRMWARE_BASE: u32 = {{rom_base | format_hex }};
+{%-for i in rom_regions%}
+pub const TD_SHIM_{{i.name_screaming_snake_case}}_BASE: u32 = {{i.region.start | format_hex }};
 {%-endfor%}


### PR DESCRIPTION
The payload may be so large that it cannot be placed in the payload region of the original image config.

To solve this, `LargePayload` is introduced. Since the large payload may have size larger than 16MiB, it is loaded into physical memory instead of ROM space. Thus, in td-layout-config tool, the image configuration is splited into rom configuration and image configuration.