### PR TITLE
td-payload: add new shared memory init function with private shadow

### DIFF
--- a/td-payload/src/lib.rs
+++ b/td-payload/src/lib.rs
@@ -33,7 +33,7 @@ pub extern "C" fn _start(hob: u64, _payload: u64) -> ! {
 
     let layout = RuntimeLayout::default();
 
-    arch::init::pre_init(hob, &layout);
+    arch::init::pre_init(hob, &layout, false);
     arch::init::init(&layout, main);
 }
 

--- a/tests/test-td-payload/src/main.rs
+++ b/tests/test-td-payload/src/main.rs
@@ -132,7 +132,7 @@ pub extern "C" fn _start(hob: u64, _payload: u64) -> ! {
         shadow_stack_size: layout::DEFAULT_SHADOW_STACK_SIZE,
     };
 
-    arch::init::pre_init(hob, &layout);
+    arch::init::pre_init(hob, &layout, false);
     arch::init::init(&layout, main);
 }
 


### PR DESCRIPTION
To keep the original API behavior unchanged. The extended API init the shared memory allocator with a private shadow start address. If the private shadow is not available, the method `copy_to_private_shadow` will return None.

As the `shadow_start` may be lower or higher than start of shared memory, the way of allocating private shadow is changed to use the offset of the allocated shared address to the start of shared allocator.

Closes https://github.com/confidential-containers/td-shim/issues/720