### PR TITLE
td-payload: increase DEFAULT_PAGE_TABLE_SIZE to 16 MiB

### DIFF
--- a/td-payload/src/mm/layout.rs
+++ b/td-payload/src/mm/layout.rs
@@ -4,7 +4,9 @@
 
 pub const DEFAULT_HEAP_SIZE: usize = 0x1000000;
 pub const DEFAULT_STACK_SIZE: usize = 0x800000;
-pub const DEFAULT_PAGE_TABLE_SIZE: usize = 0x800000;
+// 16 MiB: enough to identity-map up to ~8 GiB of RAM with 4 KiB pages, which
+// covers the high-memory E820 region QEMU creates when guest RAM > ~3.5 GiB.
+pub const DEFAULT_PAGE_TABLE_SIZE: usize = 0x1000000;
 #[cfg(not(feature = "no-shared-mem"))]
 pub const DEFAULT_SHARED_MEMORY_SIZE: usize = 0x100000;
 #[cfg(feature = "cet-shstk")]


### PR DESCRIPTION
## Problem

When the guest has more than ~3.5 GiB of RAM, QEMU places the overflow
above the 4 GiB MMIO boundary. For example, with `-m 4G` the E820 table
contains a second RAM entry:

```
E820Entry { addr: 0x100000000, size: 0x80000000, type: 1 }  // 2 GiB above 4G
```

`td-payload`'s `setup_paging()` creates a 1:1 identity map for every
E820_RAM entry using 4 KiB pages.  Mapping that extra 2 GiB requires
~1024 additional page-table frames.  Combined with the frames needed for
the lower RAM regions (~1036 frames), the total (~2060 frames × 4 KiB ≈
**8.2 MiB**) exceeds `DEFAULT_PAGE_TABLE_SIZE = 0x800000` (8 MiB).
`alloc_pt_frame()` returns `None` and the payload panics:

```
panic ... PanicInfo { message: Failed to setup paging: SetupPageTable, ... }
```

This is **independent of QEMU version** — it affects any configuration
with > ~3.5 GiB of guest RAM.

## Fix

Increase `DEFAULT_PAGE_TABLE_SIZE` from `0x800000` (8 MiB) to
`0x1000000` (16 MiB).  This comfortably covers identity-mapping up
to ~8 GiB of guest RAM with 4 KiB pages.