### PR TITLE
td-layout: place TempMem sections in DRAM for QEMU 9+ TDX compatibility

### DIFF
--- a/devtools/td-layout-config/config_image.json
+++ b/devtools/td-layout-config/config_image.json
@@ -1,5 +1,6 @@
 {
     "Config": "0x040000",
+    "TempMemBase": "0x600000",
     "Mailbox": "0x001000",
     "TempStack": "0x020000",
     "TempHeap": "0x020000",

--- a/devtools/td-layout-config/src/image.rs
+++ b/devtools/td-layout-config/src/image.rs
@@ -30,6 +30,14 @@ struct ImageConfig {
     reset_vector: String,
     #[serde(rename = "ImageSize")]
     image_size: Option<String>,
+    /// DRAM base address for TempMem sections (Mailbox, TempStack, TempHeap).
+    ///
+    /// When set, these sections are placed at DRAM addresses (starting from this
+    /// base) rather than in the ROM firmware region. This is required for QEMU 9+
+    /// TDX, where tdx_init_ram_entries() only registers E820_RAM entries.
+    /// Backward-compatible: old QEMU also accepts TempMem from DRAM.
+    #[serde(rename = "TempMemBase")]
+    tempmem_base: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -142,6 +150,14 @@ pub fn parse_image(data: String, metadata: Option<String>) -> String {
             parse_int::parse::<u32>(&payload_config).unwrap() as usize,
             "Reserved",
         )
+    }
+
+    // If TempMemBase is configured, redirect Mailbox/TempStack/TempHeap to DRAM
+    // so QEMU 9+ TDX can accept them via E820 RAM entries.
+    if let Some(tempmem_base_str) = image_config.tempmem_base {
+        let tempmem_base =
+            parse_int::parse::<usize>(&tempmem_base_str).expect("Invalid TempMemBase");
+        image_layout.set_tempmem_dram_base(tempmem_base);
     }
 
     render::render_image(&image_layout, fw_top).expect("Render image layout failed!")

--- a/devtools/td-layout-config/src/layout.rs
+++ b/devtools/td-layout-config/src/layout.rs
@@ -16,6 +16,12 @@ pub struct LayoutEntry {
     region: Range<usize>,
     entry_type: String,
     tolm: bool,
+    /// Optional DRAM address override for the BASE constant in build_time.rs.
+    /// Used to place TempMem sections (Mailbox, TempStack, TempHeap) in DRAM
+    /// instead of the ROM firmware region, enabling QEMU 9+ TDX acceptance
+    /// (tdx_init_ram_entries only registers E820_RAM entries, not the ROM area).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dram_base: Option<usize>,
 }
 
 impl LayoutEntry {
@@ -29,6 +35,7 @@ impl LayoutEntry {
             region,
             entry_type,
             tolm,
+            dram_base: None,
         }
     }
 }
@@ -137,6 +144,29 @@ impl LayoutConfig {
     #[allow(unused)]
     pub fn get_layout_region(&self, name: &'static str) -> Option<&LayoutEntry> {
         self.list.iter().find(|v| -> bool { v.name == name })
+    }
+
+    /// Set DRAM base addresses for TempMem sections (Mailbox, TempStack, TempHeap).
+    ///
+    /// `tempmem_base` is the DRAM address for the Mailbox section. TempStack and
+    /// TempHeap get addresses offset from Mailbox, preserving the original layout.
+    /// This keeps TempMem out of the ROM firmware region so QEMU 9+ TDX can accept
+    /// them via E820 RAM entries (tdx_init_ram_entries only uses E820_RAM slots).
+    pub fn set_tempmem_dram_base(&mut self, tempmem_base: usize) {
+        const TEMPMEM_SECTIONS: &[&str] = &["Mailbox", "TempStack", "TempHeap"];
+        // Mailbox image offset is the anchor point for the relative addressing.
+        let mailbox_offset = self
+            .list
+            .iter()
+            .find(|e| e.name == "Mailbox")
+            .map(|e| e.region.start)
+            .unwrap_or(0);
+        for entry in &mut self.list {
+            if TEMPMEM_SECTIONS.contains(&entry.name.as_str()) {
+                // DRAM addr = tempmem_base + (section_offset - mailbox_offset)
+                entry.dram_base = Some(tempmem_base + entry.region.start - mailbox_offset);
+            }
+        }
     }
 }
 

--- a/devtools/td-layout-config/src/template/image.jinja
+++ b/devtools/td-layout-config/src/template/image.jinja
@@ -29,6 +29,12 @@ pub const TD_SHIM_SEC_CORE_INFO_OFFSET: u32 = {{sec_info_offset | format_hex }};
 pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = {{memory_offset + sec_info_offset | format_hex }};
 
 // Base Address after Loaded into Memory
+// Sections with `TempMemBase` set use a DRAM address so QEMU 9+ TDX can accept
+// them via E820 RAM entries (tdx_init_ram_entries only uses E820_RAM slots).
 {%-for i in image_regions%}
+{%- if i.dram_base %}
+pub const TD_SHIM_{{i.name_screaming_snake_case}}_BASE: u32 = {{i.dram_base | format_hex }}; // DRAM (TempMemBase)
+{%- else %}
 pub const TD_SHIM_{{i.name_screaming_snake_case}}_BASE: u32 = {{memory_offset + i.region.start | format_hex }};
+{%- endif %}
 {%-endfor%}

--- a/td-layout/src/build_time.rs
+++ b/td-layout/src/build_time.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024  Intel Corporation
+// Copyright (c) 2021 - 2026  Intel Corporation
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -67,10 +67,12 @@ pub const TD_SHIM_SEC_CORE_INFO_OFFSET: u32 = 0xFFFFAC;
 pub const TD_SHIM_SEC_CORE_INFO_BASE: u32 = 0xFFFFFFAC;
 
 // Base Address after Loaded into Memory
+// Sections with `TempMemBase` set use a DRAM address so QEMU 9+ TDX can accept
+// them via E820 RAM entries (tdx_init_ram_entries only uses E820_RAM slots).
 pub const TD_SHIM_CONFIG_BASE: u32 = 0xFF000000;
-pub const TD_SHIM_MAILBOX_BASE: u32 = 0xFF040000;
-pub const TD_SHIM_TEMP_STACK_BASE: u32 = 0xFF041000;
-pub const TD_SHIM_TEMP_HEAP_BASE: u32 = 0xFF061000;
+pub const TD_SHIM_MAILBOX_BASE: u32 = 0x600000; // DRAM (TempMemBase)
+pub const TD_SHIM_TEMP_STACK_BASE: u32 = 0x601000; // DRAM (TempMemBase)
+pub const TD_SHIM_TEMP_HEAP_BASE: u32 = 0x621000; // DRAM (TempMemBase)
 pub const TD_SHIM_FREE_BASE: u32 = 0xFF081000;
 pub const TD_SHIM_PAYLOAD_BASE: u32 = 0xFF081000;
 pub const TD_SHIM_METADATA_BASE: u32 = 0xFFCAE000;


### PR DESCRIPTION
## Problem

QEMU 9.x and later changed how TDX private memory is initialized. The
function `tdx_init_ram_entries()` now only populates TDX private memory
from E820_RAM entries.  The three TempMem TDVF sections (Mailbox,
TempStack, TempHeap) were located in the firmware ROM region
(0xFF040000–0xFF081000), which is not covered by E820_RAM.  As a
result, QEMU rejects those sections with:

```
Failed to accept memory for TDVF section 3
```

## Solution

Add an optional `TempMemBase` field to `config_image.json`.  When
present, the layout generator places Mailbox, TempStack, and TempHeap
at a DRAM address instead of deriving them from the ROM firmware offset.
The generated `build_time.rs` constants then point into DRAM (e.g.
0x600000), which is within the Bootloader E820_RAM region and therefore
accepted by QEMU's TDX initialisation.

Because the field is optional, omitting it preserves the previous
(ROM-based) behaviour, keeping backward compatibility with older QEMU
versions that do not require E820_RAM backing.

## Changes

* `devtools/td-layout-config/config_image.json` – add `TempMemBase`
* `devtools/td-layout-config/src/image.rs` – parse `TempMemBase`
* `devtools/td-layout-config/src/layout.rs` – add `dram_base` field
  and `set_tempmem_dram_base()` helper
* `devtools/td-layout-config/src/template/image.jinja` – emit DRAM
  address when `dram_base` is set
* `td-layout/src/build_time.rs` – regenerated

## Testing

Built with `cargo image --example-payload` and verified with
`td-shim-checker` that TempMem sections are at 0x600000/0x601000/0x621000.
Booted in QEMU 10.2.1 with TDX hardware without
the section-accept error.