### PR TITLE
Fix compilations warnings in libraries

### DIFF
--- a/library/patches/0001-NFC-Address-Clippy-unused-import-warning.patch
+++ b/library/patches/0001-NFC-Address-Clippy-unused-import-warning.patch
@@ -1,0 +1,29 @@
+From c4742e0cae849f08ff410a817c5266af41670b3d Mon Sep 17 00:00:00 2001
+From: Brian Smith <brian@briansmith.org>
+Date: Tue, 9 Jan 2024 10:52:37 -0800
+Subject: [PATCH] NFC: Address Clippy unused import warning.
+
+See https://github.com/briansmith/ring/issues/1887 about addressing this
+messiness long-term.
+---
+ src/rsa/padding.rs | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/rsa/padding.rs b/src/rsa/padding.rs
+index faf2422d9..9b79cd0f6 100644
+--- a/src/rsa/padding.rs
++++ b/src/rsa/padding.rs
+@@ -18,8 +18,8 @@ mod pkcs1;
+ mod pss;
+ 
+ pub use self::{
+-    pkcs1::{PKCS1, RSA_PKCS1_SHA256, RSA_PKCS1_SHA384, RSA_PKCS1_SHA512},
+-    pss::{PSS, RSA_PSS_SHA256, RSA_PSS_SHA384, RSA_PSS_SHA512},
++    pkcs1::{RSA_PKCS1_SHA256, RSA_PKCS1_SHA384, RSA_PKCS1_SHA512},
++    pss::{RSA_PSS_SHA256, RSA_PSS_SHA384, RSA_PSS_SHA512},
+ };
+ pub(super) use pkcs1::RSA_PKCS1_SHA1_FOR_LEGACY_USE_ONLY;
+ 
+-- 
+2.34.1
+

--- a/sh_script/preparation.sh
+++ b/sh_script/preparation.sh
@@ -5,11 +5,6 @@ preparation() {
     pushd library/ring
     git reset --hard 464d367252354418a2c17feb806876d4d89a8508
     git clean -f -d
-
-    # apply the patch to get rid of unused import warning during compilation
-    # https://github.com/briansmith/ring/commit/c4742e0cae849f08ff410a817c5266af41670b3d
-    git cherry-pick c4742e0cae849f08ff410a817c5266af41670b3d
-
     patch -p 1 -i ../patches/ring.diff
     popd
 }

--- a/sh_script/preparation.sh
+++ b/sh_script/preparation.sh
@@ -6,6 +6,7 @@ preparation() {
     git reset --hard 464d367252354418a2c17feb806876d4d89a8508
     git clean -f -d
     patch -p 1 -i ../patches/ring.diff
+    git apply ../patches/0001-NFC-Address-Clippy-unused-import-warning.patch
     popd
 }
 


### PR DESCRIPTION
Following changes are a fixup for the https://github.com/confidential-containers/td-shim/pull/753 
It turned out that cherry-picking patches is not aligned with current CI workflow where fetching very limited number of revisions (branches, tags, sha, etc.).
Thus reverting previous commit and bringing new one based on keeping the patch locally in the repository