### PR TITLE
fix(cc-measurement): make elided lifetimes explicit on returned readers

### DIFF
--- a/cc-measurement/src/log.rs
+++ b/cc-measurement/src/log.rs
@@ -28,7 +28,7 @@ impl CcEventLogWriter<'_> {
     pub fn new(
         area: &mut [u8],
         extender: Box<dyn Fn(&[u8; SHA384_DIGEST_SIZE], u32) -> Result<()>>,
-    ) -> Result<CcEventLogWriter> {
+    ) -> Result<CcEventLogWriter<'_>> {
         let mut cc_event_log = CcEventLogWriter {
             area,
             offset: 0,
@@ -257,7 +257,7 @@ pub struct CcEventLogReader<'a> {
 }
 
 impl CcEventLogReader<'_> {
-    pub fn new(bytes: &[u8]) -> Option<CcEventLogReader> {
+    pub fn new(bytes: &[u8]) -> Option<CcEventLogReader<'_>> {
         let specific_id_event_size =
             size_of::<TcgPcrEventHeader>() + size_of::<TcgEfiSpecIdevent>();
         if bytes.len() < specific_id_event_size {


### PR DESCRIPTION
rustc's mismatched_lifetime_syntaxes lint warns when a lifetime is elided in one position of a function signature but hidden in another, because the inconsistency makes the lifetime relationship harder to read.

CcEventLogWriter::new and CcEventLogReader::new both took an input slice with an elided lifetime and returned the corresponding reader type without naming that lifetime, triggering the warning twice.

Add the explicit `<'_>` lifetime to both return types. Behavior is unchanged; only the signatures are made consistent.