### PR TITLE
Add Result return type for tdvmcall_wrmsr, tdvmcall_rdmsr

### DIFF
--- a/td-exception/src/interrupt.rs
+++ b/td-exception/src/interrupt.rs
@@ -399,13 +399,15 @@ interrupt_no_error!(virtualization, stack, {
             }
         }
         EXIT_REASON_MSR_READ => {
-            let msr = tdx::tdvmcall_rdmsr(stack.scratch.rcx as u32);
+            let msr = tdx::tdvmcall_rdmsr(stack.scratch.rcx as u32)
+                .expect("fail to perform RDMSR operation\n");
             stack.scratch.rax = (msr as u32 & u32::MAX) as usize; // EAX
             stack.scratch.rdx = ((msr >> 32) as u32 & u32::MAX) as usize; // EDX
         }
         EXIT_REASON_MSR_WRITE => {
             let data = stack.scratch.rax as u64 | ((stack.scratch.rdx as u64) << 32); // EDX:EAX
-            tdx::tdvmcall_wrmsr(stack.scratch.rcx as u32, data);
+            tdx::tdvmcall_wrmsr(stack.scratch.rcx as u32, data)
+                .expect("fail to perform WRMSR operation\n");
         }
         EXIT_REASON_CPUID => {
             let cpuid = tdx::tdvmcall_cpuid(stack.scratch.rax as u32, stack.scratch.rcx as u32);

--- a/td-payload/src/arch/x86_64/apic.rs
+++ b/td-payload/src/arch/x86_64/apic.rs
@@ -22,8 +22,9 @@ pub fn enable_apic_interrupt() {
     // In x2APIC mode, SVR is mapped to MSR address 0x80f.
     // Since SVR(SIVR) is not virtualized, before we implement the handling in #VE of MSRRD/WR,
     // use tdvmcall instead direct read/write operation.
-    let svr = tdx_tdcall::tdx::tdvmcall_rdmsr(0x80f);
-    tdx_tdcall::tdx::tdvmcall_wrmsr(0x80f, svr | (0x1 << 8));
+    let svr = tdx_tdcall::tdx::tdvmcall_rdmsr(0x80f).expect("fail to perform RDMSR operation\n");
+    tdx_tdcall::tdx::tdvmcall_wrmsr(0x80f, svr | (0x1 << 8))
+        .expect("fail to perform WRMSR operation\n");
 }
 
 pub fn enable_and_hlt() {

--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -336,7 +336,7 @@ pub fn tdvmcall_mapgpa(shared: bool, paddr: u64, length: usize) -> Result<(), Td
 /// Used to help perform RDMSR operation.
 ///
 /// Details can be found in TDX GHCI spec section 'TDG.VP.VMCALL<Instruction.RDMSR>'
-pub fn tdvmcall_rdmsr(index: u32) -> u64 {
+pub fn tdvmcall_rdmsr(index: u32) -> Result<u64, TdVmcallError> {
     let mut args = TdVmcallArgs {
         r11: TDVMCALL_RDMSR,
         r12: index as u64,
@@ -346,16 +346,16 @@ pub fn tdvmcall_rdmsr(index: u32) -> u64 {
     let ret = td_vmcall(&mut args);
 
     if ret != TDVMCALL_STATUS_SUCCESS {
-        tdvmcall_halt();
+        return Err(ret.into());
     }
 
-    args.r11
+    Ok(args.r11)
 }
 
 /// Used to help perform WRMSR operation.
 ///
 /// Details can be found in TDX GHCI spec section 'TDG.VP.VMCALL<Instruction.WRMSR>'
-pub fn tdvmcall_wrmsr(index: u32, value: u64) {
+pub fn tdvmcall_wrmsr(index: u32, value: u64) -> Result<(), TdVmcallError> {
     let mut args = TdVmcallArgs {
         r11: TDVMCALL_WRMSR,
         r12: index as u64,
@@ -366,8 +366,10 @@ pub fn tdvmcall_wrmsr(index: u32, value: u64) {
     let ret = td_vmcall(&mut args);
 
     if ret != TDVMCALL_STATUS_SUCCESS {
-        tdvmcall_halt();
+        return Err(ret.into());
     }
+
+    Ok(())
 }
 
 /// Used to enable the TD-guest to request the VMM to emulate the CPUID operation


### PR DESCRIPTION
Ref: #708 

Replace the` tdvmcall_halt();` with `return Err(ret.into())`