### PR TITLE
ci: switch to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -42,18 +42,14 @@ jobs:
           submodules: recursive
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.STABLE_RUST_TOOLCHAIN }}
-          override: true
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.NIGHTLY_RUST_TOOLCHAIN }}
-          override: true
 
       - name: Preparation work
         run: make preparation

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -28,11 +28,9 @@ jobs:
         uses: ilammy/setup-nasm@v1
 
       - name: Install toolchain with clippy available
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly-2023-12-31
-          override: true
           components: clippy
 
       - name: Add target
@@ -65,23 +63,16 @@ jobs:
           submodules: recursive
 
       - name: Install toolchain with rustfmt available
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly-2023-12-31
-          override: true
           components: rustfmt
 
       - name: Preparation Work
         run: make preparation
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,33 +31,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          override: true
           components: rust-src, llvm-tools-preview
 
       - name: Run cargo install cargo-xbuild
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-xbuild
+        run: cargo install cargo-xbuild
       
       - name: install NASM
         uses: ilammy/setup-nasm@v1
       
       - name: Install AFL (Linux)
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-afl
+        run: cargo install cargo-afl
         if: runner.os == 'Linux'
       
       - name: Install Cargo-Fuzz (Linux)
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-fuzz
+        run: cargo install cargo-fuzz
         if: runner.os == 'Linux'
       
       - name: Preparation work

--- a/.github/workflows/integration-tdx.yml
+++ b/.github/workflows/integration-tdx.yml
@@ -37,10 +37,7 @@ jobs:
         run: bash sh_script/update_toolchain.sh ${{ env.RUST_TOOLCHAIN }}
 
       - name: Run cargo install cargo-xbuild
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-xbuild
+        run: cargo install cargo-xbuild
 
       - name: Preparation Work
         run: bash sh_script/preparation.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,18 +42,13 @@ jobs:
           submodules: recursive
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rust-src, llvm-tools-preview
 
       - name: Run cargo install cargo-xbuild
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-xbuild
+        run: cargo install cargo-xbuild
 
       # install QEMU
       - name: Install QEMU (Linux)

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -38,18 +38,14 @@ jobs:
         uses: ilammy/setup-nasm@v1
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.STABLE_RUST_TOOLCHAIN }}
-          override: true
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.NIGHTLY_RUST_TOOLCHAIN }}
-          override: true
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -87,18 +83,14 @@ jobs:
         uses: ilammy/setup-nasm@v1
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.STABLE_RUST_TOOLCHAIN }}
-          override: true
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.NIGHTLY_RUST_TOOLCHAIN }}
-          override: true
 
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,18 +46,13 @@ jobs:
           submodules: recursive
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rust-src
 
       - name: Run cargo install cargo-xbuild
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-xbuild
+        run: cargo install cargo-xbuild
       
       - name: Preparation Work
         run: bash sh_script/preparation.sh
@@ -66,16 +61,10 @@ jobs:
         run: make test 
 
       - name: Build Release TdShim
-        uses: actions-rs/cargo@v1
-        with:
-          command: xbuild
-          args: -p td-shim --target x86_64-unknown-none --release --features=main,tdx
+        run: cargo xbuild -p td-shim --target x86_64-unknown-none --release --features=main,tdx
       
       - name: Build Debug TdShim
-        uses: actions-rs/cargo@v1
-        with:
-          command: xbuild
-          args: -p td-shim --target x86_64-unknown-none --features=main,tdx --no-default-features
+        run: cargo xbuild -p td-shim --target x86_64-unknown-none --features=main,tdx --no-default-features
 
       - name: Build td-shim-tools
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,18 +28,13 @@ jobs:
           submodules: recursive
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: ${{ env.TOOLCHAIN_PROFILE }}
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          override: true
           components: rust-src
 
       - name: Run cargo install cargo-xbuild
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-xbuild
+        run: cargo install cargo-xbuild
 
       - name: Preparation Work
         run: make preparation


### PR DESCRIPTION
`self-update` of rustup causes failure on Windows. As action-rs/toolchain is not maintained, switch to dtolnay/rust-toolchain.

Closes https://github.com/confidential-containers/td-shim/issues/698