### PR TITLE
td-exception: public `InterruptCallback::new`

### DIFF
--- a/td-exception/src/interrupt.rs
+++ b/td-exception/src/interrupt.rs
@@ -98,7 +98,7 @@ pub struct InterruptCallback {
 }
 
 impl InterruptCallback {
-    const fn new(func: fn(&mut InterruptStack)) -> Self {
+    pub const fn new(func: fn(&mut InterruptStack)) -> Self {
         InterruptCallback { func }
     }
 }

--- a/td-payload/src/arch/x86_64/idt.rs
+++ b/td-payload/src/arch/x86_64/idt.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 pub use td_exception::idt::*;
+pub use td_exception::interrupt::*;
 
 pub const PAGE_FAULT_EXCEPTION: u8 = 14;
 pub const PAGE_FAULT_IST: u8 = 1;


### PR DESCRIPTION
`InterruptCallback::new` shall be set as pub to make it possible for user of this crate to register callback via `register_interrupt_callback`.

Publicly use `td_exception::interrupt::*` in `td-payload` crate can help reduce redundant references to the `td-exception` crate.