### PR TITLE
td-exception: fix interrupt handler condition

### DIFF
--- a/td-exception/src/asm/handler.asm
+++ b/td-exception/src/asm/handler.asm
@@ -52,7 +52,7 @@ interrupt_handler_table:
         i = 0
         .rept 256
         .align 32
-        .if ((EXCEPTION_ERROR_CODE_MASK >> i) & 1) == 0
+        .if i > 31 || ((EXCEPTION_ERROR_CODE_MASK >> i) & 1) == 0
         push 0
         .endif
         push i


### PR DESCRIPTION
The compiler may perform a circular right shift, resulting in incorrect assembly code for interrupt vectors greater than 64. Unconditionally push an error code of 0 for interrupt vectors greater than 31, as the CPU does not save an error code for these interrupts.