### PR TITLE
fix(td-layout-config): remove vulnerable rand 0.8.5 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,12 +31,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,36 +224,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -751,15 +724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "parse_int"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,54 +784,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
@@ -892,36 +812,6 @@ name = "r-efi"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6198999a900fd9cf051f2109ec3b9589b5c67cbfc77ff82c9fdff24aec83aa7b"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "range_map_vec"
@@ -1098,12 +988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
 name = "slug"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,7 +1096,9 @@ name = "td-layout-config"
 version = "0.1.0"
 dependencies = [
  "Inflector",
+ "chrono",
  "clap",
+ "humansize",
  "parse_int",
  "scroll",
  "serde",
@@ -1369,14 +1255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8004bca281f2d32df3bacd59bc67b312cb4c70cea46cbd79dbe8ac5ed206722"
 dependencies = [
  "chrono",
- "chrono-tz",
  "globwalk",
  "humansize",
  "lazy_static",
  "percent-encoding",
  "pest",
  "pest_derive",
- "rand",
  "regex",
  "serde",
  "serde_json",
@@ -1699,6 +1583,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.0",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"

--- a/devtools/td-layout-config/Cargo.toml
+++ b/devtools/td-layout-config/Cargo.toml
@@ -17,4 +17,6 @@ parse_int = "0.6.0"
 scroll = { version = "0.10", default-features = false, features = ["derive"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tera = "1.17.1"
+tera = { version = "1.20.1", default-features = false, features = ["urlencode", "slug", "humansize", "chrono"] }
+chrono = "0.4"
+humansize = "2"

--- a/devtools/td-layout-config/src/render.rs
+++ b/devtools/td-layout-config/src/render.rs
@@ -2,15 +2,99 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
+use chrono::Local;
+use humansize::format_size;
 use serde_json::Value;
 use std::collections::HashMap;
 use tera::{Context, Result, Tera};
 
 use super::layout::{LayoutConfig, ENTRY_TYPE_FILTER};
 
+/// Register builtin functions/filters that are normally behind tera's "builtins"
+/// feature, which we disable to avoid pulling in the vulnerable rand 0.8.5 crate.
+fn register_builtins(tera: &mut Tera) {
+    tera.register_function("now", now);
+    tera.register_filter("date", date);
+    tera.register_filter("filesizeformat", filesizeformat);
+}
+
+fn now(args: &HashMap<String, tera::Value>) -> Result<tera::Value> {
+    let utc = args.get("utc").and_then(|v| v.as_bool()).unwrap_or(false);
+    let timestamp = args
+        .get("timestamp")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if utc {
+        let dt = chrono::Utc::now();
+        if timestamp {
+            return Ok(serde_json::to_value(dt.timestamp()).unwrap());
+        }
+        Ok(serde_json::to_value(dt.to_rfc3339()).unwrap())
+    } else {
+        let dt = Local::now();
+        if timestamp {
+            return Ok(serde_json::to_value(dt.timestamp()).unwrap());
+        }
+        Ok(serde_json::to_value(dt.to_rfc3339()).unwrap())
+    }
+}
+
+fn date(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
+    let format = match args.get("format") {
+        Some(val) => val
+            .as_str()
+            .ok_or_else(|| tera::Error::msg("Filter `date` received a non-string `format`"))?
+            .to_string(),
+        None => "%Y-%m-%d".to_string(),
+    };
+    match value {
+        Value::String(s) => {
+            use chrono::{DateTime, FixedOffset, NaiveDateTime};
+            if s.contains('T') {
+                let dt: DateTime<FixedOffset> = s
+                    .parse()
+                    .map_err(|_| tera::Error::msg(format!("Failed to parse datetime `{s}`")))?;
+                Ok(Value::String(dt.format(&format).to_string()))
+            } else {
+                let dt = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
+                    .map_err(|_| tera::Error::msg(format!("Failed to parse datetime `{s}`")))?;
+                Ok(Value::String(dt.format(&format).to_string()))
+            }
+        }
+        Value::Number(n) => {
+            let i = n.as_i64().ok_or_else(|| {
+                tera::Error::msg(format!("Filter `date` was invoked on a float: {n}"))
+            })?;
+            let dt = chrono::DateTime::from_timestamp(i, 0)
+                .ok_or_else(|| tera::Error::msg("Timestamp out of range"))?
+                .naive_utc();
+            Ok(Value::String(dt.format(&format).to_string()))
+        }
+        _ => Err(tera::Error::msg(format!(
+            "Filter `date` received an invalid value: `{value}`"
+        ))),
+    }
+}
+
+fn filesizeformat(value: &Value, args: &HashMap<String, Value>) -> Result<Value> {
+    let num: usize = serde_json::from_value(value.clone())
+        .map_err(|_| tera::Error::msg("Filter `filesizeformat` received a non-number value"))?;
+    let binary = args
+        .get("binary")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let format = if binary {
+        humansize::BINARY
+    } else {
+        humansize::WINDOWS
+    };
+    Ok(serde_json::to_value(format_size(num, format)).unwrap())
+}
+
 /// Render image layout file.
 pub fn render_image(image_layout: &LayoutConfig, fw_top: usize) -> Result<String> {
     let mut tera = Tera::default();
+    register_builtins(&mut tera);
     tera.register_filter("format_hex", format_hex);
     tera.register_filter("format_name", format_name);
     tera.register_filter("format_layout_border", format_layout_border);
@@ -29,6 +113,7 @@ pub fn render_image(image_layout: &LayoutConfig, fw_top: usize) -> Result<String
 /// Render memory layout file.
 pub fn render_memory(memory_layout: &LayoutConfig) -> Result<String> {
     let mut tera = Tera::default();
+    register_builtins(&mut tera);
     tera.register_filter("format_hex", format_hex);
     tera.register_filter("format_name", format_name);
     tera.register_filter("format_layout_border", format_layout_border);


### PR DESCRIPTION
## Summary

Remove the vulnerable `rand` 0.8.5 crate ([GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc)) from the dependency tree.

## Changes

- Disable tera's default `builtins` feature in `td-layout-config`, which transitively pulled in `rand` 0.8.5
- Replace tera's built-in `now()`, `date()`, and `filesizeformat` template functions with custom implementations using `chrono` and `humansize` directly
- Update `tera` from 1.17.1 to 1.20.1
- Remove 10+ transitive dependencies (`rand`, `rand_core`, `rand_chacha`, `phf`, `phf_generator`, `chrono-tz`, `chrono-tz-build`, etc.)

## Testing

- `cargo test -p td-layout-config` passes
- Both image and memory layout rendering verified (copyright year, human-readable sizes)
- `rand` is completely removed from `Cargo.lock`

Closes #841