### PR TITLE
fix(td-shim-tools): resolve clippy warnings

### DIFF
--- a/td-shim-tools/src/enroller.rs
+++ b/td-shim-tools/src/enroller.rs
@@ -51,7 +51,7 @@ fn update_checksum(data: &mut [u8]) {
         if offset == FFS_HEADER_FILE_CHECKSUM_OFFSET || offset == FFS_HEADER_FILE_STATE_OFFSET {
             continue;
         } else {
-            sum = sum.wrapping_add(data[offset] as u8);
+            sum = sum.wrapping_add(data[offset]);
         }
     }
 
@@ -121,7 +121,7 @@ fn build_cfv_header() -> FvHeader {
     cfv_header.fv_header.revision = FVH_REVISION;
     cfv_header.fv_header.update_checksum();
 
-    cfv_header.fv_block_map[0].num_blocks = (TD_SHIM_CONFIG_SIZE as u32) / 0x1000;
+    cfv_header.fv_block_map[0].num_blocks = TD_SHIM_CONFIG_SIZE / 0x1000;
     cfv_header.fv_block_map[0].length = 0x1000;
     cfv_header.fv_ext_header.ext_header_size = 0x14;
 
@@ -172,7 +172,7 @@ pub fn enroll_files(
             });
         let mut initialization_headers = Vec::new();
         let igvm =
-            IgvmFile::new_from_binary(&tdshim_bin.as_bytes(), None).expect("file parse error");
+            IgvmFile::new_from_binary(tdshim_bin.as_bytes(), None).expect("file parse error");
         let mut cfv_data;
         let mut offset: u64 = 0;
         let mut pagedataflags;
@@ -205,18 +205,16 @@ pub fn enroll_files(
                 {
                     let start = (offset * PAGE_SIZE_4K) as usize;
                     let end = min(((offset + 1) * PAGE_SIZE_4K) as usize, cfv_data.len());
-                    if cfv_data.len() == 0 {
+                    if cfv_data.is_empty() {
                         page_data = vec![];
-                    } else {
-                        if start < end {
-                            page_data = cfv_data[start..end].to_vec();
-                            if (end - start) < PAGE_SIZE_4K as usize {
-                                let paddingbytes = PAGE_SIZE_4K as usize - (end - start);
-                                page_data.extend(std::iter::repeat(0).take(paddingbytes));
-                            }
-                        } else {
-                            page_data = vec![];
+                    } else if start < end {
+                        page_data = cfv_data[start..end].to_vec();
+                        if (end - start) < PAGE_SIZE_4K as usize {
+                            let paddingbytes = PAGE_SIZE_4K as usize - (end - start);
+                            page_data.extend(std::iter::repeat_n(0, paddingbytes));
                         }
+                    } else {
+                        page_data = vec![];
                     }
                     offset += 1;
                 } else {
@@ -235,7 +233,7 @@ pub fn enroll_files(
         for p in igvm.platforms() {
             let IgvmPlatformHeader::SupportedPlatform(sp) = p;
             if sp.platform_type == IgvmPlatformType::TDX {
-                platform_header = igvm::IgvmPlatformHeader::SupportedPlatform(sp.clone());
+                platform_header = igvm::IgvmPlatformHeader::SupportedPlatform(*sp);
             }
         }
 
@@ -308,17 +306,14 @@ pub fn create_key_file(key_file: &str, hash_alg: &str) -> io::Result<FirmwareRaw
         "SHA384" => &digest::SHA384,
         _ => {
             error!("Unsupported hash algorithm {}", hash_alg);
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "unsupported hash algorithm",
-            ));
+            return Err(io::Error::other("unsupported hash algorithm"));
         }
     };
 
     let key_data = InputData::new(key_file, 1..=PUB_KEY_MAX_SIZE, "public key")?;
     let key = SubjectPublicKeyInfo::try_from(key_data.as_bytes()).map_err(|e| {
         error!("Can not load key from file {}: {}", key_file, e);
-        io::Error::new(io::ErrorKind::Other, "invalid key data")
+        io::Error::other("invalid key data")
     })?;
 
     let mut public_bytes: Vec<u8> = Vec::new();
@@ -327,10 +322,7 @@ pub fn create_key_file(key_file: &str, hash_alg: &str) -> io::Result<FirmwareRaw
             if let Some(curve) = key.algorithm.parameters {
                 if curve.as_bytes() != SECP384R1_OID.as_bytes() {
                     error!("Unsupported Named Curve from file {}", key_file);
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "unsupported Named Curve",
-                    ));
+                    return Err(io::Error::other("unsupported Named Curve"));
                 }
 
                 // The first byte indicates whether the key is compressed or uncompressed. The
@@ -341,34 +333,25 @@ pub fn create_key_file(key_file: &str, hash_alg: &str) -> io::Result<FirmwareRaw
                     || key.subject_public_key.as_bytes()[1..].len() != ECDSA_P384_PUB_KEY_LEN
                 {
                     error!("Invalid SECP384R1 public key from file {}", key_file);
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "Invalid SECP384R1 public key",
-                    ));
+                    return Err(io::Error::other("Invalid SECP384R1 public key"));
                 }
                 public_bytes.extend_from_slice(&key.subject_public_key.as_bytes()[1..]);
             } else {
                 error!("Invalid algorithm parameter from file {}", key_file);
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Invalid key algorithm parameter",
-                ));
+                return Err(io::Error::other("Invalid key algorithm parameter"));
             }
         }
         RSA_PUBKEY_OID => {
             let pubkey =
                 RsaPublicKeyInfo::try_from(key.subject_public_key.as_bytes()).map_err(|e| {
                     error!("Invalid key from file {}: {}", key_file, e);
-                    io::Error::new(io::ErrorKind::Other, "invalid key from file")
+                    io::Error::other("invalid key from file")
                 })?;
             public_bytes.extend_from_slice(pubkey.modulus.as_bytes());
             let mut exp_bytes = [0u8; 8];
             if pubkey.exponents.as_bytes().len() > 8 {
                 error!("Invalid exponent size from key file {}", key_file);
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Invalid exponent size",
-                ));
+                return Err(io::Error::other("Invalid exponent size"));
             }
             exp_bytes[8 - pubkey.exponents.as_bytes().len()..]
                 .copy_from_slice(pubkey.exponents.as_bytes());
@@ -379,14 +362,14 @@ pub fn create_key_file(key_file: &str, hash_alg: &str) -> io::Result<FirmwareRaw
             // As stated in the https://github.com/confidential-containers/td-shim/blob/main/doc/secure_boot.md,
             // use the fixed exponent 0x10001 here.
             if exp != RSA_EXPONENT || pubkey.modulus.as_bytes().len() != RSA_3072_PUB_KEY_MOD_LEN {
-                return Err(io::Error::new(io::ErrorKind::Other, "Invalid exponent"));
+                return Err(io::Error::other("Invalid exponent"));
             }
 
             public_bytes.extend_from_slice(&exp_bytes);
         }
         t => {
             error!("Unsupported key type {} from file {}", t, key_file);
-            return Err(io::Error::new(io::ErrorKind::Other, "unsupported key type"));
+            return Err(io::Error::other("unsupported key type"));
         }
     }
 

--- a/td-shim-tools/src/lib.rs
+++ b/td-shim-tools/src/lib.rs
@@ -54,7 +54,7 @@ impl InputData {
                 range.start(),
                 range.end()
             );
-            return Err(io::Error::new(io::ErrorKind::Other, "invalid file size"));
+            return Err(io::Error::other("invalid file size"));
         }
 
         let data = fs::read(name).map_err(|e| {
@@ -73,7 +73,7 @@ impl InputData {
                     range.start(),
                     range.end()
                 );
-                return Err(io::Error::new(io::ErrorKind::Other, "invalid file size"));
+                return Err(io::Error::other("invalid file size"));
             }
         }
 
@@ -150,9 +150,8 @@ impl OutputFile {
         Ok(self
             .file
             .metadata()
-            .map_err(|e| {
+            .inspect_err(|_e| {
                 error!("Can not get size of file {:?}", name.as_os_str());
-                e
             })?
             .len())
     }

--- a/td-shim-tools/src/linker.rs
+++ b/td-shim-tools/src/linker.rs
@@ -89,7 +89,7 @@ impl Default for FvHeaderByte {
 impl FvHeaderByte {
     pub fn build_tdx_payload_fv_header() -> Self {
         let mut hdr = Self::default();
-        let fv_header_size = (size_of::<FvHeader>()) as usize;
+        let fv_header_size = size_of::<FvHeader>();
 
         let mut tdx_payload_fv_header = FvHeader::default();
         tdx_payload_fv_header.fv_header.fv_length = TD_SHIM_PAYLOAD_SIZE as u64;
@@ -98,7 +98,7 @@ impl FvHeaderByte {
         tdx_payload_fv_header.fv_header.revision = FVH_REVISION;
         tdx_payload_fv_header.fv_header.update_checksum();
 
-        tdx_payload_fv_header.fv_block_map[0].num_blocks = (TD_SHIM_PAYLOAD_SIZE as u32) / 0x1000;
+        tdx_payload_fv_header.fv_block_map[0].num_blocks = TD_SHIM_PAYLOAD_SIZE / 0x1000;
         tdx_payload_fv_header.fv_block_map[0].length = 0x1000;
         tdx_payload_fv_header.fv_ext_header.fv_name.copy_from_slice(
             Guid::from_fields(
@@ -164,7 +164,7 @@ impl FvHeaderByte {
     // Build internal payload header
     pub fn build_tdx_ipl_fv_header() -> Self {
         let mut hdr = Self::default();
-        let fv_header_size = (size_of::<FvHeader>()) as usize;
+        let fv_header_size = size_of::<FvHeader>();
 
         let mut tdx_ipl_fv_header = IplFvHeader::default();
         tdx_ipl_fv_header.fv_header.fv_length =
@@ -246,15 +246,12 @@ pub fn build_tdx_metadata(
     let sections = if let Some(path) = path {
         let metadata_config = fs::read(path)?;
         serde_json::from_slice::<MetadataSections>(metadata_config.as_slice())
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+            .map_err(io::Error::other)?
     } else {
         default_metadata_sections(payload_type)
     };
 
-    TdxMetadata::new(sections).ok_or(io::Error::new(
-        io::ErrorKind::Other,
-        "Fail to create metadata",
-    ))
+    TdxMetadata::new(sections).ok_or(io::Error::other("Fail to create metadata"))
 }
 
 pub fn build_ovmf_guid_table() -> Vec<u8> {
@@ -315,7 +312,7 @@ impl std::str::FromStr for ImageFormat {
         match s {
             "tdvf" => Ok(ImageFormat::TDVF),
             "igvm" => Ok(ImageFormat::IGVM),
-            _ => return Err(format!("Invalid output file type: {}", s)),
+            _ => Err(format!("Invalid output file type: {s}")),
         }
     }
 }
@@ -339,7 +336,7 @@ impl std::str::FromStr for PayloadType {
         match s {
             "linux" => Ok(PayloadType::Linux),
             "executable" => Ok(PayloadType::Executable),
-            _ => return Err(format!("Invalid payload type: {}", s)),
+            _ => Err(format!("Invalid payload type: {s}")),
         }
     }
 }
@@ -355,14 +352,12 @@ fn insert_igvm_pages(
     for i in 0..num_pages {
         let start = (i * PAGE_SIZE_4K) as usize;
         let end = min(((i + 1) * PAGE_SIZE_4K) as usize, data.len());
-        let page_data = if data.len() == 0 {
+        let page_data = if data.is_empty() {
             vec![]
+        } else if start < end {
+            data[start..end].to_vec()
         } else {
-            if start < end {
-                data[start..end].to_vec()
-            } else {
-                vec![0u8; PAGE_SIZE_4K as usize]
-            }
+            vec![0u8; PAGE_SIZE_4K as usize]
         };
         let mut flags = IgvmPageDataFlags::new();
         if unmeasured {
@@ -371,7 +366,7 @@ fn insert_igvm_pages(
         directive_headers.push(IgvmDirectiveHeader::PageData {
             gpa: base + i * PAGE_SIZE_4K,
             compatibility_mask: 1,
-            flags: flags,
+            flags,
             data_type: IgvmPageDataType::NORMAL,
             data: page_data,
         });
@@ -491,9 +486,7 @@ impl TdShimLinker {
                     &mut payload_reloc_buf,
                     TD_SHIM_PAYLOAD_BASE as usize + payload_header.data.len(),
                 )
-                .ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::Other, "Can not relocate payload content")
-                })?;
+                .ok_or_else(|| io::Error::other("Can not relocate payload content"))?;
                 trace!("shim payload relocated to 0x{:x}", reloc);
                 payload_data.extend_from_slice(&payload_reloc_buf);
             } else {
@@ -520,7 +513,7 @@ impl TdShimLinker {
             &mut ipl_reloc_buf,
             SIZE_1MB as usize,
         )
-        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Can not relocate IPL content"))?;
+        .ok_or_else(|| io::Error::other("Can not relocate IPL content"))?;
         trace!(
             "reloc IPL entrypoint - 0x{:x} - base: 0x{:x}",
             reloc.0,
@@ -566,9 +559,9 @@ impl TdShimLinker {
 
         let bfv_size =
             (TD_SHIM_METADATA_SIZE + TD_SHIM_IPL_SIZE + TD_SHIM_RESET_VECTOR_SIZE) as usize;
-        let mut bfv_data = vec![0u8; bfv_size as usize];
+        let mut bfv_data = vec![0u8; bfv_size];
 
-        let start = 0 as usize;
+        let start = 0_usize;
         let end = start + metadata_bytes.len();
         bfv_data.splice(start..end, metadata_bytes);
 
@@ -590,7 +583,7 @@ impl TdShimLinker {
         );
 
         if (TD_SHIM_FIRMWARE_BASE as u64 + TD_SHIM_FIRMWARE_SIZE as u64) < MEMORY_4G {
-            let size = PAGE_SIZE_4K as u64;
+            let size = PAGE_SIZE_4K;
             let base = MEMORY_4G - size;
             let start = bfv_data.len() - size as usize;
             insert_igvm_pages(
@@ -626,11 +619,7 @@ impl TdShimLinker {
         let mut output: Vec<u8> = Vec::new();
         igvm.serialize(&mut output).unwrap();
 
-        let output_file_name = self
-            .output_file_name
-            .as_ref()
-            .map(|v| v.as_str())
-            .unwrap_or("td_shim.igvm");
+        let output_file_name = self.output_file_name.as_deref().unwrap_or("td_shim.igvm");
         let mut file = File::create(output_file_name).unwrap();
         file.write_all(&output).unwrap();
 
@@ -655,11 +644,7 @@ impl TdShimLinker {
             "reset_vector",
         )?;
         let ipl_bin = InputData::new(ipl_name, 0..=MAX_IPL_CONTENT_SIZE, "IPL")?;
-        let output_file_name = self
-            .output_file_name
-            .as_ref()
-            .map(|v| v.as_str())
-            .unwrap_or("td_shim.bin");
+        let output_file_name = self.output_file_name.as_deref().unwrap_or("td_shim.bin");
         let mut output_file = OutputFile::new(output_file_name)?;
 
         let mailbox = TdxMpWakeupMailbox::default();
@@ -686,9 +671,7 @@ impl TdShimLinker {
                     &mut payload_reloc_buf,
                     TD_SHIM_PAYLOAD_BASE as usize + payload_header.data.len(),
                 )
-                .ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::Other, "Can not relocate payload content")
-                })?;
+                .ok_or_else(|| io::Error::other("Can not relocate payload content"))?;
                 trace!("shim payload relocated to 0x{:x}", reloc);
                 output_file.write(&payload_reloc_buf, "payload content")?;
             } else {
@@ -708,9 +691,9 @@ impl TdShimLinker {
         let reloc = elf::relocate_elf_with_per_program_header(
             &ipl_bin.data,
             &mut ipl_reloc_buf,
-            0x100000 as usize,
+            0x100000_usize,
         )
-        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Can not relocate IPL content"))?;
+        .ok_or_else(|| io::Error::other("Can not relocate IPL content"))?;
         trace!(
             "reloc IPL entrypoint - 0x{:x} - base: 0x{:x}",
             reloc.0,

--- a/td-shim-tools/src/metadata.rs
+++ b/td-shim-tools/src/metadata.rs
@@ -88,6 +88,12 @@ pub struct MetadataSections {
     inner: Vec<TdxMetadataSection>,
 }
 
+impl Default for MetadataSections {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MetadataSections {
     pub fn new() -> Self {
         Self { inner: Vec::new() }
@@ -256,8 +262,8 @@ pub struct TdxMetadata {
 
 impl TdxMetadata {
     pub fn new(sections: MetadataSections) -> Option<Self> {
-        let length = size_of::<TdxMetadataDescriptor>()
-            + sections.as_slice().len() * size_of::<TdxMetadataSection>();
+        let length =
+            size_of::<TdxMetadataDescriptor>() + std::mem::size_of_val(sections.as_slice());
         if length > u32::MAX as usize {
             return None;
         }

--- a/td-shim-tools/src/public_key.rs
+++ b/td-shim-tools/src/public_key.rs
@@ -73,7 +73,7 @@ impl<'a> TryFrom<&'a [u8]> for SubjectPublicKeyInfo<'a> {
     type Error = der::Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {
-        Ok(Self::from_der(bytes)?)
+        Self::from_der(bytes)
     }
 }
 
@@ -104,6 +104,6 @@ impl<'a> TryFrom<&'a [u8]> for RsaPublicKeyInfo<'a> {
     type Error = der::Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self> {
-        Ok(Self::from_der(bytes)?)
+        Self::from_der(bytes)
     }
 }

--- a/td-shim-tools/src/signer.rs
+++ b/td-shim-tools/src/signer.rs
@@ -93,10 +93,10 @@ impl<'a> PayloadSigner<'a> {
                     .sign(&RSA_PSS_SHA384, &rng, &self.signed_image, &mut signature)
                     .map_err(|e| {
                         error!("Failed to sign message with RSA: {}", e);
-                        io::Error::new(io::ErrorKind::Other, "failed to sign message")
+                        io::Error::other("failed to sign message")
                     })?;
 
-                self.signed_image.extend_from_slice(&modulus);
+                self.signed_image.extend_from_slice(modulus);
                 self.signed_image.extend_from_slice(&exp_bytes);
                 self.signed_image.extend_from_slice(signature.as_slice());
             }
@@ -116,7 +116,7 @@ impl<'a> PayloadSigner<'a> {
                     .sign(&rng, self.signed_image.as_slice())
                     .map_err(|e| {
                         error!("Failed to sign message with ECDSA: {}", e);
-                        io::Error::new(io::ErrorKind::Other, "failed to sign message")
+                        io::Error::other("failed to sign message")
                     })?;
 
                 self.signed_image.extend_from_slice(&public_key[1..]);

--- a/td-shim-tools/src/tee_info_hash.rs
+++ b/td-shim-tools/src/tee_info_hash.rs
@@ -276,7 +276,7 @@ impl TdInfoStruct {
         let mut desc_offset = 0;
         let descriptor: TdxMetadataDescriptor = desc.pread(desc_offset).unwrap();
         if !(descriptor.is_valid()) {
-            println!("{:?}", descriptor);
+            println!("{descriptor:?}");
             panic!("The descriptor is not valid!\n");
         }
 
@@ -409,14 +409,14 @@ impl TdInfoStruct {
                 if !flags.unmeasured() {
                     // Hash the contents of the 4K page, 256 bytes at a time.
                     let page_data = data;
-                    if (page_data.len() > 0) && (page_data.len() % PAGE_SIZE as usize == 0) {
+                    if (!page_data.is_empty()) && (page_data.len() % PAGE_SIZE as usize == 0) {
                         // Use TDCALL [TDH.MR.EXTEND]
                         for offset in (0..PAGE_SIZE).step_by(TDH_MR_EXTEND_GRANULARITY as usize) {
                             fill_buffer3_128_with_mr_extend_tdvf(
                                 &mut buffer3_128,
                                 gpa + offset,
                                 page_data,
-                                offset as u64,
+                                offset,
                             );
 
                             sha384hasher.update(buffer3_128[0]);
@@ -429,7 +429,7 @@ impl TdInfoStruct {
         }
 
         let hash = sha384hasher.finalize();
-        println!("MRTD Hash: {:x?}", hash);
+        println!("MRTD Hash: {hash:x?}");
         self.mrtd.copy_from_slice(hash.as_slice());
     }
 
@@ -461,7 +461,7 @@ impl TdInfoStruct {
                 if *gpa >= TD_SHIM_CONFIG_BASE.into()
                     && *gpa < ((TD_SHIM_CONFIG_BASE + TD_SHIM_CONFIG_SIZE).into())
                 {
-                    if data.len() > 0 {
+                    if !data.is_empty() {
                         validpages += 1;
                     }
                     offset += 1;
@@ -472,7 +472,7 @@ impl TdInfoStruct {
         let paddingbytes = TD_SHIM_CONFIG_SIZE as usize - (validpages * PAGE_SIZE as usize);
         offset = (fixed_header.variable_header_size + fixed_header.variable_header_offset) as usize;
         cfv = contents[offset..offset + (validpages * PAGE_SIZE as usize)].to_vec();
-        cfv.extend(std::iter::repeat(0).take(paddingbytes));
+        cfv.extend(std::iter::repeat_n(0, paddingbytes));
         cfv
     }
 


### PR DESCRIPTION
Address clippy lints across td-shim-tools:
- Replace io::Error::new(ErrorKind::Other, ..) with io::Error::other(..)
- Replace map_err identity with inspect_err
- Add Default impl for MetadataSections
- Use std::mem::size_of_val instead of manual computation
- Inline format args and simplify closures