### PR TITLE
Publish tdx-tdcall 0.2.0 for adding new functions to support TD partitioning

### DIFF
--- a/tdx-tdcall/CHANGELOG.md
+++ b/tdx-tdcall/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [0.2.0] - 2024-06-21
+### Added
+- Wrapper to tdcall_accept_page to accept a memory range (for both normal 4K as well as 2M large pages).
+- Add tdcall_vm_read/write to access TD-scope meta field of a TD.
+- Add tdcall_vp_read/write is to access vCPU-scope meta field of a TD.
+- Add tdcall_vp_invept/invvpid to provide SEPT flushing support.
+- Add tdcall_vp_enter support.
+- Add tdcall to support memory attribute write.
+
+### Changed
+- Change return type for tdvmcall_wrmsr, tdvmcall_rdmsr
+- Replace the & operator with addr_of! macro for tdvmcall_mmio_write/tdvmcall_mmio_read
+- Extend TdInfo struct to add vcpu_index field
+
+## [0.1.0] - 2024-06-07
+### Added
+- Add README.md for publishing to crates.io

--- a/tdx-tdcall/Cargo.toml
+++ b/tdx-tdcall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdx-tdcall"
-version = "0.1.0"
+version = "0.2.0"
 description = "Constants, stuctures and wrappers to access TDCALL services"
 repository = "https://github.com/confidential-containers/td-shim"
 homepage = "https://github.com/confidential-containers"


### PR DESCRIPTION
Update the tdx-tdcall cargo.toml
Version from 0.1.0 to 0.2.0

1. General clean up work
2. New APIs:

- Wrapper to tdcall_accept_page accept a memory range ( td_accept_memory that takes start address and len of address range to be accepted).
- Add tdcall_vm_read/write to access TD-scope meta field of a TD.
- Add tdcall_vp_read/write is to access vCPU-scope meta field of a TD.
- Add tdcall_vp_invept/invvpid to provide SEPT flushing support.
- Add tdcall_vp_enter support.
- Add tdcall to support memory attribute write.