### PR TITLE
feat(td-shim-tools): add image-layout-gen, metadata-gen, and td-shim-patch tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,10 @@ jobs:
         run: |
           cargo image --example-payload --release
 
+      - name: E2E custom NRX image pipeline
+        run: |
+          bash sh_script/test_custom_nrx_image_build.sh
+
       - name: Build Debug Elf format payload
         run: |
           cargo image --example-payload

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +835,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1246,7 @@ dependencies = [
  "td-loader",
  "td-shim",
  "td-shim-interface",
+ "tempfile",
  "zerocopy 0.8.27",
  "zeroize",
 ]
@@ -1246,6 +1262,19 @@ dependencies = [
  "scroll",
  "spin 0.9.8",
  "x86_64",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/doc/custom_nrx_image.md
+++ b/doc/custom_nrx_image.md
@@ -1,0 +1,425 @@
+# Building A Custom NRX Image
+
+This document describes how to build a td-shim image tailored for NRX
+deployment. NRX images strip optional sections (Config, Mailbox) and use
+custom metadata (signature, TD_PARAMS, TD_INFO) to identify the image to
+the NRX loader.
+
+## Overview
+
+A td-shim NRX image consists of several sections laid out contiguously in a
+binary file:
+
+| Section | Purpose |
+|---------|---------|
+| TdParams | TD parameters passed to the guest |
+| TempStack | Temporary stack used during early boot |
+| TempHeap | Temporary heap used during early boot |
+| Payload | The guest payload (e.g., a kernel or firmware) |
+| TdInfo | TD measurement/info structure |
+| Metadata | TDX metadata descriptor table |
+| IPL (td-shim) | Initial Program Loader — the td-shim ELF binary |
+| ResetVector | x86 reset vector code |
+
+NRX builds use the following feature flags to strip unnecessary sections:
+- `no-config` — removes Config section
+- `no-mailbox` — removes Mailbox section
+- `no-tdvmcall` — disables TDVMCALL interface
+- `no-tdaccept` — disables TD memory acceptance (VMM handles via PAGE_AUG)
+- `no-metadata-checks` — disables attribute validation (attributes are zeroed)
+
+> **Note:** These feature flags are subject to change and may be unified under a
+> single `nrx` feature flag in the future.
+
+### NRX Build Pipeline
+
+1. Build td-shim + payload with NRX feature flags.
+2. Run `td-shim-image-layout-gen` to compute section sizes from the actual
+   artifacts. This step produces a layout JSON **including ImageSize**.
+3. Run `td-shim-metadata-gen --layout --memory-layout` to produce the TDX
+   metadata JSON (including PermMem regions for VMM-allocated guest memory).
+4. Rebuild td-shim with the generated layout and metadata
+   (via `cargo image --layout --metadata`).
+5. Validate with `td-shim-checker`.
+6. Patch the image with NRX-specific metadata (signature, TD_PARAMS, TD_INFO).
+
+```mermaid
+flowchart LR
+    A[Built Binaries] --> B[td-shim-image-layout-gen]
+    B --> C[Layout JSON\n+ ImageSize]
+    C --> D[td-shim-metadata-gen\n--layout --memory-layout]
+    M[Physical Memory JSON] --> D
+    D --> E[Metadata JSON]
+    C --> F[cargo image\n--layout --metadata]
+    E --> F
+    F --> G[Final Image]
+    G --> H[td-shim-patch\nsignature + td-params + td-info]
+    H --> I[NRX Image]
+```
+
+### Quick Start
+
+A complete NRX build using the built-in example payload:
+
+```bash
+NRX_FEATURES="no-config,no-mailbox,no-tdvmcall,no-tdaccept,no-metadata-checks"
+
+# ---- Step 1: Initial build (produces payload, IPL, reset vector) ----
+cargo image --example-payload --release --features "${NRX_FEATURES}"
+
+# ---- Step 2: Compute image layout from actual artifact sizes ----
+cargo run -p td-shim-tools --bin td-shim-image-layout-gen -- \
+    --project-root . \
+    --payload-binary example \
+    --cargo-build-directory release \
+    --template td-shim-tools/etc/sample_nrx_image_template.json \
+    --output target/config/image_layout.generated.json
+
+# ---- Step 3: Generate TDX metadata from image layout + physical memory ----
+cargo run -p td-shim-tools --bin td-shim-metadata-gen -- \
+    --layout target/config/image_layout.generated.json \
+    --memory-layout td-shim-tools/etc/sample_nrx_physical_memory.json \
+    --out target/config/nrx_metadata.json
+
+# ---- Step 4: Rebuild td-shim with the computed layout and metadata ----
+cargo image --example-payload --release \
+    --features "${NRX_FEATURES}" \
+    --layout target/config/image_layout.generated.json \
+    --metadata target/config/nrx_metadata.json
+
+# ---- Step 5: Validate ----
+cargo run -p td-shim-tools --bin td-shim-checker -- target/release/final.bin
+
+# ---- Step 6: Patch for NRX ----
+cargo run -p td-shim-tools --bin td-shim-patch -- tdx-metadata \
+    --in target/release/final.bin \
+    --out target/release/final.bin \
+    --signature 0x58524E5F
+
+cargo run -p td-shim-tools --bin td-shim-patch -- td-params \
+    --in target/release/final.bin \
+    --out target/release/final.bin \
+    --tdparams td-shim-tools/etc/sample_td_params.json
+
+cargo run -p td-shim-tools --bin td-shim-patch -- td-info \
+    --in target/release/final.bin \
+    --out target/release/final.bin \
+    --guid ffffffff-ffff-ffff-ffff-ffffffffffff \
+    --version 1.0.0 \
+    --svn 1 \
+    --payload-info path/to/nrx_info.bin
+```
+
+> **Note:** After patching the metadata signature (step 6), the image will no
+> longer pass the stock `td-shim-checker` validation because the checker expects
+> the original TDX metadata signature. The patched image is intended for the NRX
+> loader that recognizes the `0x58524E5F` ("_NRX") signature.
+
+An automated version of this workflow is available as
+`sh_script/test_custom_nrx_image_build.sh`.
+
+---
+
+The following sections document each tool in detail.
+
+## td-shim-image-layout-gen
+
+Computes a td-shim image layout from built artifacts and a JSON layout template.
+
+### What It Does
+
+1. Reads a layout template (JSON with section names and hex sizes).
+2. Measures actual payload, IPL (td-shim ELF), and reset vector binary sizes.
+3. Adds firmware volume (FV) header overhead (~256 bytes per section).
+4. Aligns all sections to 4 KiB boundaries.
+5. Outputs `image_layout.generated.json`.
+
+### Usage
+
+```bash
+td-shim-image-layout-gen --project-root <path> --payload-binary <name> [OPTIONS]
+```
+
+### Arguments
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--project-root <path>` | yes | — | Root directory of the project |
+| `--payload-binary <name>` | yes | — | Payload binary filename |
+| `--cargo-target-dir <dir>` | no | `target/` | Cargo target directory |
+| `--build-target <target>` | no | `x86_64-unknown-none` | Build target triple |
+| `--cargo-build-directory <dir>` | no | `release` | Build profile directory |
+| `--ipl-binary <name>` | no | `td-shim` | IPL binary name |
+| `--reset-vector-binary <name>` | no | `ResetVector.bin` | Reset vector binary name |
+| `--template <path>` | no | built-in default | Layout template JSON |
+| `--output <path>` | no | `target/config/image_layout.generated.json` | Output file |
+
+### Template Format
+
+The NRX template omits Config and Mailbox. Sections with `"0x0"` are measured
+from build artifacts:
+
+```json
+{
+    "TdParams": "0x1000",
+    "TempStack": "0x20000",
+    "TempHeap": "0x20000",
+    "TdInfo": "0x1000",
+    "Metadata": "0x1000",
+    "Payload": "0x0",
+    "Ipl": "0x0",
+    "ResetVector": "0x0"
+}
+```
+
+Optional fields: `Config`, `Mailbox`, `TdInfo`, `TdParams`, `ImageSize`.
+
+> **Note:** `ImageSize` is computed automatically from the sum of all sections.
+> If provided in the template, it serves as a minimum (preserving extra padding).
+> If omitted, the tool calculates the exact minimum required size.
+
+The NRX template is at `td-shim-tools/etc/sample_nrx_image_template.json`.
+
+### Example
+
+```bash
+cargo run -p td-shim-tools --bin td-shim-image-layout-gen -- \
+    --project-root . \
+    --payload-binary example \
+    --cargo-build-directory release \
+    --template td-shim-tools/etc/sample_nrx_image_template.json \
+    --output target/config/image_layout.generated.json
+```
+
+The generated layout can then be passed to `cargo image --layout`.
+
+---
+
+## td-shim-metadata-gen
+
+Generates a TDX metadata JSON file consumable by `td-shim-ld --metadata`.
+
+### What It Does
+
+1. Reads an image layout JSON (`--layout`) and computes TDX metadata sections.
+2. Optionally reads physical memory regions (`--memory-layout`) for PermMem/TempMem.
+3. Validates that no memory regions overlap.
+4. Writes the output JSON.
+
+### Usage
+
+```bash
+# From an image layout JSON (with optional physical memory regions)
+td-shim-metadata-gen --layout <path> [--memory-layout <path>] --out <path>
+```
+
+### Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--layout <path>` | yes | Image layout JSON (from td-shim-image-layout-gen) |
+| `--memory-layout <path>` | no | Physical memory JSON with PermMem/TempMem regions |
+| `--out <path>` | yes | Output metadata JSON file path |
+
+### --layout Mode
+
+When using `--layout`, the tool reads the image layout JSON (as produced by
+`td-shim-image-layout-gen`) and computes metadata section offsets from the
+section order. TdParams and TdInfo sections are included only if present in
+the layout with non-zero size.
+
+When `--memory-layout` is provided, PermMem and/or TempMem regions from the
+physical memory JSON are appended to the metadata. These describe guest physical
+address ranges that the VMM allocates (via PAGE_AUG for PermMem).
+
+The tool validates that no memory regions overlap.
+
+```bash
+cargo run -p td-shim-tools --bin td-shim-metadata-gen -- \
+    --layout target/config/image_layout.generated.json \
+    --memory-layout td-shim-tools/etc/sample_nrx_physical_memory.json \
+    --out target/config/nrx_metadata.json
+```
+
+### Physical Memory Layout Format
+
+```json
+{
+    "PermMem": [
+        { "address": "0x0", "size": "0x2000000" }
+    ],
+    "TempMem": [
+        { "address": "0x10000000", "size": "0x1000000" }
+    ]
+}
+```
+
+Both arrays are optional. Each entry specifies a guest physical address range.
+Multiple regions of the same type are supported. Sizes are u64 (supports >4GB).
+
+A sample is available at `td-shim-tools/etc/sample_nrx_physical_memory.json`.
+
+### Output Format
+
+The generated metadata JSON follows the format expected by `td-shim-ld --metadata`:
+
+```json
+{
+    "Sections": [
+        {
+            "Type": "BFV",
+            "Attributes": "0x1",
+            "DataOffset": "0x57000",
+            "RawDataSize": "0x21000",
+            "MemoryAddress": "0xFFF8F000",
+            "MemoryDataSize": "0x21000"
+        },
+        {
+            "Type": "PermMem",
+            "Attributes": "0x2",
+            "DataOffset": "0x0",
+            "RawDataSize": "0x0",
+            "MemoryAddress": "0x0",
+            "MemoryDataSize": "0x2000000"
+        }
+    ]
+}
+```
+
+### Valid Section Types
+
+`BFV`, `CFV`, `TD_HOB`, `TempMem`, `PermMem`, `Payload`, `PayloadParam`, `TdInfo`, `TdParams`
+
+---
+
+## Building
+
+The default feature set of `td-shim-tools` includes both tools:
+
+```bash
+cargo build -p td-shim-tools
+```
+
+To build each tool individually:
+
+```bash
+cargo build -p td-shim-tools --no-default-features --features layout-gen
+cargo build -p td-shim-tools --no-default-features --features metadata-gen
+cargo build -p td-shim-tools --no-default-features --features patcher
+```
+
+## Installing
+
+```bash
+cargo install --path td-shim-tools
+```
+
+Or via the Makefile:
+
+```bash
+make install
+```
+
+---
+
+## td-shim-patch
+
+Patches an existing td-shim firmware image in-place. Use this tool after linking
+to inject runtime-specific data (metadata signatures, TD parameters, TD info
+blobs) without rebuilding from source.
+
+### Subcommands
+
+| Subcommand | Purpose |
+|------------|---------|
+| `tdx-metadata` | Overwrite the TDX metadata signature and zero section attributes |
+| `td-params` | Write the TD_PARAMS section from a JSON description |
+| `td-info` | Write a TD_INFO header (GUID + version + SVN) and payload blob |
+
+### Usage
+
+```bash
+td-shim-patch <subcommand> [options]
+```
+
+### Patching Example
+
+Patching a linked td-shim image for NRX deployment (metadata signature,
+TD parameters, and TD_INFO):
+
+```bash
+# Set NRX signature (0x58524E5F = "_NRX") and zero attributes
+cargo run -p td-shim-tools --bin td-shim-patch -- tdx-metadata \
+    --in target/release/final.bin \
+    --out target/release/final.bin \
+    --signature 0x58524E5F
+
+# Write TD_PARAMS from a JSON file
+cargo run -p td-shim-tools --bin td-shim-patch -- td-params \
+    --in target/release/final.bin \
+    --out target/release/final.bin \
+    --tdparams td-shim-tools/etc/sample_td_params.json
+
+# Write TD_INFO with NRX GUID, version, SVN, and payload info blob
+cargo run -p td-shim-tools --bin td-shim-patch -- td-info \
+    --in target/release/final.bin \
+    --out target/release/final.bin \
+    --guid ffffffff-ffff-ffff-ffff-ffffffffffff \
+    --version 1.0.0 \
+    --svn 1 \
+    --payload-info path/to/nrx_info.bin
+```
+
+### Subcommand Details
+
+#### tdx-metadata
+
+Overwrites the 4-byte TDX metadata signature at the descriptor offset and zeros
+all section attribute fields. Useful for re-targeting images to alternative
+metadata consumers (e.g., NRX instead of stock TDX).
+
+```bash
+td-shim-patch tdx-metadata --in <image> --out <image> --signature <hex>
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--in <path>` | yes | Input firmware image |
+| `--out <path>` | yes | Output firmware image (can be same as input) |
+| `--signature <hex>` | yes | New 4-byte signature value (e.g., `0x58524E5F`) |
+
+#### td-params
+
+Writes a 1024-byte TD_PARAMS structure into the image's TD_PARAMS section.
+The JSON file must serialize to exactly 1024 bytes following the TDX Module
+spec layout.
+
+```bash
+td-shim-patch td-params --in <image> --out <image> --tdparams <json>
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--in <path>` | yes | Input firmware image |
+| `--out <path>` | yes | Output firmware image |
+| `--tdparams <path>` | yes | JSON file describing TD_PARAMS fields |
+
+#### td-info
+
+Writes a 28-byte generic header (GUID, length, version, SVN) followed by an
+opaque payload blob into the TD_INFO section. The GUID identifies the TD type;
+the blob format depends on the specific deployment.
+
+```bash
+td-shim-patch td-info --in <image> --out <image> --guid <guid> \
+    --version <a.b.c> --svn <n> --payload-info <blob>
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--in <path>` | yes | Input firmware image |
+| `--out <path>` | yes | Output firmware image |
+| `--guid <guid>` | yes | TD type GUID (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`) |
+| `--version <a.b.c>` | yes | Release version (major.minor.update) |
+| `--svn <n>` | yes | Security Version Number |
+| `--payload-info <path>` | yes | Binary blob with TD-type-specific info |

--- a/sh_script/test_custom_nrx_image_build.sh
+++ b/sh_script/test_custom_nrx_image_build.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Copyright (c) 2026 Intel Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# End-to-end test: full custom image build pipeline.
+#
+# Pipeline:
+#   1. Build td-shim + example payload (initial build)
+#   2. td-shim-image-layout-gen (compute layout from artifacts)
+#   3. Rebuild td-shim with generated layout (cargo image --layout)
+#   4. td-shim-metadata-gen (generate TDX metadata JSON)
+#   5. td-shim-ld (link final image with custom metadata)
+#   6. td-shim-checker (validate final image)
+#   7. td-shim-patch tdx-metadata (patch NRX signature)
+#
+# This validates the full custom image workflow described in doc/custom_nrx_image.md.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OUTPUT_DIR="${PROJECT_ROOT}/target/e2e-test"
+
+echo "=== Custom NRX Image Build Pipeline ==="
+echo "Project root: ${PROJECT_ROOT}"
+mkdir -p "${OUTPUT_DIR}"
+
+# --- Step 1: Initial build ---
+echo ""
+echo "--- Step 1: Build td-shim + example payload ---"
+
+cargo image --example-payload --release
+
+PAYLOAD="${PROJECT_ROOT}/target/x86_64-unknown-none/release/example"
+IPL="${PROJECT_ROOT}/target/x86_64-unknown-none/release/td-shim"
+RESET_VECTOR="${PROJECT_ROOT}/target/x86_64-unknown-none/release/ResetVector.bin"
+
+for f in "${PAYLOAD}" "${IPL}" "${RESET_VECTOR}"; do
+    if [[ ! -f "${f}" ]]; then
+        echo "ERROR: Required artifact not found: ${f}"
+        exit 1
+    fi
+done
+echo "PASS: All build artifacts present"
+
+# --- Step 2: Compute image layout ---
+echo ""
+echo "--- Step 2: td-shim-image-layout-gen ---"
+echo "  This step measures actual binary sizes and computes the full layout"
+echo "  including ImageSize (sum of all sections, 4K-aligned)."
+
+# Create a layout template with all optional fields included.
+# Payload, Ipl, ResetVector, and ImageSize will be overridden by the tool
+# based on actual artifact sizes.
+cat > "${OUTPUT_DIR}/layout_template.json" <<'EOF'
+{
+    "Config": "0x40000",
+    "Mailbox": "0x1000",
+    "TdParams": "0x1000",
+    "TempStack": "0x20000",
+    "TempHeap": "0x20000",
+    "TdInfo": "0x1000",
+    "Metadata": "0x1000",
+    "Payload": "0x0",
+    "Ipl": "0x0",
+    "ResetVector": "0x0"
+}
+EOF
+
+cargo run -p td-shim-tools --bin td-shim-image-layout-gen -- \
+    --project-root "${PROJECT_ROOT}" \
+    --payload-binary example \
+    --cargo-build-directory release \
+    --template "${OUTPUT_DIR}/layout_template.json" \
+    --output "${OUTPUT_DIR}/image_layout.generated.json"
+
+if [[ ! -f "${OUTPUT_DIR}/image_layout.generated.json" ]]; then
+    echo "FAIL: td-shim-image-layout-gen did not produce output"
+    exit 1
+fi
+echo "PASS: Generated ${OUTPUT_DIR}/image_layout.generated.json"
+cat "${OUTPUT_DIR}/image_layout.generated.json"
+
+# --- Step 3: Rebuild td-shim with generated layout ---
+echo ""
+echo "--- Step 3: Rebuild td-shim with generated layout (via cargo image) ---"
+
+# cargo image --layout handles: td-layout-config -> rebuild -> strip -> link
+# We use it here to rebuild with the computed layout. This also produces a final
+# image, but we'll produce our own in Step 5 using the metadata-gen output.
+cargo image --example-payload --release \
+    --layout "${OUTPUT_DIR}/image_layout.generated.json" \
+    -o "${OUTPUT_DIR}/final-via-cargo-image.bin"
+
+echo "PASS: td-shim rebuilt with custom layout"
+
+# --- Step 4: Generate TDX metadata ---
+echo ""
+echo "--- Step 4: td-shim-metadata-gen ---"
+
+cargo run -p td-shim-tools --bin td-shim-metadata-gen -- \
+    --layout "${OUTPUT_DIR}/image_layout.generated.json" \
+    --memory-layout "${PROJECT_ROOT}/td-shim-tools/etc/sample_nrx_physical_memory.json" \
+    --out "${OUTPUT_DIR}/metadata.json"
+
+if [[ ! -f "${OUTPUT_DIR}/metadata.json" ]]; then
+    echo "FAIL: td-shim-metadata-gen did not produce output"
+    exit 1
+fi
+echo "PASS: Generated ${OUTPUT_DIR}/metadata.json"
+
+# --- Step 5: Link final image with custom metadata ---
+echo ""
+echo "--- Step 5: td-shim-ld (link final image) ---"
+
+cargo run -p td-shim-tools --bin td-shim-ld --features linker -- \
+    "${PROJECT_ROOT}/target/x86_64-unknown-none/release/ResetVector.bin" \
+    "${PROJECT_ROOT}/target/x86_64-unknown-none/release/td-shim" \
+    -m "${OUTPUT_DIR}/metadata.json" \
+    -p "${PROJECT_ROOT}/target/x86_64-unknown-none/release/example" \
+    -o "${OUTPUT_DIR}/final-custom.bin"
+
+if [[ ! -f "${OUTPUT_DIR}/final-custom.bin" ]]; then
+    echo "FAIL: td-shim-ld did not produce final image"
+    exit 1
+fi
+echo "PASS: Final image at ${OUTPUT_DIR}/final-custom.bin"
+ls -lh "${OUTPUT_DIR}/final-custom.bin"
+
+# --- Step 6: Validate with td-shim-checker ---
+echo ""
+echo "--- Step 6: Validate final image ---"
+
+cargo run -p td-shim-tools --bin td-shim-checker --no-default-features --features=loader -- \
+    "${OUTPUT_DIR}/final-custom.bin"
+
+echo "PASS: td-shim-checker validated final image"
+
+# --- Step 7: Patch NRX metadata signature ---
+echo ""
+echo "--- Step 7: td-shim-patch tdx-metadata (NRX signature) ---"
+
+cargo run -p td-shim-tools --bin td-shim-patch -- tdx-metadata \
+    --in "${OUTPUT_DIR}/final-custom.bin" \
+    --out "${OUTPUT_DIR}/final-custom.bin" \
+    --signature 0x58524E5F
+
+echo "PASS: Patched metadata signature to 0x58524E5F (_NRX)"
+
+# # --- (Optional) Patch TD_PARAMS and TD_INFO ---
+# cargo run -p td-shim-tools --bin td-shim-patch -- td-params \
+#     --in "${OUTPUT_DIR}/final-custom.bin" \
+#     --out "${OUTPUT_DIR}/final-custom.bin" \
+#     --tdparams td-shim-tools/etc/sample_td_params.json
+#
+# cargo run -p td-shim-tools --bin td-shim-patch -- td-info \
+#     --in "${OUTPUT_DIR}/final-custom.bin" \
+#     --out "${OUTPUT_DIR}/final-custom.bin" \
+#     --guid ffffffff-ffff-ffff-ffff-ffffffffffff \
+#     --version 1.0.0 \
+#     --svn 1 \
+#     --payload-info path/to/nrx_info.bin
+
+# --- Restore original layout ---
+echo ""
+echo "--- Restoring original td-layout source ---"
+pushd "${PROJECT_ROOT}" > /dev/null
+git checkout -- td-layout/src/ 2>/dev/null || true
+popd > /dev/null
+
+# --- Cleanup ---
+rm -rf "${OUTPUT_DIR}"
+
+echo ""
+echo "=== All Custom NRX Image Build Pipeline steps passed ==="

--- a/td-shim-tools/Cargo.toml
+++ b/td-shim-tools/Cargo.toml
@@ -34,6 +34,18 @@ required-features = ["tee"]
 name = "td-payload-reference-calculator"
 required-features = ["calculator"]
 
+[[bin]]
+name = "td-shim-image-layout-gen"
+required-features = ["layout-gen"]
+
+[[bin]]
+name = "td-shim-metadata-gen"
+required-features = ["metadata-gen"]
+
+[[bin]]
+name = "td-shim-patch"
+required-features = ["patcher"]
+
 [dependencies]
 r-efi = "3.2.0"
 argparse = "0.2.2"
@@ -64,12 +76,19 @@ igvm_defs = "0.3.4"
 zerocopy = { version = "0.8.14", features = ["derive"]}
 
 [features]
-default = ["enroller", "linker", "signer", "loader", "tee", "calculator"]
+default = ["enroller", "linker", "signer", "loader", "tee", "calculator", "layout-gen", "metadata-gen", "patcher"]
 enroller = ["clap", "der", "env_logger", "log", "ring", "td-shim/secure-boot"]
 linker = ["clap", "env_logger", "log", "parse_int", "serde_json", "serde", "td-loader"]
 signer = ["clap", "der", "env_logger", "log", "ring", "td-shim/secure-boot"]
 loader = ["clap", "env_logger", "log", "anyhow"]
 tee = ["clap", "env_logger", "log", "serde_json", "serde", "hex", "sha2", "byteorder"]
 calculator = ["clap", "hex", "parse_int", "sha2", "anyhow", "block-padding"]
+layout-gen = ["anyhow", "serde_json", "serde"]
+metadata-gen = ["anyhow", "serde_json", "serde"]
+patcher = ["anyhow", "serde_json", "serde", "hex"]
 exec-payload-section = []
 no-config = []
+
+[dev-dependencies]
+tempfile = "3"
+serde_json = "1.0"

--- a/td-shim-tools/etc/sample_nrx_image_template.json
+++ b/td-shim-tools/etc/sample_nrx_image_template.json
@@ -1,0 +1,10 @@
+{
+    "TdParams": "0x1000",
+    "TempStack": "0x20000",
+    "TempHeap": "0x20000",
+    "TdInfo": "0x1000",
+    "Metadata": "0x1000",
+    "Payload": "0x0",
+    "Ipl": "0x0",
+    "ResetVector": "0x0"
+}

--- a/td-shim-tools/etc/sample_nrx_physical_memory.json
+++ b/td-shim-tools/etc/sample_nrx_physical_memory.json
@@ -1,0 +1,6 @@
+{
+    "PermMem": [
+        { "address": "0x0", "size": "0x2000000" }
+    ],
+    "TempMem": []
+}

--- a/td-shim-tools/etc/sample_nrx_shim_metadata.json
+++ b/td-shim-tools/etc/sample_nrx_shim_metadata.json
@@ -1,0 +1,39 @@
+{
+    "memory_regions": [
+        {
+            "name": "Bootloader",
+            "size": "0x800000",
+            "type": "Memory"
+        },
+        {
+            "name": "TdHob",
+            "size": "0x20000",
+            "type": "Memory"
+        },
+        {
+            "name": "EventLog",
+            "size": "0x100000",
+            "type": "Nvs"
+        },
+        {
+            "name": "RelocatedMailbox",
+            "size": "0x2000",
+            "type": "Nvs"
+        },
+        {
+            "name": "PayloadPageTable",
+            "size": "0x20000",
+            "type": "Reserved"
+        },
+        {
+            "name": "Payload",
+            "size": "0x1000000",
+            "type": "Reserved"
+        },
+        {
+            "name": "Acpi",
+            "size": "0x100000",
+            "type": "Acpi"
+        }
+    ]
+}

--- a/td-shim-tools/etc/sample_td_params.json
+++ b/td-shim-tools/etc/sample_td_params.json
@@ -1,0 +1,14 @@
+{
+    "attributes": "0x0000000000000001",
+    "xfam": "0x0000000000000003",
+    "maxvcpus": 8,
+    "numl2vms": 0,
+    "msrconfigctls": 0,
+    "reserved": 0,
+    "eptpcontrols": "0x0000000000000000",
+    "configflags": "0x0000000000000000",
+    "tscfrequency": 0,
+    "ia32archcapabilitiesconfig": "0x0000000000000000",
+    "mrconfigsvn": 0,
+    "mrownerconfigsvn": 0
+}

--- a/td-shim-tools/etc/test_layout_template.json
+++ b/td-shim-tools/etc/test_layout_template.json
@@ -1,0 +1,10 @@
+{
+    "TdParams": "0x1000",
+    "TempStack": "0x20000",
+    "TempHeap": "0x20000",
+    "Payload": "0x100000",
+    "TdInfo": "0x1000",
+    "Metadata": "0x1000",
+    "Ipl": "0x2e000",
+    "ResetVector": "0x8000"
+}

--- a/td-shim-tools/etc/test_metadata_config.json
+++ b/td-shim-tools/etc/test_metadata_config.json
@@ -1,0 +1,20 @@
+{
+    "Sections": [
+        {
+            "DataOffset": "0x0",
+            "RawDataSize": "0x1000",
+            "MemoryAddress": "0xFF000000",
+            "MemoryDataSize": "0x1000",
+            "Type": "BFV",
+            "Attributes": "0x1"
+        },
+        {
+            "DataOffset": "0x0",
+            "RawDataSize": "0x0",
+            "MemoryAddress": "0x800000",
+            "MemoryDataSize": "0x20000",
+            "Type": "TD_HOB",
+            "Attributes": "0x0"
+        }
+    ]
+}

--- a/td-shim-tools/etc/test_metadata_invalid.json
+++ b/td-shim-tools/etc/test_metadata_invalid.json
@@ -1,0 +1,12 @@
+{
+    "Sections": [
+        {
+            "DataOffset": "0x0",
+            "RawDataSize": "0x1000",
+            "MemoryAddress": "0xFF000000",
+            "MemoryDataSize": "0x1000",
+            "Type": "InvalidType",
+            "Attributes": "0x0"
+        }
+    ]
+}

--- a/td-shim-tools/src/bin/td-shim-image-layout-gen/README.md
+++ b/td-shim-tools/src/bin/td-shim-image-layout-gen/README.md
@@ -1,0 +1,78 @@
+# td-shim-image-layout-gen
+
+## Overview
+
+Computes a td-shim image layout from built artifacts and a JSON layout template.
+
+This tool measures the actual sizes of payload, IPL (td-shim ELF), and reset
+vector binaries, accounts for firmware volume (FV) header overhead, 4 KiB-aligns
+all sections, and produces a generated layout JSON.
+
+## Usage
+
+```
+td-shim-image-layout-gen --project-root <path> --payload-binary <name> [OPTIONS]
+```
+
+### Required Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--project-root <path>` | Root directory of the project |
+| `--payload-binary <name>` | Payload binary name (filename in target dir) |
+
+### Optional Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--cargo-target-dir <dir>` | `target/` | Cargo target directory |
+| `--build-target <target>` | `x86_64-unknown-none` | Build target triple |
+| `--cargo-build-directory <dir>` | `release` | Build profile directory |
+| `--ipl-binary <name>` | `td-shim` | IPL binary name |
+| `--reset-vector-binary <name>` | `ResetVector.bin` | Reset vector binary name |
+| `--template <path>` | built-in default | Layout template JSON |
+| `--output <path>` | `target/config/image_layout.generated.json` | Output file path |
+
+## Template Format
+
+The layout template JSON defines section sizes in hex:
+
+```json
+{
+    "TdParams": "0x1000",
+    "TempStack": "0x20000",
+    "TempHeap": "0x20000",
+    "Payload": "0x140000",
+    "TdInfo": "0x1000",
+    "Metadata": "0x1000",
+    "Ipl": "0x2e000",
+    "ResetVector": "0x8000"
+}
+```
+
+Optional fields: `Config`, `Mailbox`, `TdInfo`, `TdParams`, `ImageSize`.
+
+> `ImageSize` is computed automatically from the sum of all sections. If
+> provided in the template, it acts as a minimum size (preserving padding).
+
+## How It Works
+
+1. Reads the layout template (or uses built-in defaults).
+2. Locates built artifacts under `<target-dir>/<build-target>/<profile>/`.
+3. Measures payload binary size, adds FV header overhead (~256 bytes).
+4. Measures IPL binary size (max of file size and ELF vaddr extent), adds header overhead (~256 bytes).
+5. Measures reset vector binary size.
+6. Aligns all sizes to 4 KiB boundaries.
+7. Computes total image size.
+8. Writes `image_layout.generated.json` to `<project-root>/target/config/`.
+
+## Example
+
+```bash
+# After building td-shim and payload:
+cargo run --bin td-shim-image-layout-gen -- \
+    --project-root . \
+    --payload-binary td-payload \
+    --template td-shim-tools/etc/test_layout_template.json \
+    --output target/config/image_layout.generated.json
+```

--- a/td-shim-tools/src/bin/td-shim-image-layout-gen/main.rs
+++ b/td-shim-tools/src/bin/td-shim-image-layout-gen/main.rs
@@ -1,0 +1,556 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! Image Layout Generator
+//!
+//! Computes a td-shim image layout by reading a JSON template, measuring the
+//! actual sizes of built artifacts (payload, IPL, reset vector), accounting for
+//! firmware volume (FV) header overhead, and producing a generated layout JSON
+//! with 4 KiB-aligned section sizes.
+//!
+//! The generated JSON can be consumed by `td-layout-config` to regenerate
+//! build-time constants, or by `td-shim-ld` directly.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+use std::path::{Path, PathBuf};
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// Command-line argument names
+const PROJECT_ROOT: &str = "--project-root";
+const CARGO_TARGET_DIR: &str = "--cargo-target-dir";
+const BUILD_TARGET: &str = "--build-target";
+const CARGO_BUILD_DIRECTORY: &str = "--cargo-build-directory";
+const PAYLOAD_BINARY: &str = "--payload-binary";
+const IPL_BINARY: &str = "--ipl-binary";
+const RESET_VECTOR_BINARY: &str = "--reset-vector-binary";
+const OUTPUT: &str = "--output";
+const TEMPLATE: &str = "--template";
+
+const ALIGN_4K: u64 = 0x1000;
+const DEFAULT_LAYOUT: &str = r#"{
+    "TdParams": "0x1000",
+    "TempStack": "0x20000",
+    "TempHeap": "0x20000",
+    "Payload": "0x140000",
+    "TdInfo": "0x1000",
+    "Metadata": "0x1000",
+    "Ipl": "0x2e000",
+    "ResetVector": "0x8000"
+}"#;
+
+#[derive(Debug)]
+pub struct Args {
+    pub project_root: PathBuf,
+    pub cargo_target_dir: String,
+    pub build_target: String,
+    pub cargo_build_directory: String,
+    pub payload_binary: String,
+    pub ipl_binary: String,
+    pub reset_vector_binary: String,
+    pub output: Option<PathBuf>,
+    pub template: Option<PathBuf>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+struct ImageLayout {
+    #[serde(rename = "Config", default, skip_serializing_if = "Option::is_none")]
+    config: Option<String>,
+    #[serde(rename = "Mailbox", default, skip_serializing_if = "Option::is_none")]
+    mailbox: Option<String>,
+    #[serde(rename = "TempStack")]
+    temp_stack: String,
+    #[serde(rename = "TempHeap")]
+    temp_heap: String,
+    #[serde(rename = "Payload")]
+    payload: String,
+    #[serde(rename = "TdInfo", default, skip_serializing_if = "Option::is_none")]
+    td_info: Option<String>,
+    #[serde(rename = "TdParams", default, skip_serializing_if = "Option::is_none")]
+    td_params: Option<String>,
+    #[serde(rename = "Metadata")]
+    metadata: String,
+    #[serde(rename = "Ipl")]
+    ipl: String,
+    #[serde(rename = "ResetVector")]
+    reset_vector: String,
+    #[serde(rename = "ImageSize", default, skip_serializing_if = "Option::is_none")]
+    image_size: Option<String>,
+}
+
+fn generate_image_layout(args: Args) -> Result<()> {
+    let template_content = if let Some(template_path) = &args.template {
+        std::fs::read_to_string(template_path)
+            .with_context(|| format!("failed to read template from {}", template_path.display()))?
+    } else {
+        DEFAULT_LAYOUT.to_string()
+    };
+
+    let mut layout: ImageLayout = serde_json::from_str(&template_content)
+        .with_context(|| "failed to deserialize image layout template")?;
+
+    let target_dir = resolve_target_dir(&args.project_root, &args.cargo_target_dir);
+    let payload_path = artifact_path(
+        &target_dir,
+        &[
+            &args.build_target,
+            &args.cargo_build_directory,
+            &args.payload_binary,
+        ],
+    );
+
+    // For the IPL and reset vector, check if the requested build directory
+    // exists; fall back to release if not.
+    let ipl_build_dir = cargo_build_directory_with_fallback(
+        &args.cargo_build_directory,
+        &target_dir,
+        "x86_64-unknown-none",
+        &args.ipl_binary,
+    );
+    let ipl_path = artifact_path(
+        &target_dir,
+        &["x86_64-unknown-none", &ipl_build_dir, &args.ipl_binary],
+    );
+    let reset_vector_path = artifact_path(
+        &target_dir,
+        &[
+            "x86_64-unknown-none",
+            &ipl_build_dir,
+            &args.reset_vector_binary,
+        ],
+    );
+
+    // Account for FV headers that td-shim adds to the payload section.
+    // FvHeader + FvFfsFileHeader + FvFfsSectionHeader ≈ 148 bytes, rounded up.
+    const FV_HEADER_OVERHEAD: u64 = 256;
+
+    // Account for FV + reset vector headers that td-shim adds to the IPL section.
+    // IplFvHeaderByte (~148 bytes) + ResetVectorHeader (~40 bytes) ≈ 188 bytes.
+    const IPL_HEADER_OVERHEAD: u64 = 256;
+
+    let payload_binary_size = file_size(&payload_path)?;
+    let payload_size = align_up(payload_binary_size + FV_HEADER_OVERHEAD, ALIGN_4K);
+
+    // The linker checks both the file size and the ELF virtual address extent
+    // against MAX_IPL_CONTENT_SIZE. Use the larger of the two.
+    let ipl_file_size = file_size(&ipl_path)?;
+    let ipl_vaddr_extent = elf64_max_vaddr_filesz(&ipl_path)?;
+    let ipl_size = align_up(
+        ipl_file_size.max(ipl_vaddr_extent) + IPL_HEADER_OVERHEAD,
+        ALIGN_4K,
+    );
+    let reset_vector_size = align_up(file_size(&reset_vector_path)?, ALIGN_4K);
+
+    println!(
+        "Payload binary size: {} ({})",
+        format_size(payload_binary_size),
+        payload_binary_size
+    );
+    println!(
+        "Payload section size (with headers): {} ({})",
+        format_size(payload_size),
+        payload_size
+    );
+
+    let original_payload = parse_size(&layout.payload)?;
+    let original_ipl = parse_size(&layout.ipl)?;
+
+    layout.payload = format_size(payload_size);
+    layout.ipl = format_size(ipl_size);
+    layout.reset_vector = format_size(reset_vector_size);
+
+    let config_size = parse_optional(&layout.config)?;
+    let mailbox_size = parse_optional(&layout.mailbox)?;
+    let temp_stack = parse_size(&layout.temp_stack)?;
+    let temp_heap = parse_size(&layout.temp_heap)?;
+    let td_params = parse_optional(&layout.td_params)?;
+    let td_info = parse_optional(&layout.td_info)?;
+    let metadata = parse_size(&layout.metadata)?;
+
+    let mut new_image_size = config_size
+        + mailbox_size
+        + temp_stack
+        + temp_heap
+        + payload_size
+        + td_params
+        + td_info
+        + metadata
+        + ipl_size
+        + reset_vector_size;
+    new_image_size = align_up(new_image_size, ALIGN_4K);
+
+    if let Some(original) = layout
+        .image_size
+        .as_ref()
+        .map(|value| parse_size(value))
+        .transpose()?
+    {
+        // Preserve growth beyond computed minimum if template carried extra padding.
+        let baseline = original
+            .saturating_sub(original_payload)
+            .saturating_sub(original_ipl);
+        new_image_size = align_up(baseline + payload_size + ipl_size, ALIGN_4K).max(new_image_size);
+    }
+
+    layout.image_size = Some(format_size(new_image_size));
+
+    let generated_dir = args.project_root.join("target").join("config");
+    std::fs::create_dir_all(&generated_dir).with_context(|| {
+        format!(
+            "failed to create directory for generated layout: {}",
+            generated_dir.display()
+        )
+    })?;
+    let generated_layout = generated_dir.join("image_layout.generated.json");
+    let serialized = serde_json::to_string_pretty(&layout)?;
+    std::fs::write(&generated_layout, &serialized).with_context(|| {
+        format!(
+            "failed to write generated layout to {}",
+            generated_layout.display()
+        )
+    })?;
+
+    if let Some(output) = args.output {
+        std::fs::copy(&generated_layout, &output)
+            .with_context(|| format!("failed to copy generated layout to {}", output.display()))?;
+        println!("Image layout generated and copied to: {}", output.display());
+    } else {
+        println!("Image layout generated at: {}", generated_layout.display());
+    }
+
+    Ok(())
+}
+
+fn show_help() {
+    println!("td-shim-image-layout-gen {VERSION}");
+    println!();
+    println!("Computes a td-shim image layout from built artifacts.");
+    println!();
+    println!("Usage:");
+    println!("    {PROJECT_ROOT} <path>              Root directory of the project (required).");
+    println!("    {CARGO_TARGET_DIR} <dir>           Cargo target directory (default: target/).");
+    println!("    {BUILD_TARGET} <target>            Build target triple (default: x86_64-unknown-none).");
+    println!("    {CARGO_BUILD_DIRECTORY} <dir>      Build profile directory (default: release).");
+    println!("    {PAYLOAD_BINARY} <name>            Payload binary name (required).");
+    println!("    {IPL_BINARY} <name>                IPL binary name (default: td-shim).");
+    println!("    {RESET_VECTOR_BINARY} <name>       Reset vector binary name (default: ResetVector.bin).");
+    println!("    {TEMPLATE} <path>                  Layout template JSON (optional, uses built-in default).");
+    println!("    {OUTPUT} <path>                    Output file path (optional).");
+}
+
+fn prepare_args() -> Option<Args> {
+    use std::collections::VecDeque;
+    use std::env;
+    let mut args_list: VecDeque<String> = env::args().collect();
+    let _ = args_list.pop_front();
+
+    let mut project_root: Option<PathBuf> = None;
+    let mut cargo_target_dir: Option<String> = None;
+    let mut build_target: Option<String> = None;
+    let mut cargo_build_directory: Option<String> = None;
+    let mut payload_binary: Option<String> = None;
+    let mut ipl_binary: Option<String> = None;
+    let mut reset_vector_binary: Option<String> = None;
+    let mut output: Option<PathBuf> = None;
+    let mut template: Option<PathBuf> = None;
+
+    while let Some(cur) = args_list.pop_front() {
+        match cur.as_str() {
+            PROJECT_ROOT => {
+                if project_root.is_some() {
+                    eprintln!("{PROJECT_ROOT} is specified more than once!");
+                    return None;
+                } else if let Some(path) = args_list.pop_front() {
+                    project_root = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to {PROJECT_ROOT} is missing!");
+                    return None;
+                }
+            }
+            CARGO_TARGET_DIR => {
+                if cargo_target_dir.is_some() {
+                    eprintln!("{CARGO_TARGET_DIR} is specified more than once!");
+                    return None;
+                } else if let Some(dir) = args_list.pop_front() {
+                    cargo_target_dir = Some(dir);
+                } else {
+                    eprintln!("Parameter to {CARGO_TARGET_DIR} is missing!");
+                    return None;
+                }
+            }
+            BUILD_TARGET => {
+                if build_target.is_some() {
+                    eprintln!("{BUILD_TARGET} is specified more than once!");
+                    return None;
+                } else if let Some(target) = args_list.pop_front() {
+                    build_target = Some(target);
+                } else {
+                    eprintln!("Parameter to {BUILD_TARGET} is missing!");
+                    return None;
+                }
+            }
+            CARGO_BUILD_DIRECTORY => {
+                if cargo_build_directory.is_some() {
+                    eprintln!("{CARGO_BUILD_DIRECTORY} is specified more than once!");
+                    return None;
+                } else if let Some(dir) = args_list.pop_front() {
+                    cargo_build_directory = Some(dir);
+                } else {
+                    eprintln!("Parameter to {CARGO_BUILD_DIRECTORY} is missing!");
+                    return None;
+                }
+            }
+            PAYLOAD_BINARY => {
+                if payload_binary.is_some() {
+                    eprintln!("{PAYLOAD_BINARY} is specified more than once!");
+                    return None;
+                } else if let Some(name) = args_list.pop_front() {
+                    payload_binary = Some(name);
+                } else {
+                    eprintln!("Parameter to {PAYLOAD_BINARY} is missing!");
+                    return None;
+                }
+            }
+            IPL_BINARY => {
+                if ipl_binary.is_some() {
+                    eprintln!("{IPL_BINARY} is specified more than once!");
+                    return None;
+                } else if let Some(name) = args_list.pop_front() {
+                    ipl_binary = Some(name);
+                } else {
+                    eprintln!("Parameter to {IPL_BINARY} is missing!");
+                    return None;
+                }
+            }
+            RESET_VECTOR_BINARY => {
+                if reset_vector_binary.is_some() {
+                    eprintln!("{RESET_VECTOR_BINARY} is specified more than once!");
+                    return None;
+                } else if let Some(name) = args_list.pop_front() {
+                    reset_vector_binary = Some(name);
+                } else {
+                    eprintln!("Parameter to {RESET_VECTOR_BINARY} is missing!");
+                    return None;
+                }
+            }
+            TEMPLATE => {
+                if template.is_some() {
+                    eprintln!("{TEMPLATE} is specified more than once!");
+                    return None;
+                } else if let Some(path) = args_list.pop_front() {
+                    template = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to {TEMPLATE} is missing!");
+                    return None;
+                }
+            }
+            OUTPUT => {
+                if output.is_some() {
+                    eprintln!("{OUTPUT} is specified more than once!");
+                    return None;
+                } else if let Some(path) = args_list.pop_front() {
+                    output = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to {OUTPUT} is missing!");
+                    return None;
+                }
+            }
+            _ => {
+                eprintln!("Unknown argument: {cur}");
+                return None;
+            }
+        }
+    }
+
+    if project_root.is_none() {
+        eprintln!("{PROJECT_ROOT} is required!");
+        return None;
+    }
+    if payload_binary.is_none() {
+        eprintln!("{PAYLOAD_BINARY} is required!");
+        return None;
+    }
+
+    Some(Args {
+        project_root: project_root.unwrap(),
+        cargo_target_dir: cargo_target_dir.unwrap_or_default(),
+        build_target: build_target.unwrap_or_else(|| "x86_64-unknown-none".to_string()),
+        cargo_build_directory: cargo_build_directory.unwrap_or_else(|| "release".to_string()),
+        payload_binary: payload_binary.unwrap(),
+        ipl_binary: ipl_binary.unwrap_or_else(|| "td-shim".to_string()),
+        reset_vector_binary: reset_vector_binary.unwrap_or_else(|| "ResetVector.bin".to_string()),
+        output,
+        template,
+    })
+}
+
+fn main() {
+    if let Some(args) = prepare_args() {
+        if let Err(e) = generate_image_layout(args) {
+            eprintln!("Error: {e:?}");
+            std::process::exit(1);
+        }
+    } else {
+        show_help();
+        std::process::exit(1);
+    }
+}
+
+fn resolve_target_dir(project_root: &Path, cargo_target_dir: &str) -> PathBuf {
+    let mut target_dir = if cargo_target_dir.is_empty() {
+        project_root.join("target")
+    } else {
+        PathBuf::from(cargo_target_dir)
+    };
+
+    if target_dir.is_relative() {
+        target_dir = project_root.join(target_dir);
+    }
+
+    target_dir
+}
+
+fn cargo_build_directory_with_fallback(
+    dir: &str,
+    target_dir: &Path,
+    target_arch: &str,
+    binary_name: &str,
+) -> String {
+    if dir.is_empty() {
+        "release".to_string()
+    } else {
+        let binary_path = target_dir.join(target_arch).join(dir).join(binary_name);
+        if binary_path.exists() {
+            dir.to_string()
+        } else {
+            "release".to_string()
+        }
+    }
+}
+
+fn artifact_path(base: &Path, components: &[&str]) -> PathBuf {
+    components
+        .iter()
+        .fold(base.to_path_buf(), |acc, &c| acc.join(c))
+}
+
+fn file_size(path: &Path) -> Result<u64> {
+    Ok(std::fs::metadata(path)
+        .with_context(|| format!("failed to get metadata for {}", path.display()))?
+        .len())
+}
+
+fn parse_optional(value: &Option<String>) -> Result<u64> {
+    value.as_ref().map(|s| parse_size(s)).unwrap_or(Ok(0))
+}
+
+fn parse_size(value: &str) -> Result<u64> {
+    if let Some(stripped) = value.strip_prefix("0x") {
+        u64::from_str_radix(stripped, 16)
+            .map_err(|err| anyhow::anyhow!("invalid hex value '{}': {err}", value))
+    } else {
+        value
+            .parse::<u64>()
+            .map_err(|err| anyhow::anyhow!("invalid numeric value '{}': {err}", value))
+    }
+}
+
+fn format_size(value: u64) -> String {
+    format!("0x{value:x}")
+}
+
+fn align_up(value: u64, align: u64) -> u64 {
+    if align == 0 {
+        return value;
+    }
+    value.div_ceil(align) * align
+}
+
+/// Read an ELF64 binary and return the maximum (p_vaddr + p_filesz) across all
+/// PT_LOAD program headers. This represents the virtual address extent that the
+/// td-shim linker's relocation buffer must accommodate.
+fn elf64_max_vaddr_filesz(path: &Path) -> Result<u64> {
+    use std::io::Read;
+
+    let mut file =
+        std::fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let mut data = Vec::new();
+    file.read_to_end(&mut data)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+
+    anyhow::ensure!(data.len() >= 64, "ELF file too small: {}", path.display());
+    anyhow::ensure!(
+        &data[0..4] == b"\x7fELF",
+        "not a valid ELF file: {}",
+        path.display()
+    );
+    anyhow::ensure!(data[4] == 2, "not a 64-bit ELF file: {}", path.display());
+
+    let is_le = data[5] == 1;
+    let read_u16 = |off: usize| -> u16 {
+        if is_le {
+            u16::from_le_bytes([data[off], data[off + 1]])
+        } else {
+            u16::from_be_bytes([data[off], data[off + 1]])
+        }
+    };
+    let read_u32 = |off: usize| -> u32 {
+        if is_le {
+            u32::from_le_bytes(data[off..off + 4].try_into().unwrap())
+        } else {
+            u32::from_be_bytes(data[off..off + 4].try_into().unwrap())
+        }
+    };
+    let read_u64 = |off: usize| -> u64 {
+        if is_le {
+            u64::from_le_bytes(data[off..off + 8].try_into().unwrap())
+        } else {
+            u64::from_be_bytes(data[off..off + 8].try_into().unwrap())
+        }
+    };
+
+    let e_phoff = read_u64(32) as usize;
+    let e_phentsize = read_u16(54) as usize;
+    let e_phnum = read_u16(56) as usize;
+
+    // ELF64 program header entry is 56 bytes; reject malformed ELFs early.
+    anyhow::ensure!(
+        e_phentsize >= 56,
+        "invalid e_phentsize {} (expected >= 56) in {}",
+        e_phentsize,
+        path.display()
+    );
+
+    const PT_LOAD: u32 = 1;
+    let mut max_extent: u64 = 0;
+
+    for i in 0..e_phnum {
+        let ph_off = e_phoff + i * e_phentsize;
+        anyhow::ensure!(
+            ph_off + e_phentsize <= data.len(),
+            "program header out of bounds in {}",
+            path.display()
+        );
+        let p_type = read_u32(ph_off);
+        if p_type == PT_LOAD {
+            let p_vaddr = read_u64(ph_off + 16);
+            let p_filesz = read_u64(ph_off + 32);
+            let extent = p_vaddr
+                .checked_add(p_filesz)
+                .with_context(|| format!("overflow in ELF program header in {}", path.display()))?;
+            if extent > max_extent {
+                max_extent = extent;
+            }
+        }
+    }
+
+    anyhow::ensure!(
+        max_extent > 0,
+        "no PT_LOAD segments found in {}",
+        path.display()
+    );
+    Ok(max_extent)
+}

--- a/td-shim-tools/src/bin/td-shim-metadata-gen/README.md
+++ b/td-shim-tools/src/bin/td-shim-metadata-gen/README.md
@@ -1,0 +1,58 @@
+# td-shim-metadata-gen
+
+## Overview
+
+Generates a TDX metadata JSON file consumable by `td-shim-ld --metadata`.
+
+This tool accepts a section configuration file (JSON) that specifies each
+metadata section's type, sizes, offsets, and attributes. It validates the
+section types and writes the output JSON.
+
+## Usage
+
+```
+td-shim-metadata-gen --config <path> --out <path>
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--config <path>` | Input section configuration JSON (required) |
+| `--out <path>` | Output metadata JSON file path (required) |
+
+## Configuration Format
+
+The input JSON must have the following structure:
+
+```json
+{
+    "Sections": [
+        {
+            "Type": "BFV",
+            "Attributes": "0x1",
+            "DataOffset": "0x82000",
+            "RawDataSize": "0xF7E000",
+            "MemoryAddress": "0xFF082000",
+            "MemoryDataSize": "0xF7E000"
+        }
+    ]
+}
+```
+
+### Valid Section Types
+
+`BFV`, `CFV`, `TD_HOB`, `TempMem`, `PermMem`, `Payload`, `PayloadParam`, `TdInfo`, `TdParams`
+
+## Example
+
+```bash
+cargo run --bin td-shim-metadata-gen -- \
+    --config td-shim-tools/etc/sample_metadata.json \
+    --out target/metadata.json
+```
+
+## Output
+
+The output JSON has the same structure as the input and can be passed directly
+to `td-shim-ld --metadata`.

--- a/td-shim-tools/src/bin/td-shim-metadata-gen/main.rs
+++ b/td-shim-tools/src/bin/td-shim-metadata-gen/main.rs
@@ -1,0 +1,434 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! TDX Metadata JSON Generator
+//!
+//! Generates a TDX metadata JSON file consumable by `td-shim-ld --metadata`.
+//! Reads an image layout JSON (as produced by td-shim-image-layout-gen) and
+//! computes metadata section offsets from the section order. TdParams and TdInfo
+//! sections are included only if present in the layout with non-zero size.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::path::PathBuf;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// CLI argument names
+const LAYOUT: &str = "--layout";
+const MEMORY_LAYOUT: &str = "--memory-layout";
+const OUTPUT: &str = "--out";
+
+/// A single metadata section in the output.
+#[derive(Clone, Debug, Serialize)]
+struct SectionConfig {
+    #[serde(rename = "Type")]
+    r#type: String,
+    #[serde(rename = "Attributes")]
+    attributes: String,
+    #[serde(rename = "DataOffset")]
+    data_offset: String,
+    #[serde(rename = "RawDataSize")]
+    raw_data_size: String,
+    #[serde(rename = "MemoryAddress")]
+    memory_address: String,
+    #[serde(rename = "MemoryDataSize")]
+    memory_data_size: String,
+}
+
+/// Output format matching what `td-shim-ld --metadata` expects.
+#[derive(Clone, Debug, Serialize)]
+struct MetadataOutput {
+    #[serde(rename = "Sections")]
+    sections: Vec<SectionConfig>,
+}
+
+fn show_help() {
+    println!("td-shim-metadata-gen {VERSION}");
+    println!();
+    println!("Generates TDX metadata JSON for td-shim-ld from an image layout.");
+    println!();
+    println!("Usage:");
+    println!("    td-shim-metadata-gen {LAYOUT} <path> {OUTPUT} <path> [{MEMORY_LAYOUT} <path>]");
+    println!();
+    println!("Arguments:");
+    println!("    {LAYOUT} <path>           Image layout JSON (from td-shim-image-layout-gen).");
+    println!("    {OUTPUT} <path>           Output metadata JSON file path.");
+    println!("    {MEMORY_LAYOUT} <path>    Memory layout JSON with PermMem regions (optional).");
+    println!();
+    println!("The tool reads the image layout JSON, computes section offsets, and emits");
+    println!("metadata for BFV, TempMem, Payload, and optionally TdParams/TdInfo.");
+    println!("When --memory-layout is provided, PermMem sections are included.");
+}
+
+/// Parse a hex string like "0x20000" into u32.
+fn parse_hex(s: &str) -> Result<u32> {
+    let s = s.trim().trim_start_matches("0x").trim_start_matches("0X");
+    u32::from_str_radix(s, 16).with_context(|| format!("failed to parse hex value: {s}"))
+}
+
+/// Parse a hex string into u64.
+fn parse_hex_u64(s: &str) -> Result<u64> {
+    let s = s.trim().trim_start_matches("0x").trim_start_matches("0X");
+    u64::from_str_radix(s, 16).with_context(|| format!("failed to parse hex value: {s}"))
+}
+
+/// A memory region parsed from the memory layout file.
+struct MemoryRegion {
+    address: u64,
+    size: u64,
+}
+
+/// Parsed memory layout with PermMem and additional TempMem regions.
+struct MemoryLayoutConfig {
+    perm_mem: Vec<MemoryRegion>,
+    temp_mem: Vec<MemoryRegion>,
+}
+
+/// Parse the memory layout JSON file.
+fn parse_memory_layout(path: &PathBuf) -> Result<MemoryLayoutConfig> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let json: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    let parse_regions = |key: &str| -> Result<Vec<MemoryRegion>> {
+        match json.get(key).and_then(|v| v.as_array()) {
+            Some(arr) => {
+                let mut regions = Vec::new();
+                for entry in arr {
+                    let addr_str = entry["address"]
+                        .as_str()
+                        .with_context(|| format!("{key} entry missing 'address'"))?;
+                    let size_str = entry["size"]
+                        .as_str()
+                        .with_context(|| format!("{key} entry missing 'size'"))?;
+                    regions.push(MemoryRegion {
+                        address: parse_hex_u64(addr_str)?,
+                        size: parse_hex_u64(size_str)?,
+                    });
+                }
+                Ok(regions)
+            }
+            None => Ok(Vec::new()),
+        }
+    };
+
+    Ok(MemoryLayoutConfig {
+        perm_mem: parse_regions("PermMem")?,
+        temp_mem: parse_regions("TempMem")?,
+    })
+}
+
+fn generate_from_layout(
+    layout_path: &PathBuf,
+    memory_layout: &MemoryLayoutConfig,
+    output: &PathBuf,
+) -> Result<()> {
+    let content = std::fs::read_to_string(layout_path)
+        .with_context(|| format!("failed to read {}", layout_path.display()))?;
+
+    let layout: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse {}", layout_path.display()))?;
+
+    let obj = layout
+        .as_object()
+        .context("layout JSON must be an object")?;
+
+    let image_size = obj
+        .get("ImageSize")
+        .and_then(|v| v.as_str())
+        .context("ImageSize not found in layout")?;
+    let image_size = parse_hex(image_size)?;
+    let firmware_base = 0x1_0000_0000u64.wrapping_sub(image_size as u64) as u32;
+
+    // Section order (NRX): TempStack, TempHeap, Payload, TdInfo, TdParams, Metadata, Ipl, ResetVector
+    let section_order = [
+        "TempStack",
+        "TempHeap",
+        "Payload",
+        "TdInfo",
+        "TdParams",
+        "Metadata",
+        "Ipl",
+        "ResetVector",
+    ];
+
+    // Compute cumulative offsets
+    let mut offset = 0u32;
+    let mut section_offsets: Vec<(&str, u32, u32)> = Vec::new(); // (name, offset, size)
+    for name in &section_order {
+        if let Some(val) = obj.get(*name).and_then(|v| v.as_str()) {
+            let size = parse_hex(val)?;
+            section_offsets.push((name, offset, size));
+            offset += size;
+        }
+    }
+
+    // Find specific sections
+    let find = |name: &str| -> Option<(u32, u32)> {
+        section_offsets
+            .iter()
+            .find(|(n, _, _)| *n == name)
+            .map(|(_, off, sz)| (*off, *sz))
+    };
+
+    let mut sections = Vec::new();
+
+    // TdParams (optional)
+    if let Some((td_params_off, td_params_sz)) = find("TdParams") {
+        if td_params_sz > 0 {
+            sections.push(SectionConfig {
+                r#type: "TdParams".to_string(),
+                attributes: "0x0".to_string(),
+                data_offset: format!("0x{:X}", td_params_off),
+                raw_data_size: format!("0x{:X}", td_params_sz),
+                memory_address: "0x0".to_string(),
+                memory_data_size: "0x0".to_string(),
+            });
+        }
+    }
+
+    // BFV: starts at the earliest of TdInfo/TdParams (both must be within BFV)
+    // and extends to end of image.
+    let bfv_start = find("TdInfo")
+        .filter(|(_, sz)| *sz > 0)
+        .map(|(off, _)| off)
+        .into_iter()
+        .chain(
+            find("TdParams")
+                .filter(|(_, sz)| *sz > 0)
+                .map(|(off, _)| off)
+                .into_iter(),
+        )
+        .chain(find("Metadata").map(|(off, _)| off).into_iter())
+        .chain(find("Ipl").map(|(off, _)| off).into_iter())
+        .min()
+        .unwrap_or(0);
+    let bfv_size = image_size - bfv_start;
+    let bfv_base = firmware_base.wrapping_add(bfv_start);
+
+    sections.push(SectionConfig {
+        r#type: "BFV".to_string(),
+        attributes: "0x1".to_string(),
+        data_offset: format!("0x{:X}", bfv_start),
+        raw_data_size: format!("0x{:X}", bfv_size),
+        memory_address: format!("0x{:X}", bfv_base),
+        memory_data_size: format!("0x{:X}", bfv_size),
+    });
+
+    // TempMem: combine TempStack + TempHeap from image layout
+    let temp_stack = find("TempStack");
+    let temp_heap = find("TempHeap");
+    if let Some((stack_off, stack_sz)) = temp_stack {
+        let heap_sz = temp_heap.map(|(_, sz)| sz).unwrap_or(0);
+        let total = stack_sz + heap_sz;
+        let base = firmware_base.wrapping_add(stack_off);
+        sections.push(SectionConfig {
+            r#type: "TempMem".to_string(),
+            attributes: "0x0".to_string(),
+            data_offset: "0x0".to_string(),
+            raw_data_size: "0x0".to_string(),
+            memory_address: format!("0x{:X}", base),
+            memory_data_size: format!("0x{:X}", total),
+        });
+    }
+
+    // Additional TempMem regions from memory layout
+    for region in &memory_layout.temp_mem {
+        if region.size > 0 {
+            sections.push(SectionConfig {
+                r#type: "TempMem".to_string(),
+                attributes: "0x0".to_string(),
+                data_offset: "0x0".to_string(),
+                raw_data_size: "0x0".to_string(),
+                memory_address: format!("0x{:X}", region.address),
+                memory_data_size: format!("0x{:X}", region.size),
+            });
+        }
+    }
+
+    // Payload
+    if let Some((payload_off, payload_sz)) = find("Payload") {
+        if payload_sz > 0 {
+            let base = firmware_base.wrapping_add(payload_off);
+            sections.push(SectionConfig {
+                r#type: "Payload".to_string(),
+                attributes: "0x1".to_string(),
+                data_offset: format!("0x{:X}", payload_off),
+                raw_data_size: format!("0x{:X}", payload_sz),
+                memory_address: format!("0x{:X}", base),
+                memory_data_size: format!("0x{:X}", payload_sz),
+            });
+        }
+    }
+
+    // TdInfo (optional)
+    if let Some((td_info_off, td_info_sz)) = find("TdInfo") {
+        if td_info_sz > 0 {
+            sections.push(SectionConfig {
+                r#type: "TdInfo".to_string(),
+                attributes: "0x0".to_string(),
+                data_offset: format!("0x{:X}", td_info_off),
+                raw_data_size: format!("0x{:X}", td_info_sz),
+                memory_address: "0x0".to_string(),
+                memory_data_size: "0x0".to_string(),
+            });
+        }
+    }
+
+    // PermMem (VMM-allocated permanent memory via PAGE_AUG)
+    for region in &memory_layout.perm_mem {
+        if region.size > 0 {
+            sections.push(SectionConfig {
+                r#type: "PermMem".to_string(),
+                attributes: "0x2".to_string(),
+                data_offset: "0x0".to_string(),
+                raw_data_size: "0x0".to_string(),
+                memory_address: format!("0x{:X}", region.address),
+                memory_data_size: format!("0x{:X}", region.size),
+            });
+        }
+    }
+
+    // Validate no memory region overlaps
+    check_memory_overlaps(&sections)?;
+
+    let output_data = MetadataOutput { sections };
+    let json = serde_json::to_string_pretty(&output_data)?;
+    std::fs::write(output, &json)
+        .with_context(|| format!("failed to write output to {}", output.display()))?;
+
+    println!("TDX metadata JSON written to: {}", output.display());
+    Ok(())
+}
+
+/// Check that no two sections with non-zero memory ranges overlap.
+fn check_memory_overlaps(sections: &[SectionConfig]) -> Result<()> {
+    let ranges: Vec<(&str, u64, u64)> = sections
+        .iter()
+        .filter_map(|s| {
+            let addr = parse_hex_u64(&s.memory_address).ok()?;
+            let size = parse_hex_u64(&s.memory_data_size).ok()?;
+            if size == 0 {
+                return None;
+            }
+            Some((s.r#type.as_str(), addr, size))
+        })
+        .collect();
+
+    for i in 0..ranges.len() {
+        for j in (i + 1)..ranges.len() {
+            let (name_a, start_a, size_a) = ranges[i];
+            let (name_b, start_b, size_b) = ranges[j];
+            let end_a = start_a + size_a;
+            let end_b = start_b + size_b;
+            if start_a < end_b && start_b < end_a {
+                anyhow::bail!(
+                    "memory overlap: {name_a} [0x{start_a:X}..0x{end_a:X}) overlaps \
+                     {name_b} [0x{start_b:X}..0x{end_b:X})"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Args {
+    layout: PathBuf,
+    memory_layout: Option<PathBuf>,
+    output: PathBuf,
+}
+
+fn prepare_args() -> Option<Args> {
+    use std::collections::VecDeque;
+    use std::env;
+    let mut args_list: VecDeque<String> = env::args().collect();
+    let _ = args_list.pop_front();
+
+    let mut layout: Option<PathBuf> = None;
+    let mut memory_layout: Option<PathBuf> = None;
+    let mut output: Option<PathBuf> = None;
+
+    while let Some(cur) = args_list.pop_front() {
+        match cur.as_str() {
+            LAYOUT => {
+                if layout.is_some() {
+                    eprintln!("{LAYOUT} is specified more than once!");
+                    return None;
+                } else if let Some(path) = args_list.pop_front() {
+                    layout = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to {LAYOUT} is missing!");
+                    return None;
+                }
+            }
+            MEMORY_LAYOUT => {
+                if memory_layout.is_some() {
+                    eprintln!("{MEMORY_LAYOUT} is specified more than once!");
+                    return None;
+                } else if let Some(path) = args_list.pop_front() {
+                    memory_layout = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to {MEMORY_LAYOUT} is missing!");
+                    return None;
+                }
+            }
+            OUTPUT => {
+                if output.is_some() {
+                    eprintln!("{OUTPUT} is specified more than once!");
+                    return None;
+                } else if let Some(path) = args_list.pop_front() {
+                    output = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to {OUTPUT} is missing!");
+                    return None;
+                }
+            }
+            _ => {
+                eprintln!("Unknown argument: {cur}");
+                return None;
+            }
+        }
+    }
+
+    if layout.is_none() {
+        eprintln!("{LAYOUT} is required!");
+        return None;
+    }
+    if output.is_none() {
+        eprintln!("{OUTPUT} is required!");
+        return None;
+    }
+
+    Some(Args {
+        layout: layout.unwrap(),
+        memory_layout,
+        output: output.unwrap(),
+    })
+}
+
+fn main() {
+    if let Some(args) = prepare_args() {
+        let mem_config = if let Some(path) = &args.memory_layout {
+            parse_memory_layout(path).unwrap_or_else(|e| {
+                eprintln!("Error parsing memory layout: {e:?}");
+                std::process::exit(1);
+            })
+        } else {
+            MemoryLayoutConfig {
+                perm_mem: Vec::new(),
+                temp_mem: Vec::new(),
+            }
+        };
+        if let Err(e) = generate_from_layout(&args.layout, &mem_config, &args.output) {
+            eprintln!("Error: {e:?}");
+            std::process::exit(1);
+        }
+    } else {
+        show_help();
+        std::process::exit(1);
+    }
+}

--- a/td-shim-tools/src/bin/td-shim-patch/README.md
+++ b/td-shim-tools/src/bin/td-shim-patch/README.md
@@ -1,0 +1,66 @@
+# td-shim-patch
+
+Unified patching tool for td-shim firmware images. Allows replacing any member
+of the TDX Metadata descriptor (signature, section attributes), TD Params
+structure (all fields of the 1024-byte binary layout), and TD Info section
+(GUID, version, SVN, and the opaque payload-specific blob) in a built firmware
+image without rebuilding from source.
+
+## Usage
+
+```
+td-shim-patch <subcommand> [options]
+```
+
+## Subcommands
+
+### `tdx-metadata`
+
+Patches the TDX metadata signature and zeros all section attributes.
+
+```
+td-shim-patch tdx-metadata --in <image> --out <image> --signature <hex>
+```
+
+| Option | Description |
+|--------|-------------|
+| `--in <path>` | Input firmware image |
+| `--out <path>` | Output firmware image |
+| `--signature <hex>` | New metadata signature (e.g., `0x58524e5f`) |
+
+### `td-params`
+
+Patches the TD_PARAMS section from a JSON file.
+
+```
+td-shim-patch td-params --in <image> --out <image> --tdparams <json>
+```
+
+| Option | Description |
+|--------|-------------|
+| `--in <path>` | Input firmware image |
+| `--out <path>` | Output firmware image |
+| `--tdparams <path>` | JSON file with TD_PARAMS fields |
+
+### `td-info`
+
+Patches the TD_INFO section with a generic header and a payload-specific binary blob.
+
+```
+td-shim-patch td-info --in <image> --out <image> --guid <guid> --version <a.b.c> --svn <n> --payload-info <path>
+```
+
+| Option | Description |
+|--------|-------------|
+| `--in <path>` | Input firmware image |
+| `--out <path>` | Output firmware image |
+| `--guid <guid>` | TD type GUID (e.g., `6d8415a6-5701-0247-a696-c0420ce3b4e9`) |
+| `--version <a.b.c>` | Release version as `major.minor.update` |
+| `--svn <n>` | Security Version Number |
+| `--payload-info <path>` | Binary blob with TD-type-specific info |
+
+## Building
+
+```
+cargo build -p td-shim-tools --bin td-shim-patch
+```

--- a/td-shim-tools/src/bin/td-shim-patch/main.rs
+++ b/td-shim-tools/src/bin/td-shim-patch/main.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! td-shim-patch
+//!
+//! Unified patching tool for td-shim firmware images.
+//! Subcommands: tdx-metadata, td-params, td-info
+
+mod metadata;
+mod td_info;
+mod td_params;
+
+fn print_help() {
+    println!("td-shim-patch {}", env!("CARGO_PKG_VERSION"));
+    println!();
+    println!("Usage: td-shim-patch <subcommand> [options]");
+    println!();
+    println!("Subcommands:");
+    println!("    tdx-metadata  Patch TDX metadata signature and zero section attributes.");
+    println!("    td-params     Patch the TD_PARAMS section from a JSON file.");
+    println!("    td-info       Patch the TD_INFO section with a header + payload blob.");
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        print_help();
+        std::process::exit(1);
+    }
+
+    let subcommand = &args[1];
+    // Pass remaining args (skip binary name and subcommand)
+    let sub_args: Vec<String> = args[2..].to_vec();
+
+    let result = match subcommand.as_str() {
+        "tdx-metadata" => metadata::run(sub_args),
+        "td-params" => td_params::run(sub_args),
+        "td-info" => td_info::run(sub_args),
+        "--help" | "-h" => {
+            print_help();
+            std::process::exit(0);
+        }
+        other => {
+            eprintln!("Unknown subcommand: {other}");
+            eprintln!();
+            print_help();
+            std::process::exit(1);
+        }
+    };
+
+    if let Err(e) = result {
+        eprintln!("Error: {e:?}");
+        std::process::exit(1);
+    }
+}

--- a/td-shim-tools/src/bin/td-shim-patch/metadata.rs
+++ b/td-shim-tools/src/bin/td-shim-patch/metadata.rs
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! Patches the TDX metadata signature in a td-shim firmware image and zeros
+//! all section attributes. This is used to re-sign images for alternative
+//! metadata consumers (e.g., NRX).
+
+use std::mem::size_of;
+use std::path::PathBuf;
+
+use anyhow::Result;
+use scroll::Pwrite;
+use td_shim_interface::metadata::{
+    TdxMetadataSection, TDX_METADATA_DESCRIPTOR_LEN, TDX_METADATA_SECTION_LEN,
+};
+use td_shim_tools::image::{Image, ParsedMetadata};
+
+#[derive(Debug)]
+struct Args {
+    input: PathBuf,
+    output: PathBuf,
+    signature: u32,
+}
+
+fn patch_metadata(args: &Args) -> Result<()> {
+    let mut image = Image::open(&args.input)?;
+    let metadata = ParsedMetadata::from_image(&image)?;
+
+    println!(
+        "TDX Metadata found at offset 0x{:x}",
+        metadata.descriptor_offset
+    );
+    println!(
+        "  Current signature: 0x{:08x}",
+        metadata.descriptor.signature
+    );
+    println!("  Sections: {}", metadata.sections.len());
+
+    // Patch signature in the descriptor
+    let desc_off = metadata.descriptor_offset;
+    image
+        .binary
+        .pwrite_with(args.signature, desc_off, scroll::LE)
+        .map_err(|e| anyhow::anyhow!("failed to write signature: {e}"))?;
+
+    println!("  New signature: 0x{:08x}", args.signature);
+
+    // Zero all section attributes
+    let sections_start = desc_off + TDX_METADATA_DESCRIPTOR_LEN as usize;
+    for i in 0..metadata.sections.len() {
+        let section_off = sections_start + i * TDX_METADATA_SECTION_LEN as usize;
+        // attributes is the last u32 in TdxMetadataSection (offset 28 within the section)
+        let attr_off = section_off + size_of::<TdxMetadataSection>() - size_of::<u32>();
+        image
+            .binary
+            .pwrite_with(0u32, attr_off, scroll::LE)
+            .map_err(|e| anyhow::anyhow!("failed to zero attributes for section {i}: {e}"))?;
+    }
+
+    println!(
+        "  Zeroed attributes for all {} sections",
+        metadata.sections.len()
+    );
+
+    image.write(&args.output)?;
+    println!("Patched image written to: {}", args.output.display());
+
+    Ok(())
+}
+
+fn show_help() {
+    eprintln!("td-shim-patch tdx-metadata");
+    eprintln!();
+    eprintln!("Patches TDX metadata signature and zeros section attributes.");
+    eprintln!();
+    eprintln!("Usage:");
+    eprintln!("    --in <path>          Input firmware image (required).");
+    eprintln!("    --out <path>         Output firmware image (required).");
+    eprintln!(
+        "    --signature <hex>    New metadata signature as hex (e.g., 0x58524e5f) (required)."
+    );
+}
+
+fn parse_hex_u32(s: &str) -> Option<u32> {
+    if let Some(stripped) = s.strip_prefix("0x") {
+        u32::from_str_radix(stripped, 16).ok()
+    } else if let Some(stripped) = s.strip_prefix("0X") {
+        u32::from_str_radix(stripped, 16).ok()
+    } else {
+        s.parse::<u32>().ok()
+    }
+}
+
+fn prepare_args(args_list: Vec<String>) -> Option<Args> {
+    use std::collections::VecDeque;
+    let mut args_list: VecDeque<String> = args_list.into();
+
+    let mut input: Option<PathBuf> = None;
+    let mut output: Option<PathBuf> = None;
+    let mut signature: Option<u32> = None;
+
+    while let Some(cur) = args_list.pop_front() {
+        match cur.as_str() {
+            "--in" => {
+                if let Some(path) = args_list.pop_front() {
+                    input = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to --in is missing!");
+                    return None;
+                }
+            }
+            "--out" => {
+                if let Some(path) = args_list.pop_front() {
+                    output = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to --out is missing!");
+                    return None;
+                }
+            }
+            "--signature" => {
+                if let Some(sig_str) = args_list.pop_front() {
+                    if let Some(sig) = parse_hex_u32(&sig_str) {
+                        signature = Some(sig);
+                    } else {
+                        eprintln!("Failed to parse --signature value: {sig_str}");
+                        return None;
+                    }
+                } else {
+                    eprintln!("Parameter to --signature is missing!");
+                    return None;
+                }
+            }
+            _ => {
+                eprintln!("Unknown argument: {cur}");
+                return None;
+            }
+        }
+    }
+
+    if input.is_none() || output.is_none() || signature.is_none() {
+        return None;
+    }
+
+    Some(Args {
+        input: input.unwrap(),
+        output: output.unwrap(),
+        signature: signature.unwrap(),
+    })
+}
+
+pub fn run(args: Vec<String>) -> Result<()> {
+    if let Some(parsed) = prepare_args(args) {
+        patch_metadata(&parsed)
+    } else {
+        show_help();
+        std::process::exit(1);
+    }
+}

--- a/td-shim-tools/src/bin/td-shim-patch/td_info.rs
+++ b/td-shim-tools/src/bin/td-shim-patch/td_info.rs
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! Patches the TD_INFO section of a td-shim firmware image with a generic
+//! header (GUID, length, version, SVN) and an opaque payload-specific binary
+//! blob. The blob format is defined by the caller (TD type specific).
+
+use std::path::PathBuf;
+
+use anyhow::{ensure, Context, Result};
+use td_shim_interface::metadata::TDX_METADATA_SECTION_TYPE_TD_INFO;
+use td_shim_tools::image::{Image, ParsedMetadata};
+
+/// TD_INFO generic header: guid(16) + length(4) + version(4) + svn(4) = 28 bytes
+const TD_INFO_HEADER_SIZE: usize = 28;
+
+#[derive(Debug)]
+struct Args {
+    input: PathBuf,
+    output: PathBuf,
+    guid: [u8; 16],
+    version: u32,
+    svn: u32,
+    payload_info: PathBuf,
+}
+
+fn patch_td_info(args: &Args) -> Result<()> {
+    let mut image = Image::open(&args.input)?;
+    let metadata = ParsedMetadata::from_image(&image)?;
+
+    let section = metadata
+        .find_section(TDX_METADATA_SECTION_TYPE_TD_INFO)
+        .context("TD_INFO section not found in TDX metadata")?;
+
+    let offset = section.data_offset as usize;
+    let max_size = section.raw_data_size as usize;
+    ensure!(
+        offset + max_size <= image.binary.len(),
+        "TD_INFO section extends beyond image bounds"
+    );
+
+    // Read the payload-info blob
+    let payload_blob = std::fs::read(&args.payload_info)
+        .with_context(|| format!("failed to read {}", args.payload_info.display()))?;
+
+    let total_size = TD_INFO_HEADER_SIZE + payload_blob.len();
+    ensure!(
+        total_size <= max_size,
+        "TD_INFO data ({total_size} bytes) exceeds section capacity ({max_size} bytes)",
+    );
+
+    // Zero the entire section first
+    image.binary[offset..offset + max_size].fill(0);
+
+    // Write generic header
+    let mut pos = offset;
+
+    // GUID (16 bytes)
+    image.binary[pos..pos + 16].copy_from_slice(&args.guid);
+    pos += 16;
+
+    // Length (4 bytes, LE) — total size of TdInfo including header + payload
+    let length = total_size as u32;
+    image.binary[pos..pos + 4].copy_from_slice(&length.to_le_bytes());
+    pos += 4;
+
+    // Version (4 bytes, LE)
+    image.binary[pos..pos + 4].copy_from_slice(&args.version.to_le_bytes());
+    pos += 4;
+
+    // SVN (4 bytes, LE)
+    image.binary[pos..pos + 4].copy_from_slice(&args.svn.to_le_bytes());
+    pos += 4;
+
+    // Payload-specific blob
+    image.binary[pos..pos + payload_blob.len()].copy_from_slice(&payload_blob);
+
+    println!("TD_INFO patched at offset 0x{offset:x}");
+    println!("  GUID: {:02x?}", args.guid);
+    println!("  Length: {total_size} (0x{total_size:x})");
+    println!("  Version: 0x{:08x}", args.version);
+    println!("  SVN: {}", args.svn);
+    println!(
+        "  Payload info: {} bytes from {}",
+        payload_blob.len(),
+        args.payload_info.display()
+    );
+
+    image.write(&args.output)?;
+    println!("Patched image written to: {}", args.output.display());
+
+    Ok(())
+}
+
+/// Parse a GUID string in the form "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+/// into 16 bytes in mixed-endian format (matching UEFI PI GUID encoding).
+fn parse_guid(s: &str) -> Option<[u8; 16]> {
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 5 {
+        return None;
+    }
+
+    // Validate expected field lengths: 8-4-4-4-12
+    if parts[0].len() != 8
+        || parts[1].len() != 4
+        || parts[2].len() != 4
+        || parts[3].len() != 4
+        || parts[4].len() != 12
+    {
+        return None;
+    }
+
+    let d1 = u32::from_str_radix(parts[0], 16).ok()?;
+    let d2 = u16::from_str_radix(parts[1], 16).ok()?;
+    let d3 = u16::from_str_radix(parts[2], 16).ok()?;
+    let d4 = u16::from_str_radix(parts[3], 16).ok()?;
+    let d5 = u64::from_str_radix(parts[4], 16).ok()?;
+
+    let mut guid = [0u8; 16];
+    // First three fields are little-endian (UEFI mixed-endian GUID)
+    guid[0..4].copy_from_slice(&d1.to_le_bytes());
+    guid[4..6].copy_from_slice(&d2.to_le_bytes());
+    guid[6..8].copy_from_slice(&d3.to_le_bytes());
+    // Last two fields are big-endian
+    guid[8..10].copy_from_slice(&d4.to_be_bytes());
+    guid[10..16].copy_from_slice(&d5.to_be_bytes()[2..8]);
+
+    Some(guid)
+}
+
+/// Parse version string "major.minor.update" into packed u32:
+/// (major << 24) | (minor << 16) | update
+fn parse_version(s: &str) -> Option<u32> {
+    let parts: Vec<&str> = s.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let major = parts[0].parse::<u8>().ok()?;
+    let minor = parts[1].parse::<u8>().ok()?;
+    let update = parts[2].parse::<u16>().ok()?;
+    Some(((major as u32) << 24) | ((minor as u32) << 16) | (update as u32))
+}
+
+fn show_help() {
+    eprintln!("td-shim-patch td-info");
+    eprintln!();
+    eprintln!("Patches the TD_INFO section with a generic header + payload-specific blob.");
+    eprintln!();
+    eprintln!("Usage:");
+    eprintln!("    --in <path>              Input firmware image (required).");
+    eprintln!("    --out <path>             Output firmware image (required).");
+    eprintln!("    --guid <guid>            TD type GUID, e.g. 6d8415a6-5701-0247-a696-c0420ce3b4e9 (required).");
+    eprintln!("    --version <a.b.c>        Release version as major.minor.update (required).");
+    eprintln!("    --svn <n>                Security Version Number (required).");
+    eprintln!("    --payload-info <path>    Binary blob with TD-type-specific info (required).");
+}
+
+fn prepare_args(args_list: Vec<String>) -> Option<Args> {
+    use std::collections::VecDeque;
+    let mut args_list: VecDeque<String> = args_list.into();
+
+    let mut input: Option<PathBuf> = None;
+    let mut output: Option<PathBuf> = None;
+    let mut guid: Option<[u8; 16]> = None;
+    let mut version: Option<u32> = None;
+    let mut svn: Option<u32> = None;
+    let mut payload_info: Option<PathBuf> = None;
+
+    while let Some(cur) = args_list.pop_front() {
+        match cur.as_str() {
+            "--in" => {
+                if let Some(path) = args_list.pop_front() {
+                    input = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to --in is missing!");
+                    return None;
+                }
+            }
+            "--out" => {
+                if let Some(path) = args_list.pop_front() {
+                    output = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to --out is missing!");
+                    return None;
+                }
+            }
+            "--guid" => {
+                if let Some(guid_str) = args_list.pop_front() {
+                    if let Some(g) = parse_guid(&guid_str) {
+                        guid = Some(g);
+                    } else {
+                        eprintln!("Failed to parse GUID: {guid_str}");
+                        return None;
+                    }
+                } else {
+                    eprintln!("Parameter to --guid is missing!");
+                    return None;
+                }
+            }
+            "--version" => {
+                if let Some(ver_str) = args_list.pop_front() {
+                    if let Some(v) = parse_version(&ver_str) {
+                        version = Some(v);
+                    } else {
+                        eprintln!(
+                            "Failed to parse version: {ver_str} (expected major.minor.update)"
+                        );
+                        return None;
+                    }
+                } else {
+                    eprintln!("Parameter to --version is missing!");
+                    return None;
+                }
+            }
+            "--svn" => {
+                if let Some(svn_str) = args_list.pop_front() {
+                    if let Ok(s) = svn_str.parse::<u32>() {
+                        svn = Some(s);
+                    } else {
+                        eprintln!("Failed to parse SVN: {svn_str}");
+                        return None;
+                    }
+                } else {
+                    eprintln!("Parameter to --svn is missing!");
+                    return None;
+                }
+            }
+            "--payload-info" => {
+                if let Some(path) = args_list.pop_front() {
+                    payload_info = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to --payload-info is missing!");
+                    return None;
+                }
+            }
+            _ => {
+                eprintln!("Unknown argument: {cur}");
+                return None;
+            }
+        }
+    }
+
+    if input.is_none()
+        || output.is_none()
+        || guid.is_none()
+        || version.is_none()
+        || svn.is_none()
+        || payload_info.is_none()
+    {
+        return None;
+    }
+
+    Some(Args {
+        input: input.unwrap(),
+        output: output.unwrap(),
+        guid: guid.unwrap(),
+        version: version.unwrap(),
+        svn: svn.unwrap(),
+        payload_info: payload_info.unwrap(),
+    })
+}
+
+pub fn run(args: Vec<String>) -> Result<()> {
+    if let Some(parsed) = prepare_args(args) {
+        patch_td_info(&parsed)
+    } else {
+        show_help();
+        std::process::exit(1);
+    }
+}

--- a/td-shim-tools/src/bin/td-shim-patch/td_params.rs
+++ b/td-shim-tools/src/bin/td-shim-patch/td_params.rs
@@ -1,0 +1,349 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! Patches the TD_PARAMS section of a td-shim firmware image from a JSON file.
+//! The JSON file must contain the full 1024-byte TD_PARAMS structure serialized
+//! as a flat JSON object with fields matching the TDX TD_PARAMS layout.
+
+use std::path::PathBuf;
+
+use anyhow::{ensure, Context, Result};
+use td_shim_interface::metadata::TDX_METADATA_SECTION_TYPE_TD_PARAMS;
+use td_shim_tools::image::{Image, ParsedMetadata};
+
+/// TD_PARAMS is exactly 1024 bytes (as defined in TDX Module spec).
+const TD_PARAMS_SIZE: usize = 1024;
+
+#[derive(Debug)]
+struct Args {
+    input: PathBuf,
+    output: PathBuf,
+    tdparams_json: PathBuf,
+}
+
+fn patch_params(args: &Args) -> Result<()> {
+    let mut image = Image::open(&args.input)?;
+    let metadata = ParsedMetadata::from_image(&image)?;
+
+    let section = metadata
+        .find_section(TDX_METADATA_SECTION_TYPE_TD_PARAMS)
+        .context("TD_PARAMS section not found in TDX metadata")?;
+
+    let offset = section.data_offset as usize;
+    let size = section.raw_data_size as usize;
+    ensure!(
+        size >= TD_PARAMS_SIZE,
+        "TD_PARAMS section too small: {size} bytes, need {TD_PARAMS_SIZE}",
+    );
+    ensure!(
+        offset + size <= image.binary.len(),
+        "TD_PARAMS section extends beyond image bounds"
+    );
+
+    // Read the JSON file as raw bytes and deserialize into the TD_PARAMS region.
+    // The JSON structure should produce exactly TD_PARAMS_SIZE bytes when serialized.
+    let json_content = std::fs::read_to_string(&args.tdparams_json)
+        .with_context(|| format!("failed to read {}", args.tdparams_json.display()))?;
+
+    let td_params: serde_json::Value = serde_json::from_str(&json_content)
+        .with_context(|| format!("failed to parse {}", args.tdparams_json.display()))?;
+
+    // Serialize the TD_PARAMS fields into the binary region.
+    // We expect the JSON to contain hex-string fields that map to the TD_PARAMS structure.
+    let params_bytes = serialize_td_params(&td_params)?;
+    ensure!(
+        params_bytes.len() == TD_PARAMS_SIZE,
+        "serialized TD_PARAMS is {} bytes, expected {TD_PARAMS_SIZE}",
+        params_bytes.len(),
+    );
+
+    image.binary[offset..offset + TD_PARAMS_SIZE].copy_from_slice(&params_bytes);
+
+    println!("TD_PARAMS patched at offset 0x{offset:x} ({TD_PARAMS_SIZE} bytes)");
+
+    image.write(&args.output)?;
+    println!("Patched image written to: {}", args.output.display());
+
+    Ok(())
+}
+
+/// Serialize TD_PARAMS JSON into the 1024-byte binary layout.
+///
+/// Expected JSON fields (all values as hex strings or integers):
+/// - attributes (u64), xfam (u64), maxvcpus (u16), numl2vms (u8),
+///   msrconfigctls (u8), reserved (u32), eptpcontrols (u64), configflags (u64),
+///   tscfrequency (u16), reserved2 ([u8;38]), mrconfigid ([u8;48]),
+///   mrowner ([u8;48]), mrownerconfig ([u8;48]), ia32archcapabilitiesconfig (u64),
+///   mrconfigsvn (u16), mrownerconfigsvn (u16), reserved3 ([u8;20]),
+///   cpuid_config ([u8;768])
+fn serialize_td_params(value: &serde_json::Value) -> Result<Vec<u8>> {
+    let mut buf = vec![0u8; TD_PARAMS_SIZE];
+    let mut offset = 0usize;
+
+    let write_u64 =
+        |buf: &mut Vec<u8>, off: &mut usize, v: &serde_json::Value, name: &str| -> Result<()> {
+            let val = parse_json_u64(v, name)?;
+            buf[*off..*off + 8].copy_from_slice(&val.to_le_bytes());
+            *off += 8;
+            Ok(())
+        };
+    let write_u32 =
+        |buf: &mut Vec<u8>, off: &mut usize, v: &serde_json::Value, name: &str| -> Result<()> {
+            let val = parse_json_u32(v, name)?;
+            buf[*off..*off + 4].copy_from_slice(&val.to_le_bytes());
+            *off += 4;
+            Ok(())
+        };
+    let write_u16 =
+        |buf: &mut Vec<u8>, off: &mut usize, v: &serde_json::Value, name: &str| -> Result<()> {
+            let val = parse_json_u16(v, name)?;
+            buf[*off..*off + 2].copy_from_slice(&val.to_le_bytes());
+            *off += 2;
+            Ok(())
+        };
+    let write_u8 =
+        |buf: &mut Vec<u8>, off: &mut usize, v: &serde_json::Value, name: &str| -> Result<()> {
+            let val = parse_json_u8(v, name)?;
+            buf[*off] = val;
+            *off += 1;
+            Ok(())
+        };
+    let write_bytes = |buf: &mut Vec<u8>,
+                       off: &mut usize,
+                       v: &serde_json::Value,
+                       name: &str,
+                       len: usize|
+     -> Result<()> {
+        let bytes = parse_json_bytes(v, name, len)?;
+        buf[*off..*off + len].copy_from_slice(&bytes);
+        *off += len;
+        Ok(())
+    };
+
+    write_u64(&mut buf, &mut offset, value, "attributes")?;
+    write_u64(&mut buf, &mut offset, value, "xfam")?;
+    write_u16(&mut buf, &mut offset, value, "maxvcpus")?;
+    write_u8(&mut buf, &mut offset, value, "numl2vms")?;
+    write_u8(&mut buf, &mut offset, value, "msrconfigctls")?;
+    write_u32(&mut buf, &mut offset, value, "reserved")?;
+    write_u64(&mut buf, &mut offset, value, "eptpcontrols")?;
+    write_u64(&mut buf, &mut offset, value, "configflags")?;
+    write_u16(&mut buf, &mut offset, value, "tscfrequency")?;
+    write_bytes(&mut buf, &mut offset, value, "reserved2", 38)?;
+    write_bytes(&mut buf, &mut offset, value, "mrconfigid", 48)?;
+    write_bytes(&mut buf, &mut offset, value, "mrowner", 48)?;
+    write_bytes(&mut buf, &mut offset, value, "mrownerconfig", 48)?;
+    write_u64(&mut buf, &mut offset, value, "ia32archcapabilitiesconfig")?;
+    write_u16(&mut buf, &mut offset, value, "mrconfigsvn")?;
+    write_u16(&mut buf, &mut offset, value, "mrownerconfigsvn")?;
+    write_bytes(&mut buf, &mut offset, value, "reserved3", 20)?;
+    write_bytes(&mut buf, &mut offset, value, "cpuid_config", 768)?;
+
+    ensure!(
+        offset == TD_PARAMS_SIZE,
+        "TD_PARAMS serialization offset mismatch: got {offset}, expected {TD_PARAMS_SIZE}"
+    );
+    Ok(buf)
+}
+
+fn parse_json_u64(obj: &serde_json::Value, field: &str) -> Result<u64> {
+    match obj.get(field) {
+        Some(serde_json::Value::Number(n)) => n
+            .as_u64()
+            .context(format!("field '{field}' is not a valid u64")),
+        Some(serde_json::Value::String(s)) => {
+            parse_hex_u64(s).with_context(|| format!("field '{field}' has invalid hex value '{s}'"))
+        }
+        Some(_) => anyhow::bail!("field '{field}' has unexpected type"),
+        None => Ok(0),
+    }
+}
+
+fn parse_json_u32(obj: &serde_json::Value, field: &str) -> Result<u32> {
+    match obj.get(field) {
+        Some(serde_json::Value::Number(n)) => {
+            let v = n
+                .as_u64()
+                .context(format!("field '{field}' is not a valid u32"))?;
+            ensure!(
+                v <= u32::MAX as u64,
+                "field '{field}' value {v} overflows u32"
+            );
+            Ok(v as u32)
+        }
+        Some(serde_json::Value::String(s)) => {
+            parse_hex_u32(s).with_context(|| format!("field '{field}' has invalid hex value '{s}'"))
+        }
+        Some(_) => anyhow::bail!("field '{field}' has unexpected type"),
+        None => Ok(0),
+    }
+}
+
+fn parse_json_u16(obj: &serde_json::Value, field: &str) -> Result<u16> {
+    match obj.get(field) {
+        Some(serde_json::Value::Number(n)) => {
+            let v = n
+                .as_u64()
+                .context(format!("field '{field}' is not a valid u16"))?;
+            ensure!(
+                v <= u16::MAX as u64,
+                "field '{field}' value {v} overflows u16"
+            );
+            Ok(v as u16)
+        }
+        Some(serde_json::Value::String(s)) => {
+            parse_hex_u16(s).with_context(|| format!("field '{field}' has invalid hex value '{s}'"))
+        }
+        Some(_) => anyhow::bail!("field '{field}' has unexpected type"),
+        None => Ok(0),
+    }
+}
+
+fn parse_json_u8(obj: &serde_json::Value, field: &str) -> Result<u8> {
+    match obj.get(field) {
+        Some(serde_json::Value::Number(n)) => {
+            let v = n
+                .as_u64()
+                .context(format!("field '{field}' is not a valid u8"))?;
+            ensure!(
+                v <= u8::MAX as u64,
+                "field '{field}' value {v} overflows u8"
+            );
+            Ok(v as u8)
+        }
+        Some(serde_json::Value::String(s)) => {
+            parse_hex_u8(s).with_context(|| format!("field '{field}' has invalid hex value '{s}'"))
+        }
+        Some(_) => anyhow::bail!("field '{field}' has unexpected type"),
+        None => Ok(0),
+    }
+}
+
+fn parse_json_bytes(obj: &serde_json::Value, field: &str, expected_len: usize) -> Result<Vec<u8>> {
+    match obj.get(field) {
+        Some(serde_json::Value::String(s)) => {
+            let bytes = hex::decode(s.trim_start_matches("0x").trim_start_matches("0X"))
+                .with_context(|| format!("field '{field}' has invalid hex bytes"))?;
+            ensure!(
+                bytes.len() == expected_len,
+                "field '{field}': expected {expected_len} bytes, got {}",
+                bytes.len()
+            );
+            Ok(bytes)
+        }
+        Some(serde_json::Value::Array(arr)) => {
+            let mut bytes = Vec::with_capacity(expected_len);
+            for (i, v) in arr.iter().enumerate() {
+                let val = v
+                    .as_u64()
+                    .with_context(|| format!("field '{field}' element {i} is not a number"))?;
+                ensure!(
+                    val <= u8::MAX as u64,
+                    "field '{field}' element {i} value {val} overflows u8"
+                );
+                bytes.push(val as u8);
+            }
+            ensure!(
+                bytes.len() == expected_len,
+                "field '{field}': expected {expected_len} bytes, got {}",
+                bytes.len()
+            );
+            Ok(bytes)
+        }
+        Some(_) => anyhow::bail!("field '{field}' has unexpected type"),
+        None => Ok(vec![0u8; expected_len]),
+    }
+}
+
+fn parse_hex_u64(s: &str) -> Result<u64> {
+    let s = s.trim_start_matches("0x").trim_start_matches("0X");
+    u64::from_str_radix(s, 16).with_context(|| format!("invalid hex u64: {s}"))
+}
+
+fn parse_hex_u32(s: &str) -> Result<u32> {
+    let s = s.trim_start_matches("0x").trim_start_matches("0X");
+    u32::from_str_radix(s, 16).with_context(|| format!("invalid hex u32: {s}"))
+}
+
+fn parse_hex_u16(s: &str) -> Result<u16> {
+    let s = s.trim_start_matches("0x").trim_start_matches("0X");
+    u16::from_str_radix(s, 16).with_context(|| format!("invalid hex u16: {s}"))
+}
+
+fn parse_hex_u8(s: &str) -> Result<u8> {
+    let s = s.trim_start_matches("0x").trim_start_matches("0X");
+    u8::from_str_radix(s, 16).with_context(|| format!("invalid hex u8: {s}"))
+}
+
+fn show_help() {
+    eprintln!("td-shim-patch td-params");
+    eprintln!();
+    eprintln!("Patches the TD_PARAMS section of a td-shim firmware image from JSON.");
+    eprintln!();
+    eprintln!("Usage:");
+    eprintln!("    --in <path>          Input firmware image (required).");
+    eprintln!("    --out <path>         Output firmware image (required).");
+    eprintln!("    --tdparams <path>    TD_PARAMS JSON file (required).");
+}
+
+fn prepare_args(args_list: Vec<String>) -> Option<Args> {
+    use std::collections::VecDeque;
+    let mut args_list: VecDeque<String> = args_list.into();
+
+    let mut input: Option<PathBuf> = None;
+    let mut output: Option<PathBuf> = None;
+    let mut tdparams_json: Option<PathBuf> = None;
+
+    while let Some(cur) = args_list.pop_front() {
+        match cur.as_str() {
+            "--in" => {
+                if let Some(path) = args_list.pop_front() {
+                    input = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to --in is missing!");
+                    return None;
+                }
+            }
+            "--out" => {
+                if let Some(path) = args_list.pop_front() {
+                    output = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to --out is missing!");
+                    return None;
+                }
+            }
+            "--tdparams" => {
+                if let Some(path) = args_list.pop_front() {
+                    tdparams_json = Some(PathBuf::from(path));
+                } else {
+                    eprintln!("Parameter to --tdparams is missing!");
+                    return None;
+                }
+            }
+            _ => {
+                eprintln!("Unknown argument: {cur}");
+                return None;
+            }
+        }
+    }
+
+    if input.is_none() || output.is_none() || tdparams_json.is_none() {
+        return None;
+    }
+
+    Some(Args {
+        input: input.unwrap(),
+        output: output.unwrap(),
+        tdparams_json: tdparams_json.unwrap(),
+    })
+}
+
+pub fn run(args: Vec<String>) -> Result<()> {
+    if let Some(parsed) = prepare_args(args) {
+        patch_params(&parsed)
+    } else {
+        show_help();
+        std::process::exit(1);
+    }
+}

--- a/td-shim-tools/src/image.rs
+++ b/td-shim-tools/src/image.rs
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! Shared image I/O for td-shim binary patching tools.
+//!
+//! Provides reading/writing of td-shim firmware images and locating TDX
+//! metadata sections within them.
+
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::mem::size_of;
+use std::path::Path;
+
+use anyhow::{ensure, Context, Result};
+use scroll::Pread;
+use td_shim_interface::metadata::{
+    TdxMetadataDescriptor, TdxMetadataSection, TDX_METADATA_DESCRIPTOR_LEN, TDX_METADATA_GUID,
+    TDX_METADATA_GUID_LEN, TDX_METADATA_OFFSET, TDX_METADATA_SECTION_LEN,
+};
+use td_shim_interface::td_uefi_pi::pi::guid::Guid;
+
+pub const MAX_IMAGE_SIZE: usize = 0x1000000; // 16 MiB
+
+/// A loaded td-shim firmware image.
+pub struct Image {
+    pub binary: Vec<u8>,
+}
+
+impl Image {
+    /// Read a td-shim firmware image from the given path.
+    pub fn open(path: &Path) -> Result<Self> {
+        let metadata = std::fs::metadata(path)
+            .with_context(|| format!("failed to stat {}", path.display()))?;
+        let size = metadata.len() as usize;
+        ensure!(
+            size <= MAX_IMAGE_SIZE,
+            "image too large ({} bytes, max {})",
+            size,
+            MAX_IMAGE_SIZE
+        );
+
+        let file =
+            File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+        let mut reader = BufReader::new(file);
+        let mut binary = Vec::with_capacity(size);
+        reader
+            .read_to_end(&mut binary)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+
+        Ok(Image { binary })
+    }
+
+    /// Write the image to the given path.
+    pub fn write(&self, path: &Path) -> Result<()> {
+        let file =
+            File::create(path).with_context(|| format!("failed to create {}", path.display()))?;
+        let mut writer = BufWriter::new(file);
+        writer
+            .write_all(&self.binary)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        Ok(())
+    }
+}
+
+/// Parsed TDX metadata from an image.
+pub struct ParsedMetadata {
+    /// Byte offset of the TdxMetadataDescriptor within the image.
+    pub descriptor_offset: usize,
+    /// The metadata descriptor.
+    pub descriptor: TdxMetadataDescriptor,
+    /// The metadata GUID bytes.
+    pub guid: [u8; 16],
+    /// All sections parsed from the image.
+    pub sections: Vec<TdxMetadataSection>,
+}
+
+impl ParsedMetadata {
+    /// Locate and parse TDX metadata from the image.
+    pub fn from_image(image: &Image) -> Result<Self> {
+        let eob = image.binary.len();
+        ensure!(
+            eob > TDX_METADATA_OFFSET as usize + size_of::<u32>(),
+            "image too small to contain metadata pointer"
+        );
+
+        // Read the metadata offset pointer (located at end - TDX_METADATA_OFFSET)
+        let ptr_offset = eob - TDX_METADATA_OFFSET as usize;
+        let metadata_offset: u32 = image
+            .binary
+            .pread_with(ptr_offset, scroll::LE)
+            .map_err(|e| anyhow::anyhow!("failed to read metadata offset pointer: {}", e))?;
+        let metadata_offset = metadata_offset as usize;
+
+        ensure!(
+            metadata_offset + TDX_METADATA_DESCRIPTOR_LEN as usize <= eob,
+            "metadata offset 0x{:x} is out of bounds",
+            metadata_offset
+        );
+        ensure!(
+            metadata_offset >= TDX_METADATA_GUID_LEN as usize,
+            "metadata offset 0x{:x} leaves no room for GUID",
+            metadata_offset
+        );
+
+        // Read GUID (immediately before the descriptor)
+        let guid_start = metadata_offset - TDX_METADATA_GUID_LEN as usize;
+        let mut guid = [0u8; 16];
+        guid.copy_from_slice(&image.binary[guid_start..metadata_offset]);
+
+        // Validate GUID
+        let parsed_guid = Guid::from_bytes(&guid);
+        ensure!(
+            parsed_guid == TDX_METADATA_GUID,
+            "TDX metadata GUID mismatch: expected {:?}, got {:?}",
+            TDX_METADATA_GUID,
+            parsed_guid
+        );
+
+        // Read descriptor
+        let descriptor: TdxMetadataDescriptor = image
+            .binary
+            .pread_with(metadata_offset, scroll::LE)
+            .map_err(|e| anyhow::anyhow!("failed to read TDX metadata descriptor: {}", e))?;
+
+        ensure!(
+            descriptor.version == 1,
+            "unsupported TDX metadata version: {} (expected 1)",
+            descriptor.version
+        );
+
+        // Read sections
+        let num_sections = descriptor.number_of_section_entry as usize;
+        let sections_start = metadata_offset + TDX_METADATA_DESCRIPTOR_LEN as usize;
+        let sections_end = sections_start + num_sections * TDX_METADATA_SECTION_LEN as usize;
+        ensure!(
+            sections_end <= eob,
+            "metadata sections extend beyond image bounds"
+        );
+
+        let mut sections = Vec::with_capacity(num_sections);
+        for i in 0..num_sections {
+            let off = sections_start + i * TDX_METADATA_SECTION_LEN as usize;
+            let section: TdxMetadataSection = image
+                .binary
+                .pread_with(off, scroll::LE)
+                .map_err(|e| anyhow::anyhow!("failed to read metadata section {}: {}", i, e))?;
+            sections.push(section);
+        }
+
+        Ok(ParsedMetadata {
+            descriptor_offset: metadata_offset,
+            descriptor,
+            guid,
+            sections,
+        })
+    }
+
+    /// Find a section by type. Returns the first match.
+    pub fn find_section(&self, section_type: u32) -> Option<&TdxMetadataSection> {
+        self.sections.iter().find(|s| s.r#type == section_type)
+    }
+}

--- a/td-shim-tools/src/lib.rs
+++ b/td-shim-tools/src/lib.rs
@@ -30,6 +30,9 @@ pub mod read_file;
 #[cfg(feature = "tee")]
 pub mod tee_info_hash;
 
+#[cfg(feature = "patcher")]
+pub mod image;
+
 /// Struct to read input data from a file.
 pub struct InputData {
     data: Vec<u8>,

--- a/td-shim-tools/tests/image-layout-gen-test.rs
+++ b/td-shim-tools/tests/image-layout-gen-test.rs
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! Integration tests for td-shim-image-layout-gen binary.
+//!
+//! Note: Full end-to-end tests require actual build artifacts (ELF binaries,
+//! reset vector). These tests validate argument parsing and error handling.
+//! For full integration testing with real artifacts, use the project's CI
+//! build pipeline which produces the required binaries first.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn bin_path() -> PathBuf {
+    let mut path = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    path.push("td-shim-image-layout-gen");
+    path
+}
+
+#[test]
+fn test_image_layout_missing_args() {
+    let status = Command::new(bin_path())
+        .status()
+        .expect("failed to run td-shim-image-layout-gen");
+
+    assert!(!status.success(), "should fail with no arguments");
+}
+
+#[test]
+fn test_image_layout_missing_payload_binary() {
+    let status = Command::new(bin_path())
+        .args(["--project-root", "/tmp"])
+        .status()
+        .expect("failed to run td-shim-image-layout-gen");
+
+    assert!(!status.success(), "should fail without --payload-binary");
+}
+
+#[test]
+fn test_image_layout_missing_project_root() {
+    let status = Command::new(bin_path())
+        .args(["--payload-binary", "some-payload"])
+        .status()
+        .expect("failed to run td-shim-image-layout-gen");
+
+    assert!(!status.success(), "should fail without --project-root");
+}
+
+#[test]
+fn test_image_layout_unknown_argument() {
+    let output = Command::new(bin_path())
+        .args(["--unknown-flag", "value"])
+        .output()
+        .expect("failed to run td-shim-image-layout-gen");
+
+    assert!(
+        !output.status.success(),
+        "should fail with unknown argument"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Unknown argument"),
+        "should report unknown argument"
+    );
+}
+
+#[test]
+fn test_image_layout_duplicate_project_root() {
+    let output = Command::new(bin_path())
+        .args([
+            "--project-root",
+            "/tmp",
+            "--project-root",
+            "/tmp",
+            "--payload-binary",
+            "test",
+        ])
+        .output()
+        .expect("failed to run td-shim-image-layout-gen");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("specified more than once"));
+}
+
+#[test]
+fn test_image_layout_nonexistent_artifacts() {
+    // Even with valid args, should fail if the target directory/artifacts don't exist
+    let tmp = tempfile::tempdir().unwrap();
+    let output = Command::new(bin_path())
+        .args([
+            "--project-root",
+            tmp.path().to_str().unwrap(),
+            "--payload-binary",
+            "nonexistent-payload",
+        ])
+        .output()
+        .expect("failed to run td-shim-image-layout-gen");
+
+    assert!(
+        !output.status.success(),
+        "should fail when artifact files don't exist"
+    );
+}

--- a/td-shim-tools/tests/metadata-gen-test.rs
+++ b/td-shim-tools/tests/metadata-gen-test.rs
@@ -1,0 +1,438 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! Integration tests for td-shim-metadata-gen binary.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn bin_path() -> PathBuf {
+    // The integration test binary is built alongside the workspace binaries.
+    let mut path = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    path.push("td-shim-metadata-gen");
+    path
+}
+
+/// Create a temporary layout JSON for testing.
+fn write_layout(dir: &std::path::Path, content: &str) -> PathBuf {
+    let path = dir.join("layout.json");
+    std::fs::write(&path, content).unwrap();
+    path
+}
+
+#[test]
+fn test_metadata_gen_with_layout() {
+    let output_dir = tempfile::tempdir().unwrap();
+    let output_path = output_dir.path().join("metadata_output.json");
+
+    let layout = write_layout(
+        output_dir.path(),
+        r#"{
+            "TempStack": "0x20000",
+            "TempHeap": "0x20000",
+            "Payload": "0x17000",
+            "TdInfo": "0x1000",
+            "TdParams": "0x1000",
+            "Metadata": "0x1000",
+            "Ipl": "0x16000",
+            "ResetVector": "0x8000",
+            "ImageSize": "0x78000"
+        }"#,
+    );
+
+    let status = Command::new(bin_path())
+        .args([
+            "--layout",
+            layout.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-metadata-gen");
+
+    assert!(status.success(), "td-shim-metadata-gen should succeed");
+    assert!(output_path.exists(), "output file should be created");
+
+    let content = std::fs::read_to_string(&output_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let sections = parsed["Sections"].as_array().unwrap();
+    // Should have: TdParams, BFV, TempMem, Payload, TdInfo
+    assert_eq!(sections.len(), 5);
+    assert_eq!(sections[0]["Type"], "TdParams");
+    assert_eq!(sections[1]["Type"], "BFV");
+    assert_eq!(sections[2]["Type"], "TempMem");
+    assert_eq!(sections[3]["Type"], "Payload");
+    assert_eq!(sections[4]["Type"], "TdInfo");
+}
+
+/// Create a temporary memory layout JSON for testing.
+fn write_memory_layout(dir: &std::path::Path, content: &str) -> PathBuf {
+    let path = dir.join("memory_layout.json");
+    std::fs::write(&path, content).unwrap();
+    path
+}
+
+#[test]
+fn test_metadata_gen_with_perm_mem() {
+    let output_dir = tempfile::tempdir().unwrap();
+    let output_path = output_dir.path().join("metadata_output.json");
+
+    let layout = write_layout(
+        output_dir.path(),
+        r#"{
+            "TempStack": "0x20000",
+            "TempHeap": "0x20000",
+            "Payload": "0x17000",
+            "TdInfo": "0x1000",
+            "TdParams": "0x1000",
+            "Metadata": "0x1000",
+            "Ipl": "0x16000",
+            "ResetVector": "0x8000",
+            "ImageSize": "0x78000"
+        }"#,
+    );
+
+    let mem_layout = write_memory_layout(
+        output_dir.path(),
+        r#"{
+            "PermMem": [
+                { "address": "0x0", "size": "0x2000000" }
+            ]
+        }"#,
+    );
+
+    let status = Command::new(bin_path())
+        .args([
+            "--layout",
+            layout.to_str().unwrap(),
+            "--memory-layout",
+            mem_layout.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-metadata-gen");
+
+    assert!(status.success(), "td-shim-metadata-gen should succeed");
+
+    let content = std::fs::read_to_string(&output_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let sections = parsed["Sections"].as_array().unwrap();
+    // Should have: TdParams, BFV, TempMem, Payload, TdInfo, PermMem
+    assert_eq!(sections.len(), 6);
+    assert_eq!(sections[5]["Type"], "PermMem");
+    assert_eq!(sections[5]["Attributes"], "0x2");
+    assert_eq!(sections[5]["MemoryAddress"], "0x0");
+    assert_eq!(sections[5]["MemoryDataSize"], "0x2000000");
+    assert_eq!(sections[5]["DataOffset"], "0x0");
+    assert_eq!(sections[5]["RawDataSize"], "0x0");
+}
+
+#[test]
+fn test_metadata_gen_with_multiple_perm_mem() {
+    let output_dir = tempfile::tempdir().unwrap();
+    let output_path = output_dir.path().join("metadata_output.json");
+
+    let layout = write_layout(
+        output_dir.path(),
+        r#"{
+            "TempStack": "0x20000",
+            "TempHeap": "0x20000",
+            "Payload": "0x17000",
+            "Metadata": "0x1000",
+            "Ipl": "0x16000",
+            "ResetVector": "0x8000",
+            "ImageSize": "0x70000"
+        }"#,
+    );
+
+    let mem_layout = write_memory_layout(
+        output_dir.path(),
+        r#"{
+            "PermMem": [
+                { "address": "0x0", "size": "0x2000000" },
+                { "address": "0x100000000", "size": "0x800000000" }
+            ]
+        }"#,
+    );
+
+    let status = Command::new(bin_path())
+        .args([
+            "--layout",
+            layout.to_str().unwrap(),
+            "--memory-layout",
+            mem_layout.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-metadata-gen");
+
+    assert!(status.success());
+
+    let content = std::fs::read_to_string(&output_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let sections = parsed["Sections"].as_array().unwrap();
+    // BFV, TempMem, Payload + 2x PermMem = 5
+    assert_eq!(sections.len(), 5);
+    assert_eq!(sections[3]["Type"], "PermMem");
+    assert_eq!(sections[3]["MemoryDataSize"], "0x2000000");
+    assert_eq!(sections[4]["Type"], "PermMem");
+    assert_eq!(sections[4]["MemoryDataSize"], "0x800000000");
+}
+
+#[test]
+fn test_metadata_gen_with_additional_temp_mem() {
+    let output_dir = tempfile::tempdir().unwrap();
+    let output_path = output_dir.path().join("metadata_output.json");
+
+    let layout = write_layout(
+        output_dir.path(),
+        r#"{
+            "TempStack": "0x20000",
+            "TempHeap": "0x20000",
+            "Payload": "0x17000",
+            "Metadata": "0x1000",
+            "Ipl": "0x16000",
+            "ResetVector": "0x8000",
+            "ImageSize": "0x70000"
+        }"#,
+    );
+
+    let mem_layout = write_memory_layout(
+        output_dir.path(),
+        r#"{
+            "PermMem": [
+                { "address": "0x0", "size": "0x2000000" }
+            ],
+            "TempMem": [
+                { "address": "0x10000000", "size": "0x1000000" }
+            ]
+        }"#,
+    );
+
+    let status = Command::new(bin_path())
+        .args([
+            "--layout",
+            layout.to_str().unwrap(),
+            "--memory-layout",
+            mem_layout.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-metadata-gen");
+
+    assert!(status.success());
+
+    let content = std::fs::read_to_string(&output_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let sections = parsed["Sections"].as_array().unwrap();
+    // BFV, TempMem (from layout), TempMem (from memory-layout), Payload, PermMem = 5
+    assert_eq!(sections.len(), 5);
+    // First TempMem from image layout (TempStack + TempHeap)
+    assert_eq!(sections[1]["Type"], "TempMem");
+    // Second TempMem from memory layout
+    assert_eq!(sections[2]["Type"], "TempMem");
+    assert_eq!(sections[2]["MemoryAddress"], "0x10000000");
+    assert_eq!(sections[2]["MemoryDataSize"], "0x1000000");
+    // PermMem
+    assert_eq!(sections[4]["Type"], "PermMem");
+}
+
+#[test]
+fn test_metadata_gen_overlap_detection() {
+    let output_dir = tempfile::tempdir().unwrap();
+    let output_path = output_dir.path().join("metadata_output.json");
+
+    let layout = write_layout(
+        output_dir.path(),
+        r#"{
+            "TempStack": "0x20000",
+            "TempHeap": "0x20000",
+            "Payload": "0x17000",
+            "Metadata": "0x1000",
+            "Ipl": "0x16000",
+            "ResetVector": "0x8000",
+            "ImageSize": "0x70000"
+        }"#,
+    );
+
+    // PermMem overlaps with itself (two regions at the same address)
+    let mem_layout = write_memory_layout(
+        output_dir.path(),
+        r#"{
+            "PermMem": [
+                { "address": "0x0", "size": "0x2000000" },
+                { "address": "0x1000000", "size": "0x2000000" }
+            ],
+            "TempMem": []
+        }"#,
+    );
+
+    let status = Command::new(bin_path())
+        .args([
+            "--layout",
+            layout.to_str().unwrap(),
+            "--memory-layout",
+            mem_layout.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-metadata-gen");
+
+    assert!(!status.success(), "should fail when memory regions overlap");
+}
+
+#[test]
+fn test_metadata_gen_layout_without_tdparams() {
+    let output_dir = tempfile::tempdir().unwrap();
+    let output_path = output_dir.path().join("metadata_output.json");
+
+    // Layout without TdParams or TdInfo
+    let layout = write_layout(
+        output_dir.path(),
+        r#"{
+            "TempStack": "0x20000",
+            "TempHeap": "0x20000",
+            "Payload": "0x17000",
+            "Metadata": "0x1000",
+            "Ipl": "0x16000",
+            "ResetVector": "0x8000",
+            "ImageSize": "0x70000"
+        }"#,
+    );
+
+    let status = Command::new(bin_path())
+        .args([
+            "--layout",
+            layout.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-metadata-gen");
+
+    assert!(status.success(), "should succeed without TdParams/TdInfo");
+
+    let content = std::fs::read_to_string(&output_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let sections = parsed["Sections"].as_array().unwrap();
+    // Should have: BFV, TempMem, Payload (no TdParams, no TdInfo)
+    assert_eq!(sections.len(), 3);
+    assert_eq!(sections[0]["Type"], "BFV");
+    assert_eq!(sections[1]["Type"], "TempMem");
+    assert_eq!(sections[2]["Type"], "Payload");
+}
+
+#[test]
+fn test_metadata_gen_sample_nrx_image_template() {
+    // Verify the tool handles an NRX-style layout with a separate memory layout.
+    let output_dir = tempfile::tempdir().unwrap();
+    let output_path = output_dir.path().join("metadata_output.json");
+
+    let layout = write_layout(
+        output_dir.path(),
+        r#"{
+            "TdParams": "0x1000",
+            "TempStack": "0x20000",
+            "TempHeap": "0x20000",
+            "TdInfo": "0x1000",
+            "Metadata": "0x1000",
+            "Payload": "0x10000",
+            "Ipl": "0x10000",
+            "ResetVector": "0x8000",
+            "ImageSize": "0x6C000"
+        }"#,
+    );
+
+    let mem_layout = write_memory_layout(
+        output_dir.path(),
+        r#"{
+            "PermMem": [
+                { "address": "0x0", "size": "0x2000000" }
+            ]
+        }"#,
+    );
+
+    let status = Command::new(bin_path())
+        .args([
+            "--layout",
+            layout.to_str().unwrap(),
+            "--memory-layout",
+            mem_layout.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-metadata-gen");
+
+    assert!(status.success());
+
+    let content = std::fs::read_to_string(&output_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let sections = parsed["Sections"].as_array().unwrap();
+    // TdParams, BFV, TempMem, Payload, TdInfo, PermMem
+    assert_eq!(sections.len(), 6);
+    assert_eq!(sections[5]["Type"], "PermMem");
+}
+
+#[test]
+fn test_metadata_gen_missing_args() {
+    let status = Command::new(bin_path())
+        .status()
+        .expect("failed to run td-shim-metadata-gen");
+
+    assert!(!status.success(), "should fail with no arguments");
+}
+
+#[test]
+fn test_metadata_gen_missing_layout_file() {
+    let output_dir = tempfile::tempdir().unwrap();
+    let output_path = output_dir.path().join("metadata_output.json");
+
+    let status = Command::new(bin_path())
+        .args([
+            "--layout",
+            "/nonexistent/path/layout.json",
+            "--out",
+            output_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-metadata-gen");
+
+    assert!(
+        !status.success(),
+        "should fail when layout file does not exist"
+    );
+}
+
+#[test]
+fn test_metadata_gen_duplicate_args() {
+    let output_dir = tempfile::tempdir().unwrap();
+    let output_path = output_dir.path().join("metadata_output.json");
+
+    let layout = write_layout(output_dir.path(), r#"{"ImageSize": "0x10000"}"#);
+
+    let status = Command::new(bin_path())
+        .args([
+            "--layout",
+            layout.to_str().unwrap(),
+            "--layout",
+            layout.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-metadata-gen");
+
+    assert!(!status.success(), "should fail with duplicate --layout");
+}

--- a/td-shim-tools/tests/patch-test.rs
+++ b/td-shim-tools/tests/patch-test.rs
@@ -1,0 +1,482 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+//! Integration tests for td-shim-patch binary.
+//!
+//! These tests build synthetic firmware images with valid TDX metadata
+//! and exercise each subcommand.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use scroll::Pwrite;
+
+fn bin_path() -> PathBuf {
+    let mut path = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    path.push("td-shim-patch");
+    path
+}
+
+// -- Constants matching td-shim-interface/src/metadata.rs --
+
+const TDX_METADATA_OFFSET: u32 = 0x20;
+const TDX_METADATA_GUID: [u8; 16] = [
+    0xf3, 0xf9, 0xea, 0xe9, // data1 LE
+    0x8e, 0x16, // data2 LE
+    0xd5, 0x44, // data3 LE
+    0xa8, 0xeb, 0x7f, 0x4d, 0x87, 0x38, 0xf6, 0xae, // data4 BE
+];
+
+const TDX_METADATA_SIGNATURE: u32 = 0x46564454; // 'TDVF'
+const TDX_METADATA_SECTION_TYPE_TD_INFO: u32 = 7;
+const TDX_METADATA_SECTION_TYPE_TD_PARAMS: u32 = 8;
+
+/// Build a synthetic firmware image with TDX metadata containing two sections:
+/// TD_INFO and TD_PARAMS.
+///
+/// Layout (from start to end):
+/// [0x0000 .. 0x0400)  TD_INFO data region  (1024 bytes)
+/// [0x0400 .. 0x0800)  TD_PARAMS data region (1024 bytes)
+/// [0x0800 .. end)     padding + metadata structures at end
+///
+/// Image size: 4096 bytes (one page, easy to reason about).
+fn build_test_image() -> Vec<u8> {
+    let image_size: usize = 4096;
+    let mut image = vec![0u8; image_size];
+
+    // Section data regions
+    let td_info_offset: u32 = 0x0000;
+    let td_info_size: u32 = 1024;
+    let td_params_offset: u32 = 0x0400;
+    let td_params_size: u32 = 1024;
+
+    // We'll place metadata at a known position near the end.
+    // Metadata pointer is at: image_size - TDX_METADATA_OFFSET (= 4096 - 32 = 4064)
+    // Metadata layout (from descriptor start going forward):
+    //   GUID (16 bytes) | Descriptor (16 bytes) | Section0 (32 bytes) | Section1 (32 bytes)
+    // Total metadata block = 16 + 16 + 64 = 96 bytes
+    // Let descriptor start at offset 3952 (which leaves room: 3952 + 16 + 64 = 4032, < 4064)
+
+    let descriptor_offset: usize = 3952;
+    let guid_offset = descriptor_offset - 16;
+
+    // Write GUID
+    image[guid_offset..guid_offset + 16].copy_from_slice(&TDX_METADATA_GUID);
+
+    // Write descriptor: signature(4) + length(4) + version(4) + num_sections(4)
+    let num_sections: u32 = 2;
+    let descriptor_length: u32 = 16 + num_sections * 32; // 80
+    image
+        .pwrite_with(TDX_METADATA_SIGNATURE, descriptor_offset, scroll::LE)
+        .unwrap();
+    image
+        .pwrite_with(descriptor_length, descriptor_offset + 4, scroll::LE)
+        .unwrap();
+    image
+        .pwrite_with(1u32, descriptor_offset + 8, scroll::LE)
+        .unwrap(); // version
+    image
+        .pwrite_with(num_sections, descriptor_offset + 12, scroll::LE)
+        .unwrap();
+
+    // Write sections (each 32 bytes): data_offset(4) + raw_data_size(4) +
+    //   memory_address(8) + memory_data_size(8) + type(4) + attributes(4)
+    let sections_start = descriptor_offset + 16;
+
+    // Section 0: TD_INFO
+    let s0 = sections_start;
+    image.pwrite_with(td_info_offset, s0, scroll::LE).unwrap();
+    image.pwrite_with(td_info_size, s0 + 4, scroll::LE).unwrap();
+    image
+        .pwrite_with(0x1000_0000u64, s0 + 8, scroll::LE)
+        .unwrap(); // memory_address
+    image
+        .pwrite_with(td_info_size as u64, s0 + 16, scroll::LE)
+        .unwrap(); // memory_data_size
+    image
+        .pwrite_with(TDX_METADATA_SECTION_TYPE_TD_INFO, s0 + 24, scroll::LE)
+        .unwrap();
+    image.pwrite_with(0x01u32, s0 + 28, scroll::LE).unwrap(); // attributes (non-zero to test zeroing)
+
+    // Section 1: TD_PARAMS
+    let s1 = sections_start + 32;
+    image.pwrite_with(td_params_offset, s1, scroll::LE).unwrap();
+    image
+        .pwrite_with(td_params_size, s1 + 4, scroll::LE)
+        .unwrap();
+    image
+        .pwrite_with(0x2000_0000u64, s1 + 8, scroll::LE)
+        .unwrap();
+    image
+        .pwrite_with(td_params_size as u64, s1 + 16, scroll::LE)
+        .unwrap();
+    image
+        .pwrite_with(TDX_METADATA_SECTION_TYPE_TD_PARAMS, s1 + 24, scroll::LE)
+        .unwrap();
+    image.pwrite_with(0x03u32, s1 + 28, scroll::LE).unwrap(); // attributes
+
+    // Write metadata pointer at (image_size - TDX_METADATA_OFFSET)
+    let ptr_offset = image_size - TDX_METADATA_OFFSET as usize;
+    image
+        .pwrite_with(descriptor_offset as u32, ptr_offset, scroll::LE)
+        .unwrap();
+
+    image
+}
+
+// ============================================================
+// Subcommand: metadata
+// ============================================================
+
+#[test]
+fn test_patch_metadata_missing_args() {
+    let output = Command::new(bin_path())
+        .args(["tdx-metadata"])
+        .output()
+        .expect("failed to run td-shim-patch");
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_patch_metadata_patches_signature_and_zeros_attributes() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("input.bin");
+    let output_path = dir.path().join("output.bin");
+
+    std::fs::write(&input_path, build_test_image()).unwrap();
+
+    let new_sig: u32 = 0x58524e5f; // "_NRX"
+
+    let status = Command::new(bin_path())
+        .args([
+            "tdx-metadata",
+            "--in",
+            input_path.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+            "--signature",
+            "0x58524e5f",
+        ])
+        .status()
+        .expect("failed to run td-shim-patch tdx-metadata");
+
+    assert!(
+        status.success(),
+        "td-shim-patch tdx-metadata should succeed"
+    );
+    assert!(output_path.exists());
+
+    // Verify the output image
+    let patched = std::fs::read(&output_path).unwrap();
+    let descriptor_offset: usize = 3952;
+    let sections_start = descriptor_offset + 16;
+
+    // Check signature was patched
+    let sig: u32 = scroll::Pread::pread_with(&patched[..], descriptor_offset, scroll::LE).unwrap();
+    assert_eq!(sig, new_sig, "signature should be patched to 0x58524e5f");
+
+    // Check section attributes were zeroed
+    let attr0: u32 =
+        scroll::Pread::pread_with(&patched[..], sections_start + 28, scroll::LE).unwrap();
+    let attr1: u32 =
+        scroll::Pread::pread_with(&patched[..], sections_start + 32 + 28, scroll::LE).unwrap();
+    assert_eq!(attr0, 0, "section 0 attributes should be zeroed");
+    assert_eq!(attr1, 0, "section 1 attributes should be zeroed");
+}
+
+#[test]
+fn test_patch_metadata_invalid_image() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("bad.bin");
+    let output_path = dir.path().join("out.bin");
+
+    // Write an image too small to have metadata
+    std::fs::write(&input_path, vec![0u8; 64]).unwrap();
+
+    let status = Command::new(bin_path())
+        .args([
+            "tdx-metadata",
+            "--in",
+            input_path.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+            "--signature",
+            "0x12345678",
+        ])
+        .status()
+        .expect("failed to run td-shim-patch tdx-metadata");
+
+    assert!(!status.success(), "should fail on invalid image");
+}
+
+// ============================================================
+// Subcommand: params
+// ============================================================
+
+#[test]
+fn test_patch_params_missing_args() {
+    let output = Command::new(bin_path())
+        .args(["td-params"])
+        .output()
+        .expect("failed to run td-shim-patch");
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_patch_params_writes_td_params_region() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("input.bin");
+    let output_path = dir.path().join("output.bin");
+    let json_path = dir.path().join("td_params.json");
+
+    std::fs::write(&input_path, build_test_image()).unwrap();
+
+    // Write a minimal TD_PARAMS JSON with known values
+    let td_params_json = serde_json::json!({
+        "attributes": "0x0000000000000001",
+        "xfam": "0x0000000000000003",
+        "maxvcpus": 8,
+        "numl2vms": 0,
+        "msrconfigctls": 0
+    });
+    std::fs::write(
+        &json_path,
+        serde_json::to_string_pretty(&td_params_json).unwrap(),
+    )
+    .unwrap();
+
+    let status = Command::new(bin_path())
+        .args([
+            "td-params",
+            "--in",
+            input_path.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+            "--tdparams",
+            json_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-patch td-params");
+
+    assert!(status.success(), "td-shim-patch td-params should succeed");
+    assert!(output_path.exists());
+
+    // Verify the TD_PARAMS region was written
+    let patched = std::fs::read(&output_path).unwrap();
+    let td_params_offset: usize = 0x0400;
+
+    // attributes (u64 LE) at offset 0 of the region
+    let attr: u64 = scroll::Pread::pread_with(&patched[..], td_params_offset, scroll::LE).unwrap();
+    assert_eq!(attr, 1, "attributes should be 1");
+
+    // xfam (u64 LE) at offset 8
+    let xfam: u64 =
+        scroll::Pread::pread_with(&patched[..], td_params_offset + 8, scroll::LE).unwrap();
+    assert_eq!(xfam, 3, "xfam should be 3");
+
+    // maxvcpus (u16 LE) at offset 16
+    let vcpus: u16 =
+        scroll::Pread::pread_with(&patched[..], td_params_offset + 16, scroll::LE).unwrap();
+    assert_eq!(vcpus, 8, "maxvcpus should be 8");
+}
+
+#[test]
+fn test_patch_params_invalid_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("input.bin");
+    let output_path = dir.path().join("output.bin");
+    let json_path = dir.path().join("bad.json");
+
+    std::fs::write(&input_path, build_test_image()).unwrap();
+    std::fs::write(&json_path, "not valid json {{{").unwrap();
+
+    let status = Command::new(bin_path())
+        .args([
+            "td-params",
+            "--in",
+            input_path.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+            "--tdparams",
+            json_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-patch td-params");
+
+    assert!(!status.success(), "should fail on invalid JSON");
+}
+
+// ============================================================
+// Subcommand: td-info
+// ============================================================
+
+#[test]
+fn test_patch_td_info_missing_args() {
+    let output = Command::new(bin_path())
+        .args(["td-info"])
+        .output()
+        .expect("failed to run td-shim-patch");
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_patch_td_info_writes_header_and_blob() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("input.bin");
+    let output_path = dir.path().join("output.bin");
+    let blob_path = dir.path().join("payload_info.bin");
+
+    std::fs::write(&input_path, build_test_image()).unwrap();
+
+    // Create a small payload blob
+    let blob_data: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE];
+    std::fs::write(&blob_path, &blob_data).unwrap();
+
+    let status = Command::new(bin_path())
+        .args([
+            "td-info",
+            "--in",
+            input_path.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+            "--guid",
+            "6d8415a6-5701-0247-a696-c0420ce3b4e9",
+            "--version",
+            "1.2.3",
+            "--svn",
+            "5",
+            "--payload-info",
+            blob_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-patch td-info");
+
+    assert!(status.success(), "td-shim-patch td-info should succeed");
+    assert!(output_path.exists());
+
+    // Verify the TD_INFO region
+    let patched = std::fs::read(&output_path).unwrap();
+    let td_info_offset: usize = 0x0000;
+
+    // GUID (16 bytes): 6d8415a6-5701-0247-a696-c0420ce3b4e9 in mixed-endian
+    let expected_guid: [u8; 16] = [
+        0xa6, 0x15, 0x84, 0x6d, // data1 LE
+        0x01, 0x57, // data2 LE
+        0x47, 0x02, // data3 LE
+        0xa6, 0x96, 0xc0, 0x42, 0x0c, 0xe3, 0xb4, 0xe9, // data4 BE
+    ];
+    assert_eq!(
+        &patched[td_info_offset..td_info_offset + 16],
+        &expected_guid,
+        "GUID should match"
+    );
+
+    // Length (4 bytes LE) at offset 16: header(28) + blob(6) = 34
+    let length: u32 =
+        scroll::Pread::pread_with(&patched[..], td_info_offset + 16, scroll::LE).unwrap();
+    assert_eq!(length, 34, "length should be header + blob size");
+
+    // Version (4 bytes LE) at offset 20: (1<<24) | (2<<16) | 3 = 0x01020003
+    let version: u32 =
+        scroll::Pread::pread_with(&patched[..], td_info_offset + 20, scroll::LE).unwrap();
+    assert_eq!(version, 0x01020003, "version should be 1.2.3 packed");
+
+    // SVN (4 bytes LE) at offset 24
+    let svn: u32 =
+        scroll::Pread::pread_with(&patched[..], td_info_offset + 24, scroll::LE).unwrap();
+    assert_eq!(svn, 5, "svn should be 5");
+
+    // Payload blob at offset 28
+    assert_eq!(
+        &patched[td_info_offset + 28..td_info_offset + 34],
+        &blob_data,
+        "payload blob should match"
+    );
+}
+
+#[test]
+fn test_patch_td_info_blob_too_large() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("input.bin");
+    let output_path = dir.path().join("output.bin");
+    let blob_path = dir.path().join("huge_blob.bin");
+
+    std::fs::write(&input_path, build_test_image()).unwrap();
+
+    // Create a blob larger than the TD_INFO section (1024 bytes total, minus 28 header = 996 max)
+    let blob_data = vec![0xAA; 1024];
+    std::fs::write(&blob_path, &blob_data).unwrap();
+
+    let status = Command::new(bin_path())
+        .args([
+            "td-info",
+            "--in",
+            input_path.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+            "--guid",
+            "6d8415a6-5701-0247-a696-c0420ce3b4e9",
+            "--version",
+            "1.0.0",
+            "--svn",
+            "0",
+            "--payload-info",
+            blob_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-patch td-info");
+
+    assert!(
+        !status.success(),
+        "should fail when blob exceeds section capacity"
+    );
+}
+
+// ============================================================
+// General / top-level
+// ============================================================
+
+#[test]
+fn test_patch_no_subcommand() {
+    let output = Command::new(bin_path())
+        .output()
+        .expect("failed to run td-shim-patch");
+
+    assert!(!output.status.success());
+}
+
+#[test]
+fn test_patch_unknown_subcommand() {
+    let output = Command::new(bin_path())
+        .args(["bogus"])
+        .output()
+        .expect("failed to run td-shim-patch");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Unknown subcommand"));
+}
+
+#[test]
+fn test_patch_help() {
+    let output = Command::new(bin_path())
+        .args(["--help"])
+        .output()
+        .expect("failed to run td-shim-patch");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("tdx-metadata"));
+    assert!(stdout.contains("td-params"));
+    assert!(stdout.contains("td-info"));
+}

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-use anyhow::{anyhow, Ok, Result};
+use anyhow::{anyhow, Context, Ok, Result};
 use clap::{Parser, ValueEnum};
 use lazy_static::lazy_static;
 use std::{
@@ -139,10 +139,21 @@ impl BuildArgs {
         };
 
         let sh = Shell::new()?;
+        let output_path = PROJECT_ROOT.join("td-layout/src/build_time.rs");
         sh.change_dir(PROJECT_ROOT.join("devtools/td-layout-config"));
-        cmd!(sh, "cargo run -- ")
-            .args(["--config", layout_config.to_str().unwrap()])
-            .arg(PROJECT_ROOT.join("td-layout/src"))
+        cmd!(sh, "cargo run --")
+            .arg(
+                layout_config
+                    .to_str()
+                    .context("layout config path is not valid UTF-8")?,
+            )
+            .args(["-t", "image"])
+            .args([
+                "-o",
+                output_path
+                    .to_str()
+                    .context("output path is not valid UTF-8")?,
+            ])
             .run()?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

Add three new binaries to `td-shim-tools` for building custom td-shim images:

### `td-shim-image-layout-gen`
Computes an image layout from built artifacts and a JSON template. Measures actual binary sizes, aligns to 4 KiB, adds FV header overhead, and emits `image_layout.generated.json` (including `ImageSize`).

### `td-shim-metadata-gen`
Generates TDX metadata JSON from an image layout (`--layout`). Optionally reads physical memory regions (`--memory-layout`) for PermMem/TempMem. Validates no memory regions overlap. Output is consumable by `td-shim-ld --metadata`.

### `td-shim-patch`
Patches a linked td-shim image in-place with three subcommands:
- `tdx-metadata` — overwrite signature and zero section attributes
- `td-params` — write TD_PARAMS from JSON
- `td-info` — write TD_INFO header (GUID + version + SVN + payload blob)

## Documentation
- `doc/custom_nrx_image.md` — full NRX build pipeline walkthrough
- Per-tool READMEs in `td-shim-tools/src/bin/*/README.md`

## Testing
- Unit/integration tests for all three tools (`cargo test -p td-shim-tools`)
- E2E script: `sh_script/test_custom_nrx_image_build.sh`

## Commit Structure
1. `feat(td-shim-tools): add image-layout-gen and metadata-gen tools`
2. `feat(td-shim-tools): add td-shim-patch image patching tool`
3. `docs: add NRX custom image build documentation and e2e test`