### PR TITLE
Resolve RUSTSEC-2026-0190 and RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "argparse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,11 +619,11 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -1014,15 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -1079,7 +1073,7 @@ dependencies = [
  "linked_list_allocator",
  "log",
  "scroll",
- "spin 0.9.8",
+ "spin",
  "td-layout",
  "x86",
 ]
@@ -1091,7 +1085,7 @@ dependencies = [
  "bitflags 1.3.2",
  "lazy_static",
  "log",
- "spin 0.9.8",
+ "spin",
  "tdx-tdcall",
  "x86_64",
 ]
@@ -1136,7 +1130,7 @@ version = "0.1.0"
 dependencies = [
  "lazy_static",
  "log",
- "spin 0.9.8",
+ "spin",
  "tdx-tdcall",
  "x86",
 ]
@@ -1147,7 +1141,7 @@ version = "0.1.0"
 dependencies = [
  "bitfield",
  "log",
- "spin 0.9.8",
+ "spin",
  "td-layout",
  "x86",
  "x86_64",
@@ -1166,7 +1160,7 @@ dependencies = [
  "scroll",
  "serde",
  "serde_json",
- "spin 0.9.8",
+ "spin",
  "td-benchmark",
  "td-exception",
  "td-layout",
@@ -1194,7 +1188,7 @@ dependencies = [
  "r-efi",
  "ring",
  "scroll",
- "spin 0.9.8",
+ "spin",
  "td-exception",
  "td-layout",
  "td-loader",
@@ -1260,7 +1254,7 @@ dependencies = [
  "lazy_static",
  "log",
  "scroll",
- "spin 0.9.8",
+ "spin",
  "x86_64",
 ]
 
@@ -1311,7 +1305,7 @@ name = "test-runner-client"
 version = "0.1.0"
 dependencies = [
  "linked_list_allocator",
- "spin 0.9.8",
+ "spin",
  "uart_16550",
  "x86_64",
 ]
@@ -1359,7 +1353,7 @@ dependencies = [
  "scroll",
  "serde",
  "serde_json",
- "spin 0.9.8",
+ "spin",
  "td-layout",
  "td-logger",
  "td-paging",


### PR DESCRIPTION
This PR updates packages affected by RUSTSEC-2026-0190 vulnerability and RUSTSEC-2026-0204 vulnerability.
See https://rustsec.org/advisories/RUSTSEC-2026-0190 and https://rustsec.org/advisories/RUSTSEC-2026-0204 for more details.