### PR TITLE
Fix compilation warning in ring library

### DIFF
--- a/sh_script/preparation.sh
+++ b/sh_script/preparation.sh
@@ -5,6 +5,11 @@ preparation() {
     pushd library/ring
     git reset --hard 464d367252354418a2c17feb806876d4d89a8508
     git clean -f -d
+
+    # apply the patch to get rid of unused import warning during compilation
+    # https://github.com/briansmith/ring/commit/c4742e0cae849f08ff410a817c5266af41670b3d
+    git cherry-pick c4742e0cae849f08ff410a817c5266af41670b3d
+
     patch -p 1 -i ../patches/ring.diff
     popd
 }


### PR DESCRIPTION
The following warning is being fixed:

warning: unused imports: `PKCS1`, `PSS`
  --> ring/src/rsa/padding.rs:21:13
   |
21 |     pkcs1::{PKCS1, RSA_PKCS1_SHA256, RSA_PKCS1_SHA384, RSA_PKCS1_SHA512},
   |             ^^^^^
22 |     pss::{PSS, RSA_PSS_SHA256, RSA_PSS_SHA384, RSA_PSS_SHA512},
   |           ^^^
   |
   = note: `#[warn(unused_imports)]` on by default

That warning was already fixed with this patch:
https://github.com/briansmith/ring/commit/c4742e0cae849f08ff410a817c5266af41670b3d

Once ring library version will be bumped up, this patch could be dropped.