### PR TITLE
fix GPAW mask in the reset vector

### DIFF
--- a/td-shim/ResetVector/Ia32/Flat32ToFlat64.asm
+++ b/td-shim/ResetVector/Ia32/Flat32ToFlat64.asm
@@ -22,7 +22,7 @@ Transition32FlatTo64Flat:
     ; LA57 and use 5-level paging
     ;
     mov     ecx, esp
-    and     ecx, 0x2f
+    and     ecx, 0x3f
     cmp     ecx, 52
     jl      .set_cr4
     bts     eax, 12


### PR DESCRIPTION
GPAW is the [0:6] bit of ESP. the current mask 0x2f does not extract the 5th bit. 0x3f is the correct bitmask.

this should close issue #734