### PR TITLE
td-shim: Clear RBP from TDVMCALL register mask for NO_RBP_MOD

### DIFF
--- a/td-shim/src/bin/td-shim/asm/ap_loop.asm
+++ b/td-shim/src/bin/td-shim/asm/ap_loop.asm
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Intel Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
-.set TDVMCALL_EXPOSE_REGS_MASK,           0xffec
+.set TDVMCALL_EXPOSE_REGS_MASK,           0xffcc
 .set TDVMCALL,                            0x0
 .set INSTRUCTION_CPUID,                   0xa
 

--- a/tdx-tdcall/src/asm/tdvmcall_emu.asm
+++ b/tdx-tdcall/src/asm/tdvmcall_emu.asm
@@ -4,7 +4,7 @@
 .section .text
 
 .equ USE_TDX_EMULATION, 1
-.equ TDVMCALL_EXPOSE_REGS_MASK,       0xffec
+.equ TDVMCALL_EXPOSE_REGS_MASK,       0xffcc
 .equ TDVMCALL,                        0x0
 .equ EXIT_REASON_CPUID,               0xa
 


### PR DESCRIPTION
The TDVMCALL register mask (RCX/GPR_SELECT) in question here exposes RBP (bit 5) to the VMM.

While Linux/KVM creates TDs with TDX_CONFIG_FLAGS_NO_RBP_MOD [by default](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/kvm/vmx/tdx.c?h=v7.2-rc6#n2416). With that flag, the TDX Module's TDG.VP.VMCALL handler requires GPR_SELECT bit 5 to be zero and [rejects ](https://github.com/intel/confidential-computing.tdx.tdx-module/blob/TDX_MODULE_2.0.14/src/td_dispatcher/vm_exits/tdg_vp_vmcall.c#L84)any TDVMCALL that sets it with TDX_OPERAND_INVALID. 

As a result **an AP doing CPUID via TDVMCALL during SMP bring-up then triple-faults the guest** (>= 2 vCPUs; 1-vCPU TDs are unaffected). Fix by clearing RBP to align with current Linux implementation.