### PR TITLE
fix(td-shim-tools): emit TD_INFO as last section

### DIFF
--- a/td-shim-tools/src/bin/td-shim-metadata-gen/main.rs
+++ b/td-shim-tools/src/bin/td-shim-metadata-gen/main.rs
@@ -264,20 +264,6 @@ fn generate_from_layout(
         }
     }
 
-    // TdInfo (optional)
-    if let Some((td_info_off, td_info_sz)) = find("TdInfo") {
-        if td_info_sz > 0 {
-            sections.push(SectionConfig {
-                r#type: "TdInfo".to_string(),
-                attributes: "0x0".to_string(),
-                data_offset: format!("0x{:X}", td_info_off),
-                raw_data_size: format!("0x{:X}", td_info_sz),
-                memory_address: "0x0".to_string(),
-                memory_data_size: "0x0".to_string(),
-            });
-        }
-    }
-
     // PermMem (VMM-allocated permanent memory via PAGE_AUG)
     for region in &memory_layout.perm_mem {
         if region.size > 0 {
@@ -288,6 +274,20 @@ fn generate_from_layout(
                 raw_data_size: "0x0".to_string(),
                 memory_address: format!("0x{:X}", region.address),
                 memory_data_size: format!("0x{:X}", region.size),
+            });
+        }
+    }
+
+    // TdInfo must be the last metadata section.
+    if let Some((td_info_off, td_info_sz)) = find("TdInfo") {
+        if td_info_sz > 0 {
+            sections.push(SectionConfig {
+                r#type: "TdInfo".to_string(),
+                attributes: "0x0".to_string(),
+                data_offset: format!("0x{:X}", td_info_off),
+                raw_data_size: format!("0x{:X}", td_info_sz),
+                memory_address: "0x0".to_string(),
+                memory_data_size: "0x0".to_string(),
             });
         }
     }

--- a/td-shim-tools/tests/metadata-gen-test.rs
+++ b/td-shim-tools/tests/metadata-gen-test.rs
@@ -125,14 +125,15 @@ fn test_metadata_gen_with_perm_mem() {
     let content = std::fs::read_to_string(&output_path).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
     let sections = parsed["Sections"].as_array().unwrap();
-    // Should have: TdParams, BFV, TempMem, Payload, TdInfo, PermMem
+    // Should have: TdParams, BFV, TempMem, Payload, PermMem, TdInfo
     assert_eq!(sections.len(), 6);
-    assert_eq!(sections[5]["Type"], "PermMem");
-    assert_eq!(sections[5]["Attributes"], "0x2");
-    assert_eq!(sections[5]["MemoryAddress"], "0x0");
-    assert_eq!(sections[5]["MemoryDataSize"], "0x2000000");
-    assert_eq!(sections[5]["DataOffset"], "0x0");
-    assert_eq!(sections[5]["RawDataSize"], "0x0");
+    assert_eq!(sections[4]["Type"], "PermMem");
+    assert_eq!(sections[4]["Attributes"], "0x2");
+    assert_eq!(sections[4]["MemoryAddress"], "0x0");
+    assert_eq!(sections[4]["MemoryDataSize"], "0x2000000");
+    assert_eq!(sections[4]["DataOffset"], "0x0");
+    assert_eq!(sections[4]["RawDataSize"], "0x0");
+    assert_eq!(sections[5]["Type"], "TdInfo");
 }
 
 #[test]
@@ -380,9 +381,10 @@ fn test_metadata_gen_sample_nrx_image_template() {
     let content = std::fs::read_to_string(&output_path).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
     let sections = parsed["Sections"].as_array().unwrap();
-    // TdParams, BFV, TempMem, Payload, TdInfo, PermMem
+    // TdParams, BFV, TempMem, Payload, PermMem, TdInfo
     assert_eq!(sections.len(), 6);
-    assert_eq!(sections[5]["Type"], "PermMem");
+    assert_eq!(sections[4]["Type"], "PermMem");
+    assert_eq!(sections[5]["Type"], "TdInfo");
 }
 
 #[test]


### PR DESCRIPTION
NRX consumers require TD_INFO to be the final metadata section. Move its emission after all permanent-memory entries so generated metadata always satisfies that ordering constraint.