### PR TITLE
td-shim,td-logger: remove default log level

### DIFF
--- a/td-logger/Cargo.toml
+++ b/td-logger/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
-log = { version = "0.4.13", features = ["max_level_info", "release_max_level_info"] }
+log = { version = "0.4.13" }
 spin = "0.9.2"
 tdx-tdcall = { path = "../tdx-tdcall", optional = true }
 # Lock down to 0.44, otherwise it depends on inline asm

--- a/td-shim/Cargo.toml
+++ b/td-shim/Cargo.toml
@@ -29,7 +29,7 @@ zerocopy = { version = "0.7.31", features = ["derive"] }
 
 td-loader = { path = "../td-loader", optional = true }
 linked_list_allocator = { version = "0.10", optional = true }
-log = { version = "0.4.13", features = ["release_max_level_off"], optional = true }
+log = { version = "0.4.13", optional = true }
 ring = { version = "0.17.14", default-features = false, features = ["alloc"], optional = true }
 spin = { version = "0.9.2", optional = true }
 td-exception =  { path = "../td-exception", optional = true }


### PR DESCRIPTION
Both td-shim and td-logger are used as libraries for different products. Declaring log-level as default feature prevents the consumers from overriding the log-level to higher value.

This change is to allow consumers to declare their own log-level.