### PR TITLE
remove `alloc_error_handler`

### DIFF
--- a/td-payload/src/bin/example/main.rs
+++ b/td-payload/src/bin/example/main.rs
@@ -15,7 +15,6 @@
 
 #![no_std]
 #![cfg_attr(not(test), no_main)]
-#![feature(alloc_error_handler)]
 #![allow(unused)]
 
 use core::mem::size_of;

--- a/td-payload/src/lib.rs
+++ b/td-payload/src/lib.rs
@@ -5,7 +5,6 @@
 
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
-#![feature(alloc_error_handler)]
 
 use console::CONSOLE;
 use core::fmt::{Arguments, Write};

--- a/td-payload/src/mm/heap.rs
+++ b/td-payload/src/mm/heap.rs
@@ -25,16 +25,6 @@ fn panic(_info: &PanicInfo) -> ! {
     loop {}
 }
 
-#[alloc_error_handler]
-#[allow(clippy::empty_loop)]
-fn alloc_error(_info: core::alloc::Layout) -> ! {
-    use crate::println;
-
-    println!("alloc_error ... {:?}", _info);
-    x86_64::instructions::hlt();
-    loop {}
-}
-
 /// The initialization method for the global heap allocator.
 pub fn init_heap(heap_start: u64, heap_size: usize) {
     unsafe {

--- a/td-shim/src/bin/td-shim/main.rs
+++ b/td-shim/src/bin/td-shim/main.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #![allow(unused)]
-#![feature(alloc_error_handler)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 #![allow(unused_imports)]
@@ -58,14 +57,6 @@ mod td;
 #[allow(clippy::empty_loop)]
 fn panic(_info: &PanicInfo) -> ! {
     log::info!("panic ... {:?}\n", _info);
-    deadloop()
-}
-
-#[cfg(not(test))]
-#[alloc_error_handler]
-#[allow(clippy::empty_loop)]
-fn alloc_error(_info: core::alloc::Layout) -> ! {
-    log::info!("alloc_error ... {:?}\n", _info);
     deadloop()
 }
 

--- a/tests/test-td-payload/src/main.rs
+++ b/tests/test-td-payload/src/main.rs
@@ -5,7 +5,6 @@
 #![no_std]
 #![no_main]
 #![allow(unused)]
-#![feature(alloc_error_handler)]
 #[macro_use]
 
 mod lib;


### PR DESCRIPTION
As the feature `default_alloc_error_handler` has been stablized, compiler can automatically generate a default OOM handler that panics if no `#[alloc_error_handler]` is provided.