### PR TITLE
Introduce a new feature no-metadata-checks

### DIFF
--- a/td-shim-interface/Cargo.toml
+++ b/td-shim-interface/Cargo.toml
@@ -16,3 +16,6 @@ scroll = { version = "0.10", default-features = false, features = ["derive"] }
 zerocopy = { version = "0.7.31", features = ["derive"] }
 
 log = "0.4.13"
+
+[features]
+no-metadata-checks = []

--- a/td-shim-interface/src/metadata.rs
+++ b/td-shim-interface/src/metadata.rs
@@ -98,14 +98,22 @@ impl TdxMetadataDescriptor {
     }
 
     pub fn is_valid(&self) -> bool {
-        let len = self.length;
+        #[cfg(not(feature = "no-metadata-checks"))]
+        if self.signature != TDX_METADATA_SIGNATURE {
+            return false;
+        }
 
-        !(self.signature != TDX_METADATA_SIGNATURE
-            || self.version != 1
+        let len = self.length;
+        if self.version != 1
             || self.number_of_section_entry == 0
             || len < 16
             || (len - 16) % 32 != 0
-            || (len - 16) / 32 != self.number_of_section_entry)
+            || (len - 16) / 32 != self.number_of_section_entry
+        {
+            return false;
+        }
+
+        true
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -235,6 +243,7 @@ pub fn validate_sections(sections: &[TdxMetadataSection]) -> Result<(), TdxMetad
                 if section.raw_data_size == 0 {
                     return Err(TdxMetadataError::InvalidSection);
                 }
+                #[cfg(not(feature = "no-metadata-checks"))]
                 if section.attributes != TDX_METADATA_ATTRIBUTES_EXTENDMR {
                     return Err(TdxMetadataError::InvalidSection);
                 }
@@ -328,6 +337,7 @@ pub fn validate_sections(sections: &[TdxMetadataSection]) -> Result<(), TdxMetad
                 if section.raw_data_size != 0 || section.data_offset != 0 {
                     return Err(TdxMetadataError::InvalidSection);
                 }
+                #[cfg(not(feature = "no-metadata-checks"))]
                 if section.attributes != TDX_METADATA_ATTRIBUTES_PAGE_AUG {
                     return Err(TdxMetadataError::InvalidSection);
                 }
@@ -352,6 +362,7 @@ pub fn validate_sections(sections: &[TdxMetadataSection]) -> Result<(), TdxMetad
                 if payload_cnt > 1 {
                     return Err(TdxMetadataError::InvalidSection);
                 }
+                #[cfg(not(feature = "no-metadata-checks"))]
                 if section.attributes & (!TDX_METADATA_ATTRIBUTES_EXTENDMR) != 0 {
                     return Err(TdxMetadataError::InvalidSection);
                 }

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -53,6 +53,7 @@ ring-hash = ["cc-measurement/ring"]
 sha2-hash = ["cc-measurement/sha2"]
 no-tdvmcall = ["tdx-tdcall/no-tdvmcall", "td-logger/no-tdvmcall", "td-exception/no-tdvmcall"]
 no-tdaccept = ["tdx-tdcall/no-tdaccept"]
+no-metadata-checks = ["td-shim-interface/no-metadata-checks"]
 
 main = [
     "log",


### PR DESCRIPTION
Some consumers of TD-Shim (such as TPA TD) might require td-shim to skip runtime metadata checks such as
signature check or entries attributes checks when the image is deliberately not compliant with TD-Shim specification.
This PR introduces new feature flag no-metadata-checks which allows user to skip those checks.