### PR TITLE
td-shim-tools: unmeasure CFV for igvm

### DIFF
--- a/td-shim-tools/src/enroller.rs
+++ b/td-shim-tools/src/enroller.rs
@@ -214,7 +214,7 @@ pub fn enroll_files(
                                 let paddingbytes = PAGE_SIZE_4K as usize - (end - start);
                                 page_data.extend(std::iter::repeat(0).take(paddingbytes));
                             }
-                            pagedataflags.set_unmeasured(false);
+                            pagedataflags.set_unmeasured(true);
                         } else {
                             page_data = vec![];
                         }


### PR DESCRIPTION
CFV memory should not be in MRTD otherwise we have circular dependency between policy (which is in CFV) and MRTD measurement. CFV memories are measured in RTMRs.