### PR TITLE
tdx-tdcall: don't use heap allocated buffers for TD reports

### DIFF
--- a/tdx-tdcall/src/lib.rs
+++ b/tdx-tdcall/src/lib.rs
@@ -21,7 +21,6 @@
 
 #![no_std]
 
-extern crate alloc;
 use core::ffi::c_void;
 
 #[cfg(feature = "use_tdx_emulation")]

--- a/tdx-tdcall/src/tdreport.rs
+++ b/tdx-tdcall/src/tdreport.rs
@@ -190,7 +190,7 @@ struct TdxReportBuf(TdxReport);
 /// information of the guest TD, measurements/configuration information of the Intel
 /// TDX module and a REPORTMACSTRUCT
 ///
-/// Details can be found in TDX GHCI spec section 'TDG.MR.REPORT'
+/// Details can be found in TDX module ABI spec section 'TDG.MR.REPORT'
 pub fn tdcall_report(
     additional_data: &[u8; TD_REPORT_ADDITIONAL_DATA_SIZE],
 ) -> Result<TdxReport, TdCallError> {


### PR DESCRIPTION
There's little reason to use a heap-allocated buffer for requesting TD reports putting it behind a global lock. Furthermore, the TDX module doesn't require the additional data to be inside the TD report buffer. Instead, put the buffer on the stack and directly pass a pointer to the additional data.
Note that with and without this patch, the memory passed to the TDX module must be identity-mapped.