### PR TITLE
ci: make TDX integration test workflow manual-only

### DIFF
--- a/.github/workflows/integration-tdx.yml
+++ b/.github/workflows/integration-tdx.yml
@@ -1,10 +1,4 @@
 on:
-  push:
-    paths-ignore:
-      - "**.md"
-  pull_request:
-    paths-ignore:
-      - "**.md"
   workflow_dispatch:
 
 name: Integration Test on TDX Server


### PR DESCRIPTION
Remove push and pull_request triggers from the integration-tdx workflow, keeping only workflow_dispatch.
The self-hosted TDX runner is currently broken, causing CI failures on every PR.