### PR TITLE
td-layout-config: add TempMemBase to relocate TempMem entries to guest RAM

### DIFF
--- a/devtools/td-layout-config/config_image.json
+++ b/devtools/td-layout-config/config_image.json
@@ -6,5 +6,6 @@
     "Metadata": "0x001000",
     "Payload": "0xC2D000",
     "Ipl": "0x349000",
-    "ResetVector": "0x008000"
+    "ResetVector": "0x008000",
+    "TempMemBase": "0x1FBF000"
 }

--- a/devtools/td-layout-config/src/image.rs
+++ b/devtools/td-layout-config/src/image.rs
@@ -30,6 +30,12 @@ struct ImageConfig {
     reset_vector: String,
     #[serde(rename = "ImageSize")]
     image_size: Option<String>,
+    /// Optional base address for TempMem entries (Mailbox, TempStack, TempHeap)
+    /// in guest RAM. When set, these entries get _BASE addresses relative to this
+    /// base instead of the firmware memory range. This allows QEMU to accept
+    /// TempMem pages via E820 RAM entries.
+    #[serde(rename = "TempMemBase")]
+    temp_mem_base: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -50,9 +56,14 @@ pub fn parse_image(data: String, metadata: Option<String>) -> String {
     let image_config = serde_json::from_str::<ImageConfig>(&data)
         .expect("Content in configuration file is invalid");
 
+    let temp_mem_base = image_config
+        .temp_mem_base
+        .as_ref()
+        .map(|s| parse_int::parse::<usize>(s).unwrap());
+
     let mut image_size = 0x100_0000 as usize;
-    if image_config.image_size.is_some() {
-        image_size = parse_int::parse::<u32>(&image_config.image_size.unwrap()).unwrap() as usize;
+    if let Some(ref size) = image_config.image_size {
+        image_size = parse_int::parse::<u32>(size).unwrap() as usize;
     }
 
     const MEMORY_4G: usize = 0x1_0000_0000;
@@ -142,6 +153,10 @@ pub fn parse_image(data: String, metadata: Option<String>) -> String {
             parse_int::parse::<u32>(&payload_config).unwrap() as usize,
             "Reserved",
         )
+    }
+
+    if let Some(base) = temp_mem_base {
+        image_layout.relocate_entries(base, &["MAILBOX", "TEMP_STACK", "TEMP_HEAP"]);
     }
 
     render::render_image(&image_layout, fw_top).expect("Render image layout failed!")

--- a/devtools/td-layout-config/src/layout.rs
+++ b/devtools/td-layout-config/src/layout.rs
@@ -16,6 +16,10 @@ pub struct LayoutEntry {
     region: Range<usize>,
     entry_type: String,
     tolm: bool,
+    /// Absolute base address override for entries relocated to guest RAM.
+    pub base_override: Option<usize>,
+    /// Whether base_override is set (for template rendering, since Tera treats 0 as falsy).
+    pub has_base_override: bool,
 }
 
 impl LayoutEntry {
@@ -29,6 +33,8 @@ impl LayoutEntry {
             region,
             entry_type,
             tolm,
+            base_override: None,
+            has_base_override: false,
         }
     }
 }
@@ -112,6 +118,18 @@ impl LayoutConfig {
 
     pub fn get_total_usage(&self) -> usize {
         self.top - self.base - (self.free_top() - self.free_base())
+    }
+
+    /// Relocate named entries to a contiguous block starting at `base`.
+    pub fn relocate_entries(&mut self, base: usize, names: &[&str]) {
+        let mut offset = 0usize;
+        for entry in self.list.iter_mut() {
+            if names.contains(&entry.name_screaming_snake_case.as_str()) {
+                entry.base_override = Some(base + offset);
+                entry.has_base_override = true;
+                offset += entry.region.end - entry.region.start;
+            }
+        }
     }
 
     pub fn get_regions(&self) -> &[LayoutEntry] {

--- a/devtools/td-layout-config/src/template/image.jinja
+++ b/devtools/td-layout-config/src/template/image.jinja
@@ -30,5 +30,9 @@ pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = {{memory_offset + sec_info_offset | 
 
 // Base Address after Loaded into Memory
 {%-for i in image_regions%}
+{%-if i.has_base_override %}
+pub const TD_SHIM_{{i.name_screaming_snake_case}}_BASE: u32 = {{i.base_override | format_hex }};
+{%-else%}
 pub const TD_SHIM_{{i.name_screaming_snake_case}}_BASE: u32 = {{memory_offset + i.region.start | format_hex }};
+{%-endif%}
 {%-endfor%}

--- a/td-shim-tools/etc/sample_metadata.json
+++ b/td-shim-tools/etc/sample_metadata.json
@@ -19,33 +19,9 @@
         {
             "DataOffset": "0x0",
             "RawDataSize": "0x0",
-            "MemoryAddress": "0xFF042000",
-            "MemoryDataSize": "0x20000",
-            "Type": "TempMem",
-            "Attributes": "0x0"
-        },
-        {
-            "DataOffset": "0x0",
-            "RawDataSize": "0x0",
-            "MemoryAddress": "0xFF062000",
-            "MemoryDataSize": "0x20000",
-            "Type": "TempMem",
-            "Attributes": "0x0"
-        },
-        {
-            "DataOffset": "0x0",
-            "RawDataSize": "0x0",
             "MemoryAddress": "0x800000",
             "MemoryDataSize": "0x20000",
             "Type": "TD_HOB",
-            "Attributes": "0x0"
-        },
-        {
-            "DataOffset": "0x0",
-            "RawDataSize": "0x0",
-            "MemoryAddress": "0xFF040000",
-            "MemoryDataSize": "0x1000",
-            "Type": "TempMem",
             "Attributes": "0x0"
         }
     ]

--- a/td-shim-tools/src/linker.rs
+++ b/td-shim-tools/src/linker.rs
@@ -245,8 +245,10 @@ pub fn build_tdx_metadata(
 ) -> io::Result<TdxMetadata> {
     let sections = if let Some(path) = path {
         let metadata_config = fs::read(path)?;
-        serde_json::from_slice::<MetadataSections>(metadata_config.as_slice())
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+        let mut sections = serde_json::from_slice::<MetadataSections>(metadata_config.as_slice())
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        sections.inject_temp_mem_from_layout();
+        sections
     } else {
         default_metadata_sections(payload_type)
     };

--- a/td-shim-tools/src/metadata.rs
+++ b/td-shim-tools/src/metadata.rs
@@ -100,6 +100,38 @@ impl MetadataSections {
     pub fn add(&mut self, section: TdxMetadataSection) {
         self.inner.push(section)
     }
+
+    /// Replace any TempMem sections with entries derived from build_time.rs
+    /// constants. This ensures metadata always matches the compiled layout.
+    pub fn inject_temp_mem_from_layout(&mut self) {
+        self.inner
+            .retain(|s| s.r#type != TDX_METADATA_SECTION_TYPE_TEMP_MEM);
+
+        self.inner.push(TdxMetadataSection {
+            data_offset: 0,
+            raw_data_size: 0,
+            memory_address: TD_SHIM_TEMP_STACK_BASE as u64,
+            memory_data_size: TD_SHIM_TEMP_STACK_SIZE as u64,
+            r#type: TDX_METADATA_SECTION_TYPE_TEMP_MEM,
+            attributes: 0,
+        });
+        self.inner.push(TdxMetadataSection {
+            data_offset: 0,
+            raw_data_size: 0,
+            memory_address: TD_SHIM_TEMP_HEAP_BASE as u64,
+            memory_data_size: TD_SHIM_TEMP_HEAP_SIZE as u64,
+            r#type: TDX_METADATA_SECTION_TYPE_TEMP_MEM,
+            attributes: 0,
+        });
+        self.inner.push(TdxMetadataSection {
+            data_offset: 0,
+            raw_data_size: 0,
+            memory_address: TD_SHIM_MAILBOX_BASE as u64,
+            memory_data_size: TD_SHIM_MAILBOX_SIZE as u64,
+            r#type: TDX_METADATA_SECTION_TYPE_TEMP_MEM,
+            attributes: 0,
+        });
+    }
 }
 
 fn basic_metadata_sections(payload_type: PayloadType) -> MetadataSections {


### PR DESCRIPTION
QEMU's tdx_accept_ram_range() only searches E820 RAM entries when accepting TDX memory. TempMem metadata sections with addresses in the firmware pflash range (0xFF000000+) cause 'Failed to accept memory for TDVF section' errors on upstream QEMU without patches.

Add optional "TempMemBase" field to image_layout.json. When set, td-layout-config relocates the _BASE addresses of Mailbox, TempStack, and TempHeap entries from the firmware range into the specified guest RAM address, making them acceptable by unpatched QEMU.

Changes:
- layout.rs: add base_override field to LayoutEntry, add relocate_entries() method
- image.rs: parse TempMemBase from config, call relocate_entries()
- image.jinja: emit base_override when present instead of memory_offset + region.start

The feature is opt-in and backward compatible: without TempMemBase in the JSON config, behavior is unchanged.

fixes #834 