### PR TITLE
tdx-tdcall: remove nightly feature in the x86_64 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "tdx-tdcall"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "lazy_static",
  "log",

--- a/tdx-tdcall/Cargo.toml
+++ b/tdx-tdcall/Cargo.toml
@@ -15,7 +15,7 @@ lazy_static = { version = "1.0", features = ["spin_no_std"] }
 log = "0.4.13"
 scroll = { version = "0.10", default-features = false, features = ["derive"] }
 spin = "0.9.2"
-x86_64 = "0.14.9"
+x86_64 = { version = "0.14.9", default-features = false, features = ["instructions"] }
 
 [features]
 default = []


### PR DESCRIPTION
External projects may not always choose to use the Rust nightly toolchain. Remove the nightly feature in the x86_64 crate to support the Rust stable toolchain. While we're at it, also bump up the x86_64 crate version to 0.15.1.