### PR TITLE
feat(td-shim-tools): add --raw-guid to td-shim-patch td-info

### DIFF
--- a/doc/custom_nrx_image.md
+++ b/doc/custom_nrx_image.md
@@ -104,7 +104,7 @@ cargo run -p td-shim-tools --bin td-shim-patch -- td-params \
 cargo run -p td-shim-tools --bin td-shim-patch -- td-info \
     --in target/release/final.bin \
     --out target/release/final.bin \
-    --guid ffffffff-ffff-ffff-ffff-ffffffffffff \
+    --raw-guid ffffffff-ffff-ffff-ffff-ffffffffffff \
     --version 1.0.0 \
     --svn 1 \
     --payload-info path/to/nrx_info.bin
@@ -364,7 +364,7 @@ cargo run -p td-shim-tools --bin td-shim-patch -- td-params \
 cargo run -p td-shim-tools --bin td-shim-patch -- td-info \
     --in target/release/final.bin \
     --out target/release/final.bin \
-    --guid ffffffff-ffff-ffff-ffff-ffffffffffff \
+    --raw-guid ffffffff-ffff-ffff-ffff-ffffffffffff \
     --version 1.0.0 \
     --svn 1 \
     --payload-info path/to/nrx_info.bin
@@ -411,7 +411,7 @@ opaque payload blob into the TD_INFO section. The GUID identifies the TD type;
 the blob format depends on the specific deployment.
 
 ```bash
-td-shim-patch td-info --in <image> --out <image> --guid <guid> \
+td-shim-patch td-info --in <image> --out <image> (--guid <guid> | --raw-guid <guid>) \
     --version <a.b.c> --svn <n> --payload-info <blob>
 ```
 
@@ -419,7 +419,13 @@ td-shim-patch td-info --in <image> --out <image> --guid <guid> \
 |----------|----------|-------------|
 | `--in <path>` | yes | Input firmware image |
 | `--out <path>` | yes | Output firmware image |
-| `--guid <guid>` | yes | TD type GUID (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`) |
+| `--guid <guid>` | one of | TD type GUID in UEFI mixed-endian form (data1–data3 LE, data4–data5 BE on the wire) |
+| `--raw-guid <guid>` | one of | TD type GUID as a raw 16-byte sequence (no endian swap) |
 | `--version <a.b.c>` | yes | Release version (major.minor.update) |
 | `--svn <n>` | yes | Security Version Number |
 | `--payload-info <path>` | yes | Binary blob with TD-type-specific info |
+
+Exactly one of `--guid` or `--raw-guid` must be supplied. NRX TD types whose
+identifier is defined as a raw 16-byte sequence (rather than as a UEFI/RFC-4122
+GUID) must use `--raw-guid` so the bytes land in the image in the order the
+spec defines.

--- a/td-shim-tools/src/bin/td-shim-patch/README.md
+++ b/td-shim-tools/src/bin/td-shim-patch/README.md
@@ -47,17 +47,23 @@ td-shim-patch td-params --in <image> --out <image> --tdparams <json>
 Patches the TD_INFO section with a generic header and a payload-specific binary blob.
 
 ```
-td-shim-patch td-info --in <image> --out <image> --guid <guid> --version <a.b.c> --svn <n> --payload-info <path>
+td-shim-patch td-info --in <image> --out <image> (--guid <guid> | --raw-guid <guid>) --version <a.b.c> --svn <n> --payload-info <path>
 ```
 
 | Option | Description |
 |--------|-------------|
 | `--in <path>` | Input firmware image |
 | `--out <path>` | Output firmware image |
-| `--guid <guid>` | TD type GUID (e.g., `6d8415a6-5701-0247-a696-c0420ce3b4e9`) |
+| `--guid <guid>` | TD type GUID in UEFI mixed-endian form (e.g., `F9168C5E-CEB2-4FAA-B6BF-329BF39FA1E4`) |
+| `--raw-guid <guid>` | TD type GUID as a raw byte sequence with no endian swap (e.g., `01234567-89AB-CDEF-FEDC-BA9876543210`) |
 | `--version <a.b.c>` | Release version as `major.minor.update` |
 | `--svn <n>` | Security Version Number |
 | `--payload-info <path>` | Binary blob with TD-type-specific info |
+
+Exactly one of `--guid` or `--raw-guid` must be supplied. Use `--guid` for
+identifiers defined per RFC 4122 / UEFI PI (data1–data3 little-endian,
+data4–data5 big-endian on the wire). Use `--raw-guid` for identifiers defined
+as a raw 16-byte sequence with no endian swap.
 
 ## Building
 

--- a/td-shim-tools/src/bin/td-shim-patch/td_info.rs
+++ b/td-shim-tools/src/bin/td-shim-patch/td_info.rs
@@ -129,6 +129,34 @@ fn parse_guid(s: &str) -> Option<[u8; 16]> {
     Some(guid)
 }
 
+/// Parse a GUID-shaped hex string "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" as
+/// 16 raw bytes (left-to-right, no endian swap). Used for TD types whose
+/// identifier is specified as a raw 16-byte sequence rather than as a
+/// UEFI/RFC-4122 GUID.
+fn parse_guid_raw(s: &str) -> Option<[u8; 16]> {
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 5
+        || parts[0].len() != 8
+        || parts[1].len() != 4
+        || parts[2].len() != 4
+        || parts[3].len() != 4
+        || parts[4].len() != 12
+    {
+        return None;
+    }
+
+    let hex: String = parts.concat();
+    if hex.len() != 32 {
+        return None;
+    }
+
+    let mut guid = [0u8; 16];
+    for i in 0..16 {
+        guid[i] = u8::from_str_radix(&hex[2 * i..2 * i + 2], 16).ok()?;
+    }
+    Some(guid)
+}
+
 /// Parse version string "major.minor.update" into packed u32:
 /// (major << 24) | (minor << 16) | update
 fn parse_version(s: &str) -> Option<u32> {
@@ -150,7 +178,11 @@ fn show_help() {
     eprintln!("Usage:");
     eprintln!("    --in <path>              Input firmware image (required).");
     eprintln!("    --out <path>             Output firmware image (required).");
-    eprintln!("    --guid <guid>            TD type GUID, e.g. 6d8415a6-5701-0247-a696-c0420ce3b4e9 (required).");
+    eprintln!("    --guid <guid>            TD type GUID in UEFI mixed-endian form");
+    eprintln!("                             (e.g. F9168C5E-CEB2-4FAA-B6BF-329BF39FA1E4).");
+    eprintln!("    --raw-guid <guid>        TD type GUID as a raw byte sequence (no endian swap)");
+    eprintln!("                             (e.g. 01234567-89AB-CDEF-FEDC-BA9876543210).");
+    eprintln!("                             Exactly one of --guid / --raw-guid is required.");
     eprintln!("    --version <a.b.c>        Release version as major.minor.update (required).");
     eprintln!("    --svn <n>                Security Version Number (required).");
     eprintln!("    --payload-info <path>    Binary blob with TD-type-specific info (required).");
@@ -186,6 +218,10 @@ fn prepare_args(args_list: Vec<String>) -> Option<Args> {
                 }
             }
             "--guid" => {
+                if guid.is_some() {
+                    eprintln!("--guid and --raw-guid are mutually exclusive");
+                    return None;
+                }
                 if let Some(guid_str) = args_list.pop_front() {
                     if let Some(g) = parse_guid(&guid_str) {
                         guid = Some(g);
@@ -195,6 +231,23 @@ fn prepare_args(args_list: Vec<String>) -> Option<Args> {
                     }
                 } else {
                     eprintln!("Parameter to --guid is missing!");
+                    return None;
+                }
+            }
+            "--raw-guid" => {
+                if guid.is_some() {
+                    eprintln!("--guid and --raw-guid are mutually exclusive");
+                    return None;
+                }
+                if let Some(guid_str) = args_list.pop_front() {
+                    if let Some(g) = parse_guid_raw(&guid_str) {
+                        guid = Some(g);
+                    } else {
+                        eprintln!("Failed to parse raw GUID: {guid_str}");
+                        return None;
+                    }
+                } else {
+                    eprintln!("Parameter to --raw-guid is missing!");
                     return None;
                 }
             }

--- a/td-shim-tools/tests/patch-test.rs
+++ b/td-shim-tools/tests/patch-test.rs
@@ -368,7 +368,8 @@ fn test_patch_td_info_writes_header_and_blob() {
     let patched = std::fs::read(&output_path).unwrap();
     let td_info_offset: usize = 0x0000;
 
-    // GUID (16 bytes): 6d8415a6-5701-0247-a696-c0420ce3b4e9 in mixed-endian
+    // GUID (16 bytes): 6d8415a6-5701-0247-a696-c0420ce3b4e9 parsed with
+    // UEFI mixed-endian semantics (data1..data3 LE, data4..data5 BE).
     let expected_guid: [u8; 16] = [
         0xa6, 0x15, 0x84, 0x6d, // data1 LE
         0x01, 0x57, // data2 LE
@@ -439,6 +440,91 @@ fn test_patch_td_info_blob_too_large() {
     assert!(
         !status.success(),
         "should fail when blob exceeds section capacity"
+    );
+}
+
+#[test]
+fn test_patch_td_info_raw_guid_writes_bytes_verbatim() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("input.bin");
+    let output_path = dir.path().join("output.bin");
+    let blob_path = dir.path().join("payload_info.bin");
+
+    std::fs::write(&input_path, build_test_image()).unwrap();
+    std::fs::write(&blob_path, [0u8; 4]).unwrap();
+
+    // --raw-guid takes the hyphenated GUID string and writes its bytes
+    // left-to-right with no endian swap.
+    let status = Command::new(bin_path())
+        .args([
+            "td-info",
+            "--in",
+            input_path.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+            "--raw-guid",
+            "01234567-89AB-CDEF-FEDC-BA9876543210",
+            "--version",
+            "1.0.0",
+            "--svn",
+            "0",
+            "--payload-info",
+            blob_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-patch td-info");
+
+    assert!(
+        status.success(),
+        "td-shim-patch td-info --raw-guid should succeed"
+    );
+
+    let patched = std::fs::read(&output_path).unwrap();
+    let expected_raw: [u8; 16] = [
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32,
+        0x10,
+    ];
+    assert_eq!(
+        &patched[0..16],
+        &expected_raw,
+        "raw GUID bytes should be written verbatim"
+    );
+}
+
+#[test]
+fn test_patch_td_info_guid_and_raw_guid_are_mutually_exclusive() {
+    let dir = tempfile::tempdir().unwrap();
+    let input_path = dir.path().join("input.bin");
+    let output_path = dir.path().join("output.bin");
+    let blob_path = dir.path().join("payload_info.bin");
+
+    std::fs::write(&input_path, build_test_image()).unwrap();
+    std::fs::write(&blob_path, [0u8; 4]).unwrap();
+
+    let status = Command::new(bin_path())
+        .args([
+            "td-info",
+            "--in",
+            input_path.to_str().unwrap(),
+            "--out",
+            output_path.to_str().unwrap(),
+            "--guid",
+            "F9168C5E-CEB2-4FAA-B6BF-329BF39FA1E4",
+            "--raw-guid",
+            "01234567-89AB-CDEF-FEDC-BA9876543210",
+            "--version",
+            "1.0.0",
+            "--svn",
+            "0",
+            "--payload-info",
+            blob_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("failed to run td-shim-patch td-info");
+
+    assert!(
+        !status.success(),
+        "--guid and --raw-guid together should fail"
     );
 }
 


### PR DESCRIPTION
The existing --guid flag parses identifiers as UEFI / RFC 4122 GUIDs (data1..data3 little-endian, data4..data5 big-endian on the wire). This is correct for true GUIDs, but some TD types specify their TD_INFO identifier as a raw 16-byte sequence rather than a UEFI GUID. Feeding such a value to --guid produces the wrong bytes on the wire because parse_guid applies mixed-endian swaps the spec did not intend.

Add a --raw-guid flag that takes the same hyphenated 8-4-4-4-12 form but writes the bytes left-to-right with no endian swap. --guid and --raw-guid are mutually exclusive, and exactly one must be supplied. The existing --guid behavior is preserved.

Update the subcommand help text and README to document both flags, and extend patch-test with two new tests:

* test_patch_td_info_raw_guid_writes_bytes_verbatim verifies the new flag writes the byte sequence exactly as given.
* test_patch_td_info_guid_and_raw_guid_are_mutually_exclusive verifies the parser rejects passing both at once.