### PR TITLE
cc-measurement: Cargo.toml is missing license statement

### DIFF
--- a/cc-measurement/Cargo.toml
+++ b/cc-measurement/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cc-measurement"
 version = "0.1.0"
+license = "BSD-2-Clause-Patent"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Assuming BSD-2-Clause-Patent as parent directory