### PR TITLE
ResetVector: remove 5-level paging

### DIFF
--- a/td-shim/ResetVector/Ia32/Flat32ToFlat64.asm
+++ b/td-shim/ResetVector/Ia32/Flat32ToFlat64.asm
@@ -16,29 +16,11 @@ Transition32FlatTo64Flat:
 
     mov     eax, cr4
     bts     eax, 5                      ; enable PAE
-
-    ;
-    ; esp [6:0] holds gpaw, if it is at least 52 bits, need to set
-    ; LA57 and use 5-level paging
-    ;
-    mov     ecx, esp
-    and     ecx, 0x2f
-    cmp     ecx, 52
-    jl      .set_cr4
-    bts     eax, 12
-.set_cr4:
     mov     cr4, eax
 
     mov     ecx, ADDR_OF(TopLevelPageDirectory)
-    ;
-    ; if we just set la57, we are ok, if using 4-level paging, adjust top-level page directory
-    ;
-    bt      eax, 12
-    jc      .set_cr3
-    add     ecx, 0x1000
-.set_cr3:
+    add     ecx, 0x1000                 ; point to level-4 page table entry
     mov     cr3, ecx
-
     mov     eax, cr0
     bts     eax, 31                     ; set PG
     mov     cr0, eax                    ; enable paging

--- a/td-shim/src/bin/td-shim/memory.rs
+++ b/td-shim/src/bin/td-shim/memory.rs
@@ -14,6 +14,7 @@ use td_shim_interface::td_uefi_pi::pi::hob::{
     RESOURCE_SYSTEM_MEMORY,
 };
 use x86_64::{
+    registers::control::{Cr4, Cr4Flags},
     structures::paging::PageTableFlags as Flags,
     structures::paging::{OffsetPageTable, PageTable},
     PhysAddr, VirtAddr,
@@ -125,6 +126,11 @@ impl<'a> Memory<'a> {
             }
         }
 
+        if Cr4::read().contains(Cr4Flags::L5_PAGING) {
+            panic!(
+                "5-Level paging is not supported by td-shim but it is enabled in CR4 unexpectedly"
+            );
+        }
         td_paging::cr3_write(
             self.get_layout_region(SliceType::PayloadPageTable)
                 .base_address as u64,


### PR DESCRIPTION
5-level paging is not necessary in td-shim, remove the related code and page table entry in reset vector.

As the level 5 entry is removed, update the size of `ResetVector` in image layout.

This PR should close https://github.com/confidential-containers/td-shim/issues/734 as GPAW is no longer needed.