### PR TITLE
td-layout: regenerate layout source files with `td-layout-config`

### DIFF
--- a/td-layout/src/build_time.rs
+++ b/td-layout/src/build_time.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2023  Intel Corporation
+// Copyright (c) 2021 - 2024  Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -7,23 +7,23 @@
 /*
 Image Layout
 +----------------------------------------+ <- 0x0
-|                 CONFIG                 |   (0x40000) 256 KB
+|                 CONFIG                 |   (0x40000) 256 kB
 +----------------------------------------+ <- 0x40000
-|                MAILBOX                 |   (0x1000) 4 KB
+|                MAILBOX                 |   (0x1000) 4 kB
 +----------------------------------------+ <- 0x41000
-|               TEMP_STACK               |   (0x20000) 128 KB
+|               TEMP_STACK               |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x61000
-|               TEMP_HEAP                |   (0x20000) 128 KB
+|               TEMP_HEAP                |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x81000
-|                  FREE                  |   (0x1000) 4 KB
-+----------------------------------------+ <- 0x82000
+|                  FREE                  |   (0x0) 0 B
++----------------------------------------+ <- 0x81000
 |                PAYLOAD                 |   (0xC2D000) 12.18 MB
++----------------------------------------+ <- 0xCAE000
+|                METADATA                |   (0x1000) 4 kB
 +----------------------------------------+ <- 0xCAF000
-|                METADATA                |   (0x1000) 4 KB
-+----------------------------------------+ <- 0xCB0000
-|                  IPL                   |   (0x348000) 3.28 MB
+|                  IPL                   |   (0x349000) 3.29 MB
 +----------------------------------------+ <- 0xFF8000
-|              RESET_VECTOR              |   (0x8000) 32 KB
+|              RESET_VECTOR              |   (0x8000) 32 kB
 +----------------------------------------+ <- 0x1000000
 Image size: 0x1000000 (16 MB)
 */
@@ -31,31 +31,31 @@ Image size: 0x1000000 (16 MB)
 // Image Layout Configuration
 
 pub const TD_SHIM_CONFIG_OFFSET: u32 = 0x0;
-pub const TD_SHIM_CONFIG_SIZE: u32 = 0x40000; // 256 KB
+pub const TD_SHIM_CONFIG_SIZE: u32 = 0x40000; // 256 kB
 
 pub const TD_SHIM_MAILBOX_OFFSET: u32 = 0x40000;
-pub const TD_SHIM_MAILBOX_SIZE: u32 = 0x1000; // 4 KB
+pub const TD_SHIM_MAILBOX_SIZE: u32 = 0x1000; // 4 kB
 
 pub const TD_SHIM_TEMP_STACK_OFFSET: u32 = 0x41000;
-pub const TD_SHIM_TEMP_STACK_SIZE: u32 = 0x20000; // 128 KB
+pub const TD_SHIM_TEMP_STACK_SIZE: u32 = 0x20000; // 128 kB
 
 pub const TD_SHIM_TEMP_HEAP_OFFSET: u32 = 0x61000;
-pub const TD_SHIM_TEMP_HEAP_SIZE: u32 = 0x20000; // 128 KB
+pub const TD_SHIM_TEMP_HEAP_SIZE: u32 = 0x20000; // 128 kB
 
 pub const TD_SHIM_FREE_OFFSET: u32 = 0x81000;
-pub const TD_SHIM_FREE_SIZE: u32 = 0x1000; // 4 KB
+pub const TD_SHIM_FREE_SIZE: u32 = 0x0; // 0 B
 
-pub const TD_SHIM_PAYLOAD_OFFSET: u32 = 0x82000;
+pub const TD_SHIM_PAYLOAD_OFFSET: u32 = 0x81000;
 pub const TD_SHIM_PAYLOAD_SIZE: u32 = 0xC2D000; // 12.18 MB
 
-pub const TD_SHIM_METADATA_OFFSET: u32 = 0xCAF000;
-pub const TD_SHIM_METADATA_SIZE: u32 = 0x1000; // 4 KB
+pub const TD_SHIM_METADATA_OFFSET: u32 = 0xCAE000;
+pub const TD_SHIM_METADATA_SIZE: u32 = 0x1000; // 4 kB
 
-pub const TD_SHIM_IPL_OFFSET: u32 = 0xCB0000;
-pub const TD_SHIM_IPL_SIZE: u32 = 0x348000; // 3.28 MB
+pub const TD_SHIM_IPL_OFFSET: u32 = 0xCAF000;
+pub const TD_SHIM_IPL_SIZE: u32 = 0x349000; // 3.29 MB
 
 pub const TD_SHIM_RESET_VECTOR_OFFSET: u32 = 0xFF8000;
-pub const TD_SHIM_RESET_VECTOR_SIZE: u32 = 0x8000; // 32 KB
+pub const TD_SHIM_RESET_VECTOR_SIZE: u32 = 0x8000; // 32 kB
 
 // Offset when Loading into Memory
 pub const TD_SHIM_FIRMWARE_BASE: u32 = 0xFF000000;
@@ -72,7 +72,7 @@ pub const TD_SHIM_MAILBOX_BASE: u32 = 0xFF040000;
 pub const TD_SHIM_TEMP_STACK_BASE: u32 = 0xFF041000;
 pub const TD_SHIM_TEMP_HEAP_BASE: u32 = 0xFF061000;
 pub const TD_SHIM_FREE_BASE: u32 = 0xFF081000;
-pub const TD_SHIM_PAYLOAD_BASE: u32 = 0xFF082000;
-pub const TD_SHIM_METADATA_BASE: u32 = 0xFFCAF000;
-pub const TD_SHIM_IPL_BASE: u32 = 0xFFCB0000;
+pub const TD_SHIM_PAYLOAD_BASE: u32 = 0xFF081000;
+pub const TD_SHIM_METADATA_BASE: u32 = 0xFFCAE000;
+pub const TD_SHIM_IPL_BASE: u32 = 0xFFCAF000;
 pub const TD_SHIM_RESET_VECTOR_BASE: u32 = 0xFFFF8000;

--- a/td-layout/src/runtime/exec.rs
+++ b/td-layout/src/runtime/exec.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2023  Intel Corporation
+// Copyright (c) 2021 - 2024  Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -10,9 +10,9 @@ Top of Low Memory: 0x80000000
 +----------------------------------------+ <- 0x80000000
 |               EVENT_LOG                |   (0x100000) 1 MB
 +----------------------------------------+ <- 0x7FF00000
-|           RELOCATED_MAILBOX            |   (0x2000) 8 KB
+|           RELOCATED_MAILBOX            |   (0x2000) 8 kB
 +----------------------------------------+ <- 0x7FEFE000
-|           PAYLOAD_PAGE_TABLE           |   (0x20000) 128 KB
+|           PAYLOAD_PAGE_TABLE           |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x7FEDE000
 |                PAYLOAD                 |   (0x2000000) 32 MB
 +----------------------------------------+ <- 0x7DEDE000
@@ -20,7 +20,7 @@ Top of Low Memory: 0x80000000
 +----------------------------------------+ <- 0x7DDDE000
 |                  FREE                  |   (0x7D5BE000) 1.96 GB
 +----------------------------------------+ <- 0x820000
-|                 TD_HOB                 |   (0x20000) 128 KB
+|                 TD_HOB                 |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x800000
 |               BOOTLOADER               |   (0x800000) 8 MB
 +----------------------------------------+ <- 0x0
@@ -33,14 +33,14 @@ pub const TOTAL_USAGE: usize = 0x2A42000; // (42.26 MB)
 pub const BOOTLOADER_BASE: usize = 0x0;
 pub const BOOTLOADER_SIZE: usize = 0x800000; // 8 MB
 pub const TD_HOB_BASE: usize = 0x800000;
-pub const TD_HOB_SIZE: usize = 0x20000; // 128 KB
+pub const TD_HOB_SIZE: usize = 0x20000; // 128 kB
 pub const ACPI_SIZE: usize = 0x100000; // 1 MB
 pub const PAYLOAD_SIZE: usize = 0x2000000; // 32 MB
-pub const PAYLOAD_PAGE_TABLE_SIZE: usize = 0x20000; // 128 KB
-pub const RELOCATED_MAILBOX_SIZE: usize = 0x2000; // 8 KB
+pub const PAYLOAD_PAGE_TABLE_SIZE: usize = 0x20000; // 128 kB
+pub const RELOCATED_MAILBOX_SIZE: usize = 0x2000; // 8 kB
 pub const EVENT_LOG_SIZE: usize = 0x100000; // 1 MB
 
-pub const MEMORY_LAYOUT_CONFIG: &[(&str, usize, &str)] = &[
+pub const MEMORY_LAYOUT_CONFIG: &[(&'static str, usize, &'static str)] = &[
     // (name of memory region, region size, region type)
     ("Bootloader", 0x800000, "Memory"),
     ("TdHob", 0x20000, "Memory"),

--- a/td-layout/src/runtime/linux.rs
+++ b/td-layout/src/runtime/linux.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2023  Intel Corporation
+// Copyright (c) 2021 - 2024  Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -10,9 +10,9 @@ Top of Low Memory: 0x80000000
 +----------------------------------------+ <- 0x80000000
 |               EVENT_LOG                |   (0x100000) 1 MB
 +----------------------------------------+ <- 0x7FF00000
-|           RELOCATED_MAILBOX            |   (0x2000) 8 KB
+|           RELOCATED_MAILBOX            |   (0x2000) 8 kB
 +----------------------------------------+ <- 0x7FEFE000
-|           PAYLOAD_PAGE_TABLE           |   (0x20000) 128 KB
+|           PAYLOAD_PAGE_TABLE           |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x7FEDE000
 |                  ACPI                  |   (0x100000) 1 MB
 +----------------------------------------+ <- 0x7FDDE000
@@ -20,11 +20,11 @@ Top of Low Memory: 0x80000000
 +----------------------------------------+ <- 0x2861000
 |                PAYLOAD                 |   (0x2000000) 32 MB
 +----------------------------------------+ <- 0x861000
-|           PAYLOAD_PARAMETER            |   (0x1000) 4 KB
+|           PAYLOAD_PARAMETER            |   (0x1000) 4 kB
 +----------------------------------------+ <- 0x860000
-|        UNACCEPTED_MEMORY_BITMAP        |   (0x40000) 256 KB
+|        UNACCEPTED_MEMORY_BITMAP        |   (0x40000) 256 kB
 +----------------------------------------+ <- 0x820000
-|                 TD_HOB                 |   (0x20000) 128 KB
+|                 TD_HOB                 |   (0x20000) 128 kB
 +----------------------------------------+ <- 0x800000
 |               BOOTLOADER               |   (0x800000) 8 MB
 +----------------------------------------+ <- 0x0
@@ -37,19 +37,19 @@ pub const TOTAL_USAGE: usize = 0x2A83000; // (42.51 MB)
 pub const BOOTLOADER_BASE: usize = 0x0;
 pub const BOOTLOADER_SIZE: usize = 0x800000; // 8 MB
 pub const TD_HOB_BASE: usize = 0x800000;
-pub const TD_HOB_SIZE: usize = 0x20000; // 128 KB
+pub const TD_HOB_SIZE: usize = 0x20000; // 128 kB
 pub const UNACCEPTED_MEMORY_BITMAP_BASE: usize = 0x820000;
-pub const UNACCEPTED_MEMORY_BITMAP_SIZE: usize = 0x40000; // 256 KB
+pub const UNACCEPTED_MEMORY_BITMAP_SIZE: usize = 0x40000; // 256 kB
 pub const PAYLOAD_PARAMETER_BASE: usize = 0x860000;
-pub const PAYLOAD_PARAMETER_SIZE: usize = 0x1000; // 4 KB
+pub const PAYLOAD_PARAMETER_SIZE: usize = 0x1000; // 4 kB
 pub const PAYLOAD_BASE: usize = 0x861000;
 pub const PAYLOAD_SIZE: usize = 0x2000000; // 32 MB
 pub const ACPI_SIZE: usize = 0x100000; // 1 MB
-pub const PAYLOAD_PAGE_TABLE_SIZE: usize = 0x20000; // 128 KB
-pub const RELOCATED_MAILBOX_SIZE: usize = 0x2000; // 8 KB
+pub const PAYLOAD_PAGE_TABLE_SIZE: usize = 0x20000; // 128 kB
+pub const RELOCATED_MAILBOX_SIZE: usize = 0x2000; // 8 kB
 pub const EVENT_LOG_SIZE: usize = 0x100000; // 1 MB
 
-pub const MEMORY_LAYOUT_CONFIG: &[(&str, usize, &str)] = &[
+pub const MEMORY_LAYOUT_CONFIG: &[(&'static str, usize, &'static str)] = &[
     // (name of memory region, region size, region type)
     ("Bootloader", 0x800000, "Memory"),
     ("TdHob", 0x20000, "Memory"),


### PR DESCRIPTION
`tera` changed its `filesizeformat` from `KB` to `kB`. This patch updates the source files with the new format.