### PR TITLE
td-shim: support loading payload for each vCPU

### DIFF
--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -51,6 +51,7 @@ tdx = ["tdx-tdcall", "td-exception/tdx", "td-logger/tdx", "x86"]
 lazy-accept = ["tdx"]
 ring-hash = ["cc-measurement/ring"]
 sha2-hash = ["cc-measurement/sha2"]
+multi-payload = []
 main = [
     "log",
     "td-loader",

--- a/td-shim/src/bin/td-shim/e820.rs
+++ b/td-shim/src/bin/td-shim/e820.rs
@@ -8,7 +8,7 @@ use td_shim::e820::{E820Entry, E820Type};
 // Linux BootParam supports 128 e820 entries, so...
 const MAX_E820_ENTRY: usize = 128;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct E820Table {
     entries: [E820Entry; MAX_E820_ENTRY],
     num_entries: usize,

--- a/td-shim/src/bin/td-shim/td/tdx.rs
+++ b/td-shim/src/bin/td-shim/td/tdx.rs
@@ -6,6 +6,8 @@ use cc_measurement::log::CcEventLogError;
 use td_exception::idt::DescriptorTablePointer;
 use tdx_tdcall::tdx;
 
+pub use super::tdx_mailbox::ap_set_payload;
+
 extern "win64" {
     fn asm_read_msr64(index: u32) -> u64;
     fn asm_write_msr64(index: u32, value: u64) -> u64;


### PR DESCRIPTION
When feature `multi-payload` is enabled, td-shim will load a payload binary for each vCPU, and it will also evenly divide the largest contiguous available memory among each vCPU, generating the e820 table and HOB for them.