### PR TITLE
tdx-tdcall: fix TdCallError parsing

### DIFF
--- a/tdx-tdcall/src/lib.rs
+++ b/tdx-tdcall/src/lib.rs
@@ -162,10 +162,10 @@ pub enum TdCallError {
     TdxExitInvalidParameters,
 
     // The operand is busy (e.g., it is locked in Exclusive mode)
-    TdxExitReasonOperandBusy,
+    TdxExitReasonOperandBusy(u32),
 
     // Operand is invalid (e.g., illegal leaf number)
-    TdxExitReasonOperandInvalid,
+    TdxExitReasonOperandInvalid(u32),
 
     // Error code defined by individual leaf function
     LeafSpecific(u64),
@@ -174,9 +174,9 @@ pub enum TdCallError {
 // TDCALL Completion Status Codes (Returned in RAX) Definition
 impl From<u64> for TdCallError {
     fn from(val: u64) -> Self {
-        match val {
-            0x8000_0200 => Self::TdxExitReasonOperandBusy,
-            0xC000_0100 => Self::TdxExitReasonOperandInvalid,
+        match val >> 32 {
+            0x8000_0200 => Self::TdxExitReasonOperandBusy(val as u32),
+            0xC000_0100 => Self::TdxExitReasonOperandInvalid(val as u32),
             _ => Self::LeafSpecific(val),
         }
     }

--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -586,11 +586,12 @@ pub fn tdcall_accept_page(address: u64) -> Result<(), TdCallError> {
 
         if ret == TDCALL_STATUS_SUCCESS {
             return Ok(());
-        } else if TdCallError::TdxExitReasonOperandBusy != ret.into() {
-            return Err(ret.into());
+        } else {
+            match TdCallError::from(ret) {
+                TdCallError::TdxExitReasonOperandBusy(_) => retry_counter += 1,
+                e => return Err(e),
+            }
         }
-
-        retry_counter += 1;
     }
 
     return Err(ret.into());
@@ -618,7 +619,7 @@ pub fn td_accept_pages(address: u64, pages: u64, page_size: u64) {
                     }
                 }
                 panic!(
-                    "Accept Page Error: 0x{:x}, page_size: {}, err {:?}\n",
+                    "Accept Page Error: 0x{:x}, page_size: {}, err {:x?}\n",
                     accept_addr, page_size, e
                 );
             }
@@ -928,11 +929,12 @@ pub fn tdcall_mem_page_attr_wr(
 
         if ret == TDCALL_STATUS_SUCCESS {
             return Ok((args.rcx, args.rdx));
-        } else if TdCallError::TdxExitReasonOperandBusy != ret.into() {
-            return Err(ret.into());
+        } else {
+            match TdCallError::from(ret) {
+                TdCallError::TdxExitReasonOperandBusy(_) => retry_counter += 1,
+                e => return Err(e),
+            }
         }
-
-        retry_counter += 1;
     }
 
     return Err(ret.into());


### PR DESCRIPTION
According to the ABI spec, TdCallError includes:

1) Flags, Class and Name (Bits 63:32)
2) Details L2 (Bits 31:0)

Fix the logic in fn from(val: u64) to correctly parse both parts of the function completion status. Include details L2 as part of the enum.