### PR TITLE
feat(td-shim): implement FatalError TdVmcall during panic()

### DIFF
--- a/td-payload/src/mm/heap.rs
+++ b/td-payload/src/mm/heap.rs
@@ -22,6 +22,10 @@ fn panic(_info: &PanicInfo) -> ! {
     use crate::println;
 
     println!("panic ... {:?}", _info);
+
+    #[cfg(not(feature = "no-tdvmcall"))]
+    tdx_tdcall::tdx::tdvmcall_report_fatal_error(0, None);
+
     x86_64::instructions::hlt();
     loop {}
 }

--- a/tdx-tdcall/src/lib.rs
+++ b/tdx-tdcall/src/lib.rs
@@ -78,6 +78,7 @@ cfg_if::cfg_if! {
         const TDVMCALL_MMIO: u64 = 0x00030;
         const TDVMCALL_MAPGPA: u64 = 0x10001;
         const TDVMCALL_GETQUOTE: u64 = 0x10002;
+        const TDVMCALL_REPORTFATALERROR: u64 = 0x10003;
         const TDVMCALL_SETUPEVENTNOTIFY: u64 = 0x10004;
         const TDVMCALL_SERVICE: u64 = 0x10005;
         const TDVMCALL_MIGTD: u64 = 0x10006;

--- a/tdx-tdcall/src/tdx.rs
+++ b/tdx-tdcall/src/tdx.rs
@@ -101,6 +101,25 @@ lazy_static! {
     static ref SHARED_MASK: u64 = td_shared_mask().expect("Fail to get the shared mask of TD");
 }
 
+/// Report a fatal error to the VMM via TDG.VP.VMCALL<ReportFatalError>.
+///
+/// Per GHCI 1.5 section 3.4: informs the host VMM that the TD has experienced
+/// a fatal-error state with a zero-terminated error string in shared memory.
+#[cfg(not(feature = "no-tdvmcall"))]
+pub fn tdvmcall_report_fatal_error(error_code: u32, shared_gpa: Option<u64>) {
+    let r12 = (error_code as u64) | if shared_gpa.is_some() { 1u64 << 63 } else { 0 };
+    let r13 = shared_gpa.unwrap_or(0);
+
+    let mut args = TdVmcallArgs {
+        r11: TDVMCALL_REPORTFATALERROR,
+        r12,
+        r13,
+        ..Default::default()
+    };
+
+    let _ = td_vmcall(&mut args);
+}
+
 /// Used to help perform HLT operation.
 ///
 /// Details can be found in TDX GHCI spec section 'TDG.VP.VMCALL<Instruction.HLT>'


### PR DESCRIPTION
Add TDVMCALL_REPORTFATALERROR (0x10003) constant and tdvmcall_report_fatal_error() function per GHCI 1.5 section 3.4. Update panic handler to invoke ReportFatalError before halting.