### PR TITLE
Add aligned memory allocations in the memory layout

### DIFF
--- a/devtools/td-layout-config/src/image.rs
+++ b/devtools/td-layout-config/src/image.rs
@@ -36,7 +36,7 @@ pub fn parse_image(data: String) -> String {
     let image_config = serde_json::from_str::<ImageConfig>(&data)
         .expect("Content is configuration file is invalid");
 
-    let mut image_size = 0x100_0000 as usize;
+    let mut image_size = 0x100_0000_usize;
     if image_config.image_size.is_some() {
         image_size = parse_int::parse::<u32>(&image_config.image_size.unwrap()).unwrap() as usize;
     }

--- a/devtools/td-layout-config/src/main.rs
+++ b/devtools/td-layout-config/src/main.rs
@@ -37,8 +37,8 @@ struct Cli {
 fn main() {
     let cli = Cli::parse();
 
-    let config = std::fs::read_to_string(cli.config.to_string())
-        .expect("Content is configuration file is invalid");
+    let config =
+        std::fs::read_to_string(&cli.config).expect("Content is configuration file is invalid");
 
     let output_file = cli.output.as_ref().map(|path| PathBuf::from(&path));
 

--- a/devtools/td-layout-config/src/memory.rs
+++ b/devtools/td-layout-config/src/memory.rs
@@ -11,23 +11,40 @@ struct Region {
     pub name: String,
     pub size: String,
     pub r#type: String,
+    pub alignment: Option<String>, // Optional field for alignment
 }
 
 #[derive(Deserialize, Debug)]
 struct MemoryConfig {
     memory_regions: Vec<Region>,
+    memory_top: Option<String>,
 }
 
 pub fn parse_memory(data: String) -> String {
     let memory_config = serde_json::from_str::<MemoryConfig>(&data)
         .expect("Content is configuration file is invalid");
 
-    let mut memory_layout = LayoutConfig::new(0x0, 0x8000_0000);
+    let mut memory_top = 0x8000_0000 as usize; // default 2 GiB
+    if memory_config.memory_top.is_some() {
+        memory_top = parse_int::parse::<u64>(&memory_config.memory_top.unwrap()).unwrap() as usize;
+    }
+
+    let mut memory_layout = LayoutConfig::new(0x0, memory_top);
 
     for region in memory_config.memory_regions {
         let size = parse_int::parse::<usize>(&region.size).unwrap();
         if region.r#type.as_str() == "Memory" {
-            memory_layout.reserve_low(&region.name, size, &region.r#type);
+            if let Some(alignment) = &region.alignment {
+                let alignment_value = parse_int::parse::<usize>(alignment).unwrap();
+                memory_layout.reserve_low_aligned(
+                    &region.name,
+                    size,
+                    &region.r#type,
+                    alignment_value,
+                );
+            } else {
+                memory_layout.reserve_low(&region.name, size, &region.r#type);
+            }
         } else {
             memory_layout.reserve_high(&region.name, size, &region.r#type);
         }

--- a/devtools/td-layout-config/src/memory.rs
+++ b/devtools/td-layout-config/src/memory.rs
@@ -24,7 +24,7 @@ pub fn parse_memory(data: String) -> String {
     let memory_config = serde_json::from_str::<MemoryConfig>(&data)
         .expect("Content is configuration file is invalid");
 
-    let mut memory_top = 0x8000_0000 as usize; // default 2 GiB
+    let mut memory_top = 0x8000_0000_usize; // default 2 GiB
     if memory_config.memory_top.is_some() {
         memory_top = parse_int::parse::<u64>(&memory_config.memory_top.unwrap()).unwrap() as usize;
     }

--- a/devtools/td-layout-config/src/render.rs
+++ b/devtools/td-layout-config/src/render.rs
@@ -23,7 +23,7 @@ pub fn render_image(image_layout: &LayoutConfig) -> Result<String> {
     context.insert("sec_info_offset", &(image_layout.get_top() - 0x54));
     context.insert(
         "memory_offset",
-        &(u32::MAX as usize + 1 - &image_layout.get_top()),
+        &(u32::MAX as usize + 1 - image_layout.get_top()),
     );
     context.insert("entry_type_filter", ENTRY_TYPE_FILTER);
     tera.render("image.rs", &context)


### PR DESCRIPTION
**Add support for aligned memory allocations and configurable memory top**

This PR enhances the memory layout configuration with two key improvements:

**Aligned Memory Allocations:**
- Introduces an optional `alignment` field for memory regions that specifies the required base address alignment
- Implements `reserve_low_aligned()` method that properly handles alignment gaps by preserving them as free memory regions
- Refactors the layout manager to support multiple non-contiguous free regions instead of tracking a single free region
- Maintains full backward compatibility - regions without alignment specification work exactly as before

**Configurable Memory Top:**
- Adds optional `memory_top` field to memory configuration that defines the upper bound of available memory
- Defaults to 2 GiB (0x8000_0000) when not specified, preserving existing behavior
- Allows flexible memory layout sizing based on the inputs

**Technical Changes:**
- Removed single `free_index` tracking in favor of dynamic free region discovery
- Added helper methods for finding suitable free regions based on size and alignment requirements
- Updated all allocation methods (`reserve_low`, `reserve_high`, `reserve_low_aligned`) to work with fragmented memory layouts
- Enhanced memory usage calculation to account for multiple free regions
- Added comprehensive test coverage for aligned allocations