### PR TITLE
Fix compilation warnings

### DIFF
--- a/td-payload/src/mm/heap.rs
+++ b/td-payload/src/mm/heap.rs
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use core::panic::PanicInfo;
+#[cfg(not(feature = "test_heap_size"))]
 use linked_list_allocator::LockedHeap;
 #[cfg(feature = "test_heap_size")]
 use td_benchmark::Alloc;
 
 #[cfg(feature = "test_heap_size")]
 #[global_allocator]
-static HEAP: td_benchmark::Alloc = td_benchmark::Alloc;
+static HEAP: Alloc = Alloc;
 
 #[cfg(not(feature = "test_heap_size"))]
 #[global_allocator]
@@ -27,10 +28,10 @@ fn panic(_info: &PanicInfo) -> ! {
 
 /// The initialization method for the global heap allocator.
 pub fn init_heap(heap_start: u64, heap_size: usize) {
+    #[cfg(not(feature = "test_heap_size"))]
     unsafe {
-        #[cfg(not(feature = "test_heap_size"))]
         HEAP.lock().init(heap_start as *mut u8, heap_size);
-        #[cfg(feature = "test_heap_size")]
-        td_benchmark::HeapProfiling::init(heap_start, heap_size);
     }
+    #[cfg(feature = "test_heap_size")]
+    td_benchmark::HeapProfiling::init(heap_start, heap_size);
 }


### PR DESCRIPTION
The following warnings are being fixed:

warning: unused import: `linked_list_allocator::LockedHeap`
 --> deps/td-shim/td-payload/src/mm/heap.rs:6:5
  |
6 | use linked_list_allocator::LockedHeap;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `td_benchmark::Alloc`
 --> deps/td-shim/td-payload/src/mm/heap.rs:8:5
  |
8 | use td_benchmark::Alloc;
  |     ^^^^^^^^^^^^^^^^^^^

warning: unnecessary `unsafe` block
  --> deps/td-shim/td-payload/src/mm/heap.rs:30:5
   |
30 |     unsafe {
   |     ^^^^^^ unnecessary `unsafe` block
   |
   = note: `#[warn(unused_unsafe)]` on by default