### PR TITLE
Introduce a new feature tdg_dbg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "tdx-tdcall"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cfg-if",
  "lazy_static",

--- a/td-logger/Cargo.toml
+++ b/td-logger/Cargo.toml
@@ -19,3 +19,4 @@ x86 = { version = "0.47.0", optional = true }
 tdx = ["tdx-tdcall"]
 serial-port = ["x86"]
 no-tdvmcall = ["tdx-tdcall/no-tdvmcall"]
+tdg_dbg = ["tdx-tdcall/tdg_dbg"]

--- a/td-payload/src/arch/x86_64/serial.rs
+++ b/td-payload/src/arch/x86_64/serial.rs
@@ -17,6 +17,10 @@ pub fn serial_write_string(s: &str) {
     }
 }
 
+#[cfg(any(
+    all(feature = "tdx", not(feature = "no-tdvmcall")),
+    not(feature = "tdx")
+))]
 const SERIAL_IO_PORT: u16 = 0x3F8;
 
 #[cfg(all(feature = "tdx", not(feature = "no-tdvmcall")))]

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -54,6 +54,7 @@ sha2-hash = ["cc-measurement/sha2"]
 no-tdvmcall = ["tdx-tdcall/no-tdvmcall", "td-logger/no-tdvmcall", "td-exception/no-tdvmcall"]
 no-tdaccept = ["tdx-tdcall/no-tdaccept"]
 no-metadata-checks = ["td-shim-interface/no-metadata-checks"]
+tdg_dbg = ["td-logger/tdg_dbg"]
 
 main = [
     "log",

--- a/tdx-tdcall/CHANGELOG.md
+++ b/tdx-tdcall/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.2.3] - 2025-03-13
++### Added
++- Added new tdcall_tdg_debug_write_8 API under tdg_dbg feature.
+
 ## [0.2.1] - 2024-07-23
 ### Changed
 - Remove nightly feature in the x86_64 crate

--- a/tdx-tdcall/Cargo.toml
+++ b/tdx-tdcall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdx-tdcall"
-version = "0.2.2"
+version = "0.2.3"
 description = "Constants, stuctures and wrappers to access TDCALL services"
 repository = "https://github.com/confidential-containers/td-shim"
 homepage = "https://github.com/confidential-containers"
@@ -23,3 +23,4 @@ default = []
 use_tdx_emulation = []
 no-tdvmcall = []
 no-tdaccept = []
+tdg_dbg = []

--- a/tdx-tdcall/src/lib.rs
+++ b/tdx-tdcall/src/lib.rs
@@ -55,6 +55,8 @@ const TDCALL_MEM_PAGE_ATTR_WR: u64 = 24;
 const TDCALL_VP_ENTER: u64 = 25;
 const TDCALL_VP_INVEPT: u64 = 26;
 const TDCALL_VP_INVVPID: u64 = 27;
+#[cfg(feature = "tdg_dbg")]
+const TDCALL_TDG_DEBUG: u64 = 254;
 
 // TDCALL completion status code
 const TDCALL_STATUS_SUCCESS: u64 = 0;

--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -967,6 +967,24 @@ pub fn tdcall_mem_page_attr_wr(
     return Err(ret.into());
 }
 
+/// Debug-only: Write a byte to TDX Module
+///
+/// Details can be found in TDX Module v2.1 ABI spec section 'TDG.DEBUG Leaf'.
+/// This API is only valid for debug TDX Module version.
+#[cfg(feature = "tdg_dbg")]
+pub fn tdcall_tdg_debug_write_8(byte: u8) -> TdcallArgs {
+    let mut args = TdcallArgs {
+        rax: TDCALL_TDG_DEBUG,
+        rcx: 0u64, // WriteByte
+        rdx: byte as u64,
+        ..Default::default()
+    };
+
+    td_call(&mut args);
+
+    args
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This PR adds support for newly defined tdg_dbg feature.
It introduces support for TDG.DEBUG ABI that's valid only with debug TDX Module, as defined in TDX Module 2.1 ABI specification.