### PR TITLE
Upstream tdx-tdcall to crates.io

### DIFF
--- a/tdx-tdcall/Cargo.toml
+++ b/tdx-tdcall/Cargo.toml
@@ -7,6 +7,9 @@ homepage = "https://github.com/confidential-containers"
 license = "BSD-2-Clause-Patent"
 edition = "2018"
 
+readme = "README.md"
+keywords = ["TDCALL", "TDX", "intel"]
+
 [dependencies]
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
 log = "0.4.13"

--- a/tdx-tdcall/README.md
+++ b/tdx-tdcall/README.md
@@ -1,0 +1,16 @@
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fconfidential-containers%2Ftd-shim.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fconfidential-containers%2Ftd-shim?ref=badge_shield)
+# TDX-tdcall - Trust Domain Extensions tdcall
+
+## Documents
+
+* [Intel TDX](https://software.intel.com/content/www/us/en/develop/articles/intel-trust-domain-extensions.html)
+
+## Introduction
+
+Intel’s Trust Domain Extensions (TDX) protect confidential guest VMs from the host and physical attacks by isolating the guest register state and by encrypting the guest memory. In TDX, a special module running in a special mode sits between the host and the guest and manages the guest/host separation.
+
+This tdx-tdcall crate provides constants, stuctures and wrappers to support user access TDCALL services.
+
+
+## License
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fconfidential-containers%2Ftd-shim.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fconfidential-containers%2Ftd-shim?ref=badge_large)


### PR DESCRIPTION
Prepare README.md and Cargo.toml for publishing tdx-tdcall crate