### PR TITLE
Fix oss-fuzz build failure issue

### DIFF
--- a/td-loader/fuzz/Cargo.toml
+++ b/td-loader/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ libfuzzer-sys = {version = "0.4", optional = true }
 afl = {version = "*", optional = true }
 log = "0.4.13"
 arbitrary = "=1.1.3"
+serde = "=1.0.198"
 
 [dependencies.td-loader]
 path = ".."

--- a/td-shim-interface/fuzz/Cargo.toml
+++ b/td-shim-interface/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ libfuzzer-sys = {version = "0.4", optional = true }
 afl = {version = "*", optional = true }
 r-efi = "3.2.0"
 arbitrary = "=1.1.3"
+serde = "=1.0.198"
 
 [dependencies.td-shim-interface]
 path = ".."

--- a/td-shim/fuzz/Cargo.toml
+++ b/td-shim/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ libfuzzer-sys = {version = "0.4", optional = true }
 afl = {version = "*", optional = true }
 r-efi = "3.2.0"
 arbitrary = "=1.1.3"
+serde = "=1.0.198"
 
 [dependencies.td-shim]
 path = ".."


### PR DESCRIPTION
Since the compiler of oss-fuzz is not the latest version, so it will meet build failure for crate "serde 1.0.204". So we use a fixed version serde "1.0.198" to fix the issue.