### PR TITLE
changes to support hashtool and enrollment on IGVM

### DIFF
--- a/td-shim-tools/Cargo.toml
+++ b/td-shim-tools/Cargo.toml
@@ -61,6 +61,7 @@ byteorder = { version = "1.4.3", optional = true }
 parse_int = { version = "0.6.0", optional = true }
 igvm = "0.3.4"
 igvm_defs = "0.3.4"
+zerocopy = { version = "0.8.14", features = ["derive"]}
 
 [features]
 default = ["enroller", "linker", "signer", "loader", "tee", "calculator"]

--- a/td-shim-tools/src/lib.rs
+++ b/td-shim-tools/src/lib.rs
@@ -58,16 +58,20 @@ impl InputData {
             error!("Can not read data from file {}: {}", name, e);
             e
         })?;
-        let len = data.len();
-        if !range.contains(&len) {
-            error!(
-                "Size of {} file ({}) is invalid, should be in range [{}-{}]",
-                desc,
-                len,
-                range.start(),
-                range.end()
-            );
-            return Err(io::Error::new(io::ErrorKind::Other, "invalid file size"));
+
+        // IGVM files need not be TD_SHIM_FIRMWARE_SIZE, as an optimization IGVM files deduplicate pages
+        if !name.contains(".igvm") {
+            let len = data.len();
+            if !range.contains(&len) {
+                error!(
+                    "Size of {} file ({}) is invalid, should be in range [{}-{}]",
+                    desc,
+                    len,
+                    range.start(),
+                    range.end()
+                );
+                return Err(io::Error::new(io::ErrorKind::Other, "invalid file size"));
+            }
         }
 
         Ok(InputData { data })

--- a/td-shim-tools/src/linker.rs
+++ b/td-shim-tools/src/linker.rs
@@ -440,7 +440,7 @@ impl TdShimLinker {
             TD_SHIM_CONFIG_BASE as u64,
             TD_SHIM_CONFIG_SIZE as u64,
             &vec![],
-            false,
+            true,
         );
 
         insert_igvm_pages(
@@ -448,7 +448,7 @@ impl TdShimLinker {
             TD_SHIM_MAILBOX_BASE as u64,
             TD_SHIM_MAILBOX_SIZE as u64,
             &vec![],
-            false,
+            true,
         );
 
         insert_igvm_pages(
@@ -456,7 +456,7 @@ impl TdShimLinker {
             TD_SHIM_TEMP_STACK_BASE as u64,
             TD_SHIM_TEMP_STACK_SIZE as u64,
             &vec![],
-            false,
+            true,
         );
 
         insert_igvm_pages(
@@ -464,7 +464,7 @@ impl TdShimLinker {
             TD_SHIM_TEMP_HEAP_BASE as u64,
             TD_SHIM_TEMP_HEAP_SIZE as u64,
             &vec![],
-            false,
+            true,
         );
 
         if let Some(payload_name) = payload_name {
@@ -492,7 +492,7 @@ impl TdShimLinker {
                 TD_SHIM_PAYLOAD_BASE as u64,
                 TD_SHIM_PAYLOAD_SIZE as u64,
                 &payload_data,
-                true,
+                false,
             );
         }
 
@@ -574,7 +574,7 @@ impl TdShimLinker {
             TD_SHIM_METADATA_BASE as u64,
             bfv_size as u64,
             &bfv_data,
-            true,
+            false,
         );
 
         if (TD_SHIM_FIRMWARE_BASE as u64 + TD_SHIM_FIRMWARE_SIZE as u64) < MEMORY_4G {
@@ -586,7 +586,7 @@ impl TdShimLinker {
                 base,
                 size,
                 &bfv_data[start..].to_vec(),
-                true,
+                false,
             );
         }
 


### PR DESCRIPTION
Currently MRTD calculation is being done on binary format, this code ensures IGVM files are parsed for calculating MRTD hash. Also, currently Binary enrollment (CFV section) is being skipped for IGVM format, this commit supports it for IGVM files.